### PR TITLE
Fix "Sites" link highlighting correctly

### DIFF
--- a/htdocs/config/lab_config_home.php
+++ b/htdocs/config/lab_config_home.php
@@ -2447,8 +2447,8 @@ function AddnewDHIMS2Config()
 				temp changes ending point
 				-->
 
-				<a id="sites" class="menu_option"
-					href="javascript:right_load(54, 'site_config_div');">
+				<a id="option55" class="menu_option"
+					href="javascript:right_load(55, 'site_config_div');">
 					<?php echo LangUtil::$pageTerms['SITES']; ?>
 				</a>
                 <br><br>


### PR DESCRIPTION
**Bug fix!** Steps to reproduce:

1. Start BLIS
2. Log in with `testlab1_admin`/`admin123`
3. Go to "Lab Configuration" screen
4. Click each link on the sidebar
5. Notice that the "Sites" link does not highlight the same way the others do

It looks like a minor copy/paste error - this should fix it!