### PR TITLE
Add includes/platform_lib.php and genericize mysqldump path

### DIFF
--- a/htdocs/export/backup_lib.php
+++ b/htdocs/export/backup_lib.php
@@ -2,7 +2,8 @@
 #
 # Contains commonly used functions for performing backup or reverting to a backup
 #
-include("../includes/db_lib.php");
+require_once("../includes/db_lib.php");
+require_once("../includes/platform_lib.php");
 
 class BackupLib
 {
@@ -24,18 +25,17 @@ class BackupLib
 		$DB_USER = root;
 		$DB_PASS = blis123;
 		
-		$mainBlisDir = substr($currentDir,$length,strpos($currentDir,"htdocs"));
-		$mysqldumpPath = "\"".$mainBlisDir."server\mysql\bin\mysqldump.exe\"";
+		$mysqldumpPath = mySqlDumpPath();
 		$dbname = "blis_".$lab_config_id;
 		$backupLabDbFileName= "blis_".$lab_config_id."_backup.sql";
 		$count=0;
-		$command = $mysqldumpPath." -B -h $DB_HOST -P 7188 -u $DB_USER -p$DB_PASS $dbname > $backupLabDbFileName";
+		$command = $mysqldumpPath." -B -h $DB_HOST -P $DB_PORT -u $DB_USER -p$DB_PASS $dbname > $backupLabDbFileName";
 		system($command,$return);
 		$file_list1[] = $backupLabDbFileName;
 		
 		$dbname = "blis_revamp";
 		$backupDbFileName = "blis_revamp_backup.sql";
-		$command = $mysqldumpPath." -B -h $DB_HOST -P 7188 -u $DB_USER -p$DB_PASS $dbname > $backupDbFileName";
+		$command = $mysqldumpPath." -B -h $DB_HOST -P $DB_PORT -u $DB_USER -p$DB_PASS $dbname > $backupDbFileName";
 		system($command,$return);
 		$file_list2[] = $backupDbFileName;
 		
@@ -57,7 +57,7 @@ class BackupLib
 		@mkdir($destination."blis_revamp/");
 		@mkdir($destination."blis_".$lab_config_id."/");
 		@mkdir($destination."langdata_".$lab_config_id."/");
-		chmod($destination, 777);
+		chmod($destination, 0755);
 		
 		foreach($file_list1 as $file) {
 			$file_name_parts = explode("/", $file);

--- a/htdocs/export/data_backup2.php
+++ b/htdocs/export/data_backup2.php
@@ -20,13 +20,13 @@ $mysqldumpPath = "\"".$mainBlisDir."server\mysql\bin\mysqldump.exe\"";
 $dbname = "blis_".$lab_config_id;
 $backupLabDbFileName= "blis_".$lab_config_id."_backup.sql";
 $count=0;
-$command = $mysqldumpPath." -B -h $DB_HOST -P 7188 -u $DB_USER -p$DB_PASS $dbname > $backupLabDbFileName";
+$command = $mysqldumpPath." -B -h $DB_HOST -P $DB_PORT -u $DB_USER -p$DB_PASS $dbname > $backupLabDbFileName";
 system($command);
 $file_list1[] = $backupLabDbFileName;
 
 $dbname = "blis_revamp";
 $backupDbFileName = "blis_revamp_backup.sql";
-$command = $mysqldumpPath." -B -h $DB_HOST -P 7188 -u $DB_USER -p$DB_PASS $dbname > $backupDbFileName";
+$command = $mysqldumpPath." -B -h $DB_HOST -P $DB_PORT -u $DB_USER -p$DB_PASS $dbname > $backupDbFileName";
 system($command);
 $file_list2[] = $backupDbFileName;
 
@@ -48,7 +48,7 @@ $destination = "../../blis_backup_".$site_name."_".date("Ymd-Hi")."/";
 @mkdir($destination."blis_revamp/");
 @mkdir($destination."blis_".$lab_config_id."/");
 @mkdir($destination."langdata_".$lab_config_id."/");
-chmod($destination, 777);
+chmod($destination, 0755);
 
 foreach($file_list1 as $file)
 {

--- a/htdocs/export/data_backup_revert.php
+++ b/htdocs/export/data_backup_revert.php
@@ -70,7 +70,7 @@ else
 $blisLabBackupFilePath = "\"".$mainBlisDir.$backup_folder."\blis_".$lab_config_id."\blis_".$lab_config_id."_backup.sql\"";
 $mysqlExePath = "\"".$mainBlisDir."server\mysql\bin\mysql.exe\"";
 $dbname = "blis_".$lab_config_id;
-$command = $mysqlExePath." -h $DB_HOST -P 7188 -u $DB_USER -p$DB_PASS $dbname < $blisLabBackupFilePath";
+$command = $mysqlExePath." -h $DB_HOST -P $DB_PORT -u $DB_USER -p$DB_PASS $dbname < $blisLabBackupFilePath";
 $command = "C: &".$command; //the C: is a useless command to prevent the original command from failing because of having more than 2 double quotes
 
 system($command, $return);
@@ -85,7 +85,7 @@ if(file_exists($blisLabBackupFilePath.".key"))
 $blisBackUpFilePath = "\"".$mainBlisDir.$backup_folder."\blis_revamp\blis_revamp_backup.sql.dec\"";
 else
 $blisBackUpFilePath = "\"".$mainBlisDir.$backup_folder."\blis_revamp\blis_revamp_backup.sql\"";
-$command = $mysqlExePath." -h $DB_HOST -P 7188 -u $DB_USER -p$DB_PASS $dbName < $blisBackUpFilePath";
+$command = $mysqlExePath." -h $DB_HOST -P $DB_PORT -u $DB_USER -p$DB_PASS $dbName < $blisBackUpFilePath";
 $command = "C: &".$command;
 
 system($command,$return);
@@ -93,7 +93,7 @@ echo $return;
 unlink($temp);
 
 $langdata_dir = "../../".$backup_folder."/langdata_".$lab_config_id;
-chmod("../../dbdir/", 777);
+chmod("../../dbdir/", 0755);
 
 if($do_langdata === true)
 	dir_copy($langdata_dir, "../../local/langdata_".$lab_config_id);

--- a/htdocs/export/data_backup_revert_xx.php
+++ b/htdocs/export/data_backup_revert_xx.php
@@ -64,20 +64,20 @@ $mainBlisDir = substr($currentDir,$length,strpos($currentDir,"htdocs"));
 $blisLabBackupFilePath = "\"".$mainBlisDir.$backup_folder."\blis_".$lab_config_id."\blis_".$lab_config_id."_backup.sql\"";
 $mysqlExePath = "\"".$mainBlisDir."server\mysql\bin\mysql.exe\"";
 $dbname = "blis_".$lab_config_id;
-$command = $mysqlExePath." -h $DB_HOST -P 7188 -u $DB_USER -p$DB_PASS $dbname < $blisLabBackupFilePath";
+$command = $mysqlExePath." -h $DB_HOST -P $DB_PORT -u $DB_USER -p$DB_PASS $dbname < $blisLabBackupFilePath";
 $command = "C: &".$command; //the C: is a useless command to prevent the original command from failing because of having more than 2 double quotes
 system($command, $return);
 echo $return;
 
 $dbName = "blis_revamp";
 $blisBackUpFilePath = "\"".$mainBlisDir.$backup_folder."\blis_revamp\blis_revamp_backup.sql\"";
-$command = $mysqlExePath." -h $DB_HOST -P 7188 -u $DB_USER -p$DB_PASS $dbname < $blisBackUpFilePath";
+$command = $mysqlExePath." -h $DB_HOST -P $DB_PORT -u $DB_USER -p$DB_PASS $dbname < $blisBackUpFilePath";
 $command = "C: &".$command;
 system($command,$return);
 echo $return;
 
 $langdata_dir = "../../".$backup_folder."/langdata_".$lab_config_id;
-chmod("../../dbdir/", 777);
+chmod("../../dbdir/", 0755);
 
 if($do_langdata === true)
 	dir_copy($langdata_dir, "../../local/langdata_".$lab_config_id);

--- a/htdocs/export/exportLabConfiguration.php
+++ b/htdocs/export/exportLabConfiguration.php
@@ -15,13 +15,13 @@ $mysqldumpPath = "\"".$mainBlisDir."server\mysql\bin\mysqldump.exe\"";
 $dbname = "blis_".$lab_config_id;
 $backupLabDbFileName= "blis_".$lab_config_id."_configuration.sql";
 $count=0;
-$command = $mysqldumpPath." -B -h $DB_HOST -P 7188 -u $DB_USER -p$DB_PASS $dbname > $backupLabDbFileName";
+$command = $mysqldumpPath." -B -h $DB_HOST -P $DB_PORT -u $DB_USER -p$DB_PASS $dbname > $backupLabDbFileName";
 system($command,$return);
 $file_list1[] = $backupLabDbFileName;
 		
 $dbname = "blis_revamp";
 $backupDbFileName = "blis_revamp_configuration.sql";
-$command = $mysqldumpPath." -B -h $DB_HOST -P 7188 -u $DB_USER -p$DB_PASS $dbname > $backupDbFileName";
+$command = $mysqldumpPath." -B -h $DB_HOST -P $DB_PORT -u $DB_USER -p$DB_PASS $dbname > $backupDbFileName";
 system($command,$return);
 $file_list2[] = $backupDbFileName;
 
@@ -32,7 +32,7 @@ $toScreenDestination = "blis_configuration_".$site_name."_".$country;
 @mkdir($destination);
 @mkdir($destination."blis_revamp/");
 @mkdir($destination."blis_".$lab_config_id."/");
-chmod($destination, 777);
+chmod($destination, 0755);
 
 foreach($file_list1 as $file) {
 	$file_name_parts = explode("/", $file);

--- a/htdocs/export/exportNationalDatabase.php
+++ b/htdocs/export/exportNationalDatabase.php
@@ -14,14 +14,14 @@ $mainBlisDir = substr($currentDir,$length,strpos($currentDir,"htdocs"));
 $mysqldumpPath = "\"".$mainBlisDir."server\mysql\bin\mysqldump.exe\"";
 $dbName = "blis_".$country;
 $backupDbFileName= "blis_".$country."_backup.sql";
-$command = $mysqldumpPath." -B -h $DB_HOST -P 7188 -u $DB_USER -p$DB_PASS $dbName > $backupDbFileName";
+$command = $mysqldumpPath." -B -h $DB_HOST -P $DB_PORT -u $DB_USER -p$DB_PASS $dbName > $backupDbFileName";
 system($command,$return);
 $file_list1[] = $backupDbFileName;
 
 $destination = "../../blis_backup_".$country."_".date("Ymd-Hi")."/";
 $toScreenDestination = "blis_backup_".$country."_".date("Ymd-Hi");
 @mkdir($destination);
-chmod($destination, 777);
+chmod($destination, 0755);
 
 foreach($file_list1 as $file) {
 	$file_name_parts = explode("/", $file);

--- a/htdocs/export/import_data_director.php
+++ b/htdocs/export/import_data_director.php
@@ -18,7 +18,7 @@ $lid = $file_name_parts[1];
     $blisLabBackupFilePath = "\"".$mainBlisDir."\htdocs\export\blis_129_temp_backup.sql\"";
     $mysqlExePath = "\"".$mainBlisDir."server\mysql\bin\mysql.exe\"";
     //$backupLabDbFileName = "\"".$mainBlisDir."backups\\"."testsql.sql\"";
-    $command = $mysqlExePath." -h $DB_HOST -P 7188 -u $DB_USER -p$DB_PASS  < $fileName";
+    $command = $mysqlExePath." -h $DB_HOST -P $DB_PORT -u $DB_USER -p$DB_PASS  < $fileName";
     $command = "C: &".$command; //the C: is a useless command to prevent the original command from failing because of having more than 2 double quotes
     echo $command;
     system($command, $return);

--- a/htdocs/export/import_data_director1.php
+++ b/htdocs/export/import_data_director1.php
@@ -53,7 +53,7 @@ $lid = $file_name_parts[1];
 
 $fileName=$extractPath."/".$sqlFile;
 
-    $command = $mysqlExePath." -h $DB_HOST -P 7188 -u $DB_USER -p$DB_PASS  < ".$fileName;
+    $command = $mysqlExePath." -h $DB_HOST -P $DB_PORT -u $DB_USER -p$DB_PASS  < ".$fileName;
 
     $command = "C: &".$command; //the C: is a useless command to prevent the original command from failing because of having more than 2 double quotes
 $pvt="../ajax/LAB_dir.blis";
@@ -62,7 +62,7 @@ if($is_encrypted)
 if(file_exists($pvt))
 {
 decryptFile($fileName,$pvt);
-    $command = $mysqlExePath." -h $DB_HOST -P 7188 -u $DB_USER -p$DB_PASS  < ".$fileName.".dec";
+    $command = $mysqlExePath." -h $DB_HOST -P $DB_PORT -u $DB_USER -p$DB_PASS  < ".$fileName.".dec";
     $command = "C: &".$command; //the C: is a useless command to prevent the original command from failing because of having more than 2 double quotes
 }
 else

--- a/htdocs/export/updateCountryDatabase.php
+++ b/htdocs/export/updateCountryDatabase.php
@@ -60,7 +60,7 @@ function updateDatabase() {
 	$sqlFilePath = "\"".$mainBlisDir."htdocs\\export\\temp.sql\"";
 	$mysqlExePath = "\"".$mainBlisDir."server\mysql\bin\mysql.exe\"";
 	$dbname = "blis_".$country;
-	$command = $mysqlExePath." -h $DB_HOST -P 7188 -u $DB_USER -p$DB_PASS $dbname < $sqlFilePath";
+	$command = $mysqlExePath." -h $DB_HOST -P $DB_PORT -u $DB_USER -p$DB_PASS $dbname < $sqlFilePath";
 	$command = "C: &".$command; //the C: is a useless command to prevent the original command from failing because of having more than 2 double quotes
 	echo $command;
 	system($command, $return_var);
@@ -194,7 +194,7 @@ function performUpdate($lab_config_id, $backup_folder) {
 	$blisLabBackupFilePath = "\"".$mainBlisDir.$backup_folder."\blis_".$lab_config_id."\blis_".$lab_config_id."_backup.sql\"";
 	$mysqlExePath = "\"".$mainBlisDir."server\mysql\bin\mysql.exe\"";
 	$dbname = "blis_".$lab_config_id;
-	$command = $mysqlExePath." -h $DB_HOST -P 7188 -u $DB_USER -p$DB_PASS $dbname < $blisLabBackupFilePath";
+	$command = $mysqlExePath." -h $DB_HOST -P $DB_PORT -u $DB_USER -p$DB_PASS $dbname < $blisLabBackupFilePath";
 	$command = "C: &".$command; //the C: is a useless command to prevent the original command from failing because of having more than 2 double quotes
 	system($command, $return_var);
 	if( $return_var == 0 )

--- a/htdocs/export/updateNationalDatabase.php
+++ b/htdocs/export/updateNationalDatabase.php
@@ -60,7 +60,7 @@ function updateDatabase() {
 	$sqlFilePath = "\"".$mainBlisDir."htdocs\\export\\temp.sql\"";
 	$mysqlExePath = "\"".$mainBlisDir."server\mysql\bin\mysql.exe\"";
 	$dbname = "blis_".$country;
-	$command = $mysqlExePath." -h $DB_HOST -P 7188 -u $DB_USER -p$DB_PASS $dbname < $sqlFilePath";
+	$command = $mysqlExePath." -h $DB_HOST -P $DB_PORT -u $DB_USER -p$DB_PASS $dbname < $sqlFilePath";
 	$command = "C: &".$command; //the C: is a useless command to prevent the original command from failing because of having more than 2 double quotes
 	echo $command;
 	system($command, $return_var);
@@ -202,7 +202,7 @@ function performUpdate($lab_config_id, $backup_folder) {
 	$blisLabBackupFilePath = "\"".$mainBlisDir.$backup_folder."\blis_".$lab_config_id."\blis_".$lab_config_id."_backup.sql\"";
 	$mysqlExePath = "\"".$mainBlisDir."server\mysql\bin\mysql.exe\"";
 	$dbname = "blis_".$lab_config_id;
-	$command = $mysqlExePath." -h $DB_HOST -P 7188 -u $DB_USER -p$DB_PASS $dbname < $blisLabBackupFilePath";
+	$command = $mysqlExePath." -h $DB_HOST -P $DB_PORT -u $DB_USER -p$DB_PASS $dbname < $blisLabBackupFilePath";
 	$command = "C: &".$command; //the C: is a useless command to prevent the original command from failing because of having more than 2 double quotes
 	system($command, $return_var);
 	if( $return_var == 0 )

--- a/htdocs/export/update_database.php
+++ b/htdocs/export/update_database.php
@@ -81,7 +81,7 @@ function performUpdate($lab_config_id, $backup_folder) {
 	$blisLabBackupFilePath = "\"".$mainBlisDir.$backup_folder."\blis_".$lab_config_id."\blis_".$lab_config_id."_backup.sql\"";
 	$mysqlExePath = "\"".$mainBlisDir."server\mysql\bin\mysql.exe\"";
 	$dbname = "blis_".$lab_config_id;
-	$command = $mysqlExePath." -h $DB_HOST -P 7188 -u $DB_USER -p$DB_PASS $dbname < $blisLabBackupFilePath";
+	$command = $mysqlExePath." -h $DB_HOST -P $DB_PORT -u $DB_USER -p$DB_PASS $dbname < $blisLabBackupFilePath";
 	$command = "C: &".$command; //the C: is a useless command to prevent the original command from failing because of having more than 2 double quotes
 	system($command, $return_var);
 	if( $return_var == 0 )

--- a/htdocs/includes/db_constants.php
+++ b/htdocs/includes/db_constants.php
@@ -4,6 +4,8 @@
 # Include in db_mysql_lib.php
 #
 
+require_once("../includes/platform_lib.php");
+
 if(session_id() == "")
 	session_start();
 	
@@ -20,7 +22,16 @@ if($SERVER == $ON_ARC)
 	$LOCAL_PATH = "../local/";
 }
 
-$DB_HOST = "localhost";
+$DB_HOST = "127.0.0.1";
+
+// If not running on Windows, use the MySQL default port.
+$DB_PORT = 3306;
+if (PlatformLib::runningOnWindows()) {
+	// If running on Windows, assume we're running the traditional version of BLIS.
+	// The default port for the Server2Go MySQL server is 7188.
+	$DB_PORT = 7188;
+}
+
 $DB_USER = "root";
 // $d = dirname(__FILE__);
 // $name= strrpos($d,"htdocs");

--- a/htdocs/includes/platform_lib.php
+++ b/htdocs/includes/platform_lib.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * Functions that provide access to resources on the system that BLIS is running on.
+ */
+class PlatformLib {
+    public static function runningOnWindows() {
+		// PHP_OS will have something like "Windows XXX..." or "Linux..."
+		if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
+			return true;
+		}
+		return false;
+	}
+
+	public static function mySqlDumpPath() {
+		$currentDir = dirname(realpath(__FILE__));
+		if(self::runningOnWindows()) {
+			// If running on Windows, assume that we're running the portable/traditional
+			// version of BLIS, and use the bundled mysqldump.
+			return "../../server/mysql/bin/mysqldump.exe";
+		} else {
+			// Otherwise, assume that mysqldump is in the system PATH.
+			// This should work on Linux!
+			return "mysqldump";
+		}
+
+	}
+}
+?>


### PR DESCRIPTION
Fixes three issues for running BLIS on Linux:

1. Connect to database on `127.0.0.1` instead of `localhost`. Trying to connect to MySQL on `localhost` will _not_ actually resolve to `127.0.0.1` in the sense that it will establish a TCP/IP connection ([read here, see "Notes" section](https://www.php.net/mysql_connect)), but instead a system socket. Since MySQL is running in a separate container in my devcontainer setup, I force it to use TCP/IP by specifying `127.0.0.1`. This shouldn't have a big negative performance impact given the local nature of BLIS.
2. Add `$DB_PORT` variable. Since ports can vary and it needs to be specified in the commands to `mysqldump`, make `$DB_PORT` variable in `db_constants.php` the same as `$DB_HOST` is instead of copy/pasting it everywhere
3. Similarly, on Windows you can assume the path of `mysqldump` since it's bundled with BLIS. Not so on Linux, where you probably want to use the system one. I added the new class `PlatformLib` to handle the translation of this and similar things for running on different platforms.