### PR TITLE
Fix a number of bugs related to passing $lab_config_id around; reformat some lab config-related files

### DIFF
--- a/htdocs/ajax/search_config_update.php
+++ b/htdocs/ajax/search_config_update.php
@@ -110,10 +110,9 @@ if($lab_config->dob != $f_dob)
 if($lab_config->pname != $f_pname)
 	$lab_config->updatePname($f_pname);
 */
-    
+
  $res = intval($_REQUEST['sfields_resultsPerPage']);
- update_lab_config_settings_search($res);
+ update_lab_config_settings_search($res, $lab_config->id);
 SessionUtil::restore($saved_session);
 
 ?>
- 

--- a/htdocs/config/lab_config_home.php
+++ b/htdocs/config/lab_config_home.php
@@ -10,6 +10,8 @@ include("includes/header.php");
 include("includes/random.php");
 include("includes/stats_lib.php");
 
+require_once(dirname(__FILE__).'/../includes/composer.php');
+
 include_once("includes/field_order_update.php");
 
 LangUtil::setPageId("lab_config_home");
@@ -260,7 +262,7 @@ $script_elems->enableJQueryForm();
 
 $lab_config_id = $_REQUEST['id'];
 $user = get_user_by_id($_SESSION['user_id']);
-if (!((is_country_dir($user)) || (is_super_admin($user)))) {
+if (!(is_country_dir($user) || is_super_admin($user))) {
     $saved_db = DbUtil::switchToGlobal();
     $query = "SELECT lab_config_id FROM lab_config WHERE admin_user_id = ".$_SESSION['user_id'].
     " OR lab_config_id IN ( ".
@@ -295,8 +297,8 @@ if ($lab_config == null) {
     return;
 }
 
-$field_odering_patients = field_order_update::install_first_order($lab_config, 1);
-$field_odering_specimen = field_order_update::install_first_order($lab_config, 2);
+$field_odering_patients = field_order_update::install_first_order($lab_config, 1, $lab_config_id);
+$field_odering_specimen = field_order_update::install_first_order($lab_config, 2, $lab_config_id);
 ?>
 <style type='text/css'>
 
@@ -3069,7 +3071,9 @@ function AddnewDHIMS2Config()
 								<td><?php echo LangUtil::$generalTerms['SPECIMENS']; ?> - <?php echo LangUtil::$generalTerms['SPECIMEN_ID']; ?></td>
 								<td>
 									<input type='checkbox' name='use_s_addl' id='use_s_addl'<?php
-
+                                    if ($lab_config->specimenAddl != 0) {
+                                        echo " checked ";
+                                    }
                                     ?>>
 
 									</input>
@@ -4389,7 +4393,7 @@ function AddnewDHIMS2Config()
 					<br>
                     <div class='pretty_box' style='width:300px;'>
 					<form id='batch_results_form' name='batch_results_form' action='ajax/batch_results_config_update.php' method='post'>
-						<?php $page_elems->getBatchResultsFieldsForm() ?>
+						<?php $page_elems->getBatchResultsFieldsForm($lab_config_id) ?>
 
 					</form>
                     </div>

--- a/htdocs/config/lab_config_home.php
+++ b/htdocs/config/lab_config_home.php
@@ -21,11 +21,11 @@ $script_elems->enableJQueryForm();
 
 ?>
 
-  
+
 <script src="js/jquery-ui-1.8.16.js" type="text/javascript"></script>
 <link rel="stylesheet" href="css//jquery-ui-1.8.16.css" type="text/css" media="all">
 
- <link rel="stylesheet" href="css/jquery-ui-1.8.16.css" type="text/css" media="all"> 
+ <link rel="stylesheet" href="css/jquery-ui-1.8.16.css" type="text/css" media="all">
 <!-- <link rel="stylesheet" href="/resources/demos/style.css" /> -->
 <!-- <script type="text/javascript" src="js/jquery.ui.js"></script>
 <script type="text/javascript" src="js/dialog/jquery.ui.core.js"></script>
@@ -33,24 +33,24 @@ $script_elems->enableJQueryForm();
 
 <div id='Summary_config' class='right_pane' style='display:none;margin-left:10px;'>
 	<ul>
-	<?php 
-	if(LangUtil::$pageTerms['TIPS_SUMMARY_1'] != '-') {
-		echo "<li>";
-		echo LangUtil::$pageTerms['TIPS_SUMMARY_1'];
-		echo "</li>";
-	}	
-	if(LangUtil::$pageTerms['TIPS_SUMMARY_2']!="-") {
-		echo "<li>"; 
-		echo LangUtil::$pageTerms['TIPS_SUMMARY_2'];
-		echo "</li>";
-	}
-	if(LangUtil::$pageTerms['TIPS_SUMMARY_3']!="-") {
-		echo "<li>"; 
-		echo LangUtil::$pageTerms['TIPS_SUMMARY_3'];
-		echo "</li>"; 
-	}	
-	?>	
-	</ul>	
+	<?php
+    if (LangUtil::$pageTerms['TIPS_SUMMARY_1'] != '-') {
+        echo "<li>";
+        echo LangUtil::$pageTerms['TIPS_SUMMARY_1'];
+        echo "</li>";
+    }
+    if (LangUtil::$pageTerms['TIPS_SUMMARY_2']!="-") {
+        echo "<li>";
+        echo LangUtil::$pageTerms['TIPS_SUMMARY_2'];
+        echo "</li>";
+    }
+    if (LangUtil::$pageTerms['TIPS_SUMMARY_3']!="-") {
+        echo "<li>";
+        echo LangUtil::$pageTerms['TIPS_SUMMARY_3'];
+        echo "</li>";
+    }
+    ?>
+	</ul>
 </div>
 
 <div id='Tests_config' class='right_pane' style='display:none;margin-left:10px;'>
@@ -59,22 +59,22 @@ $script_elems->enableJQueryForm();
 	<p>This has the following options:</p>
 	<ul>
 		<?php
-		if(LangUtil::$pageTerms['TIPS_SPECIMENTESTTYPES']!="-") {
-			echo "<li>";
-			echo LangUtil::$pageTerms['TIPS_SPECIMENTESTTYPES'];
-			echo "</li>";
-		}	
-		if(LangUtil::$pageTerms['TIPS_TARGETTAT']!="-") {
-			echo "<li>"; 
-			echo LangUtil::$pageTerms['TIPS_TARGETTAT'];
-			echo "</li>";
-		}
-		if(LangUtil::$pageTerms['TIPS_RESULTINTERPRETATION']!="-") {
-			echo "<li>"; 
-			echo LangUtil::$pageTerms['TIPS_RESULTINTERPRETATION'];
-			echo "</li>"; 
-		}
-		?>
+        if (LangUtil::$pageTerms['TIPS_SPECIMENTESTTYPES']!="-") {
+            echo "<li>";
+            echo LangUtil::$pageTerms['TIPS_SPECIMENTESTTYPES'];
+            echo "</li>";
+        }
+        if (LangUtil::$pageTerms['TIPS_TARGETTAT']!="-") {
+            echo "<li>";
+            echo LangUtil::$pageTerms['TIPS_TARGETTAT'];
+            echo "</li>";
+        }
+        if (LangUtil::$pageTerms['TIPS_RESULTINTERPRETATION']!="-") {
+            echo "<li>";
+            echo LangUtil::$pageTerms['TIPS_RESULTINTERPRETATION'];
+            echo "</li>";
+        }
+        ?>
 	</ul>
 </div>
 
@@ -89,7 +89,7 @@ $script_elems->enableJQueryForm();
     <ul>
         <li>Enable Billing: Toggles whether or not your lab uses the billing engine.</li>
         <li>Currency Name: Denotes what name will be used when printing monetary amounts in the billing engine.</li>
-        <li>Currency Delimiter: Denotes what is used to separate 'dollars' from 
+        <li>Currency Delimiter: Denotes what is used to separate 'dollars' from
             'cents' when printing monetary amounts in the billing engine.  For example, the '.' in 10.50</li>
     </ul>
 </div>
@@ -98,8 +98,8 @@ $script_elems->enableJQueryForm();
 	<ul>
 			<li><?php echo LangUtil::$pageTerms['TIPS_INFECTIONREPORT']; ?></li>
 		</ul>
-	</div>	
-	
+	</div>
+
 	<div id='DRS_rc' class='right_pane' style='display:none;margin-left:10px;'>
 	<ul>
 			<li><?php echo LangUtil::$pageTerms['TIPS_DAILYREPORTSETTINGS']; ?></li>
@@ -112,7 +112,7 @@ $script_elems->enableJQueryForm();
 			<li><?php echo LangUtil::$pageTerms['TIPS_BATCHRESULTSCONFIGSETTINGS']; ?></li>
 		</ul>
 	</div>
-	
+
 	 <div id='PFO' class='right_pane' style='display:none;margin-left:10px;'>
 	<ul>
 			<li><?php echo LangUtil::$pageTerms['TIPS_PATIENTFIELDSORDER']; ?></li>
@@ -138,93 +138,93 @@ $script_elems->enableJQueryForm();
 			<li><?php echo LangUtil::$pageTerms['TIPS_WORKSHEETS']; ?></li>
 		</ul>
 	</div>
-	
+
 	<div id='UserAccounts_config' class='right_pane' style='display:none;margin-left:10px;'>
-	<ul>	
+	<ul>
 		<?php
-		if(LangUtil::$pageTerms['TIPS_USERACCOUNTS_1']!="-") {
-			echo "<li>";
-			echo LangUtil::$pageTerms['TIPS_USERACCOUNTS_1'];
-			echo "</li>";
-		}	
-		if(LangUtil::$pageTerms['TIPS_USERACCOUNTS_2']!="-") {
-			echo "<li>"; 
-			echo LangUtil::$pageTerms['TIPS_USERACCOUNTS_2'];
-			echo "</li>";
-		}
-		if(LangUtil::$pageTerms['TIPS_USERACCOUNTS_3']!="-") {
-			echo "<li>"; 
-			echo LangUtil::$pageTerms['TIPS_USERACCOUNTS_3'];
-			echo "</li>"; 
-		}
-		?>
+        if (LangUtil::$pageTerms['TIPS_USERACCOUNTS_1']!="-") {
+            echo "<li>";
+            echo LangUtil::$pageTerms['TIPS_USERACCOUNTS_1'];
+            echo "</li>";
+        }
+        if (LangUtil::$pageTerms['TIPS_USERACCOUNTS_2']!="-") {
+            echo "<li>";
+            echo LangUtil::$pageTerms['TIPS_USERACCOUNTS_2'];
+            echo "</li>";
+        }
+        if (LangUtil::$pageTerms['TIPS_USERACCOUNTS_3']!="-") {
+            echo "<li>";
+            echo LangUtil::$pageTerms['TIPS_USERACCOUNTS_3'];
+            echo "</li>";
+        }
+        ?>
 	</ul>
 	</div>
-	
+
 	<div id='RegistrationFields_config' class='right_pane' style='display:none;margin-left:10px;'>
-	<ul>	
+	<ul>
 		<?php
-		if(LangUtil::$pageTerms['TIPS_REGISTRATIONFIELDS_1']!="-") {
-			echo "<li>";
-			echo LangUtil::$pageTerms['TIPS_REGISTRATIONFIELDS_1'];
-			echo "</li>";
-		}	
-		if(LangUtil::$pageTerms['TIPS_REGISTRATIONFIELDS_2']!="-") {
-			echo "<li>"; 
-			echo LangUtil::$pageTerms['TIPS_REGISTRATIONFIELDS_2'];
-			echo "</li>";
-		}
-		if(LangUtil::$pageTerms['TIPS_REGISTRATIONFIELDS_3']!="-") {
-			echo "<li>"; 
-			echo LangUtil::$pageTerms['TIPS_REGISTRATIONFIELDS_3'];
-			echo "</li>"; 
-		}
-		?>
+        if (LangUtil::$pageTerms['TIPS_REGISTRATIONFIELDS_1']!="-") {
+            echo "<li>";
+            echo LangUtil::$pageTerms['TIPS_REGISTRATIONFIELDS_1'];
+            echo "</li>";
+        }
+        if (LangUtil::$pageTerms['TIPS_REGISTRATIONFIELDS_2']!="-") {
+            echo "<li>";
+            echo LangUtil::$pageTerms['TIPS_REGISTRATIONFIELDS_2'];
+            echo "</li>";
+        }
+        if (LangUtil::$pageTerms['TIPS_REGISTRATIONFIELDS_3']!="-") {
+            echo "<li>";
+            echo LangUtil::$pageTerms['TIPS_REGISTRATIONFIELDS_3'];
+            echo "</li>";
+        }
+        ?>
 	</ul>
 	</div>
 
         <!--NC3065-->
-        
+
         <div id='search_config' class='right_pane' style='display:none;margin-left:10px;'>
-	<ul>	
+	<ul>
 		<?php
-		
-			echo "<li>";
-			echo " Toggle Patient Number or Patient's Age to be displayed as part of Search Results";
-			echo "</li>";
+
+            echo "<li>";
+            echo " Toggle Patient Number or Patient's Age to be displayed as part of Search Results";
+            echo "</li>";
                         echo "<li>";
-			echo " Choosing to display Patient Number and/or Patient's Age as part of Search results slows down the time taken to search ";
-			echo "</li>";
-                        
-                        
-		
-		?>
+            echo " Choosing to display Patient Number and/or Patient's Age as part of Search results slows down the time taken to search ";
+            echo "</li>";
+
+
+
+        ?>
 	</ul>
 	</div>
-        
+
         <div id='barcode_config' class='right_pane' style='display:none;margin-left:10px;'>
-	<ul>	
+	<ul>
 		<?php
-		
-			echo "<li>";
-			echo " Configure your settings for barcode formats";
-			echo "</li>";
+
+            echo "<li>";
+            echo " Configure your settings for barcode formats";
+            echo "</li>";
                         echo "<li>";
-			echo " Width and Height are the dimensions of the bars ";
-			echo "</li>";
+            echo " Width and Height are the dimensions of the bars ";
+            echo "</li>";
                         echo "<li>";
-			echo " Text size os the for the code printed underneath the barcodes";
-			echo "</li>";
-                       
-                        
-                        
-		
-		?>
+            echo " Text size os the for the code printed underneath the barcodes";
+            echo "</li>";
+
+
+
+
+        ?>
 	</ul>
 	</div>
-        
+
         <!---NC3065-->
-	
+
 	<div id='SetupNet' class='right_pane' style='display:none;margin-left:10px;'>
 	<ul>
 			<li><?php echo LangUtil::$pageTerms['TIPS_SETUPNETWORK_3']; ?></li>
@@ -235,7 +235,7 @@ $script_elems->enableJQueryForm();
 	<ul>
 		<li><?php echo LangUtil::$pageTerms['TIPS_KEY_MANAGEMENT']; ?></li>
 	</ul>
-	</div>	
+	</div>
 	<div id='Revert' class='right_pane' style='display:none;margin-left:10px;'>
 	<ul>
 		<li><?php echo LangUtil::$pageTerms['TIPS_REVERT']; ?></li>
@@ -260,21 +260,21 @@ $script_elems->enableJQueryForm();
 
 $lab_config_id = $_REQUEST['id'];
 $user = get_user_by_id($_SESSION['user_id']);
-if ( !((is_country_dir($user)) || (is_super_admin($user)) ) ) {
-	$saved_db = DbUtil::switchToGlobal();
-	$query = "SELECT lab_config_id FROM lab_config WHERE admin_user_id = ".$_SESSION['user_id'].
+if (!((is_country_dir($user)) || (is_super_admin($user)))) {
+    $saved_db = DbUtil::switchToGlobal();
+    $query = "SELECT lab_config_id FROM lab_config WHERE admin_user_id = ".$_SESSION['user_id'].
     " OR lab_config_id IN ( ".
     "	SELECT lab_config_id FROM lab_config_access ".
     "	WHERE user_id='".$_SESSION['user_id'] .
     "') ORDER BY name";
-	$record = query_associative_one($query);
-	$labId = $record['lab_config_id'];
-	if($labId != $lab_config_id) {
-		echo "You are not authorized to access the configuration";
-		include("includes/footer.php");
-		die();
-	}
-	DbUtil::switchRestore($saved_db);
+    $record = query_associative_one($query);
+    $labId = $record['lab_config_id'];
+    if ($labId != $lab_config_id) {
+        echo "You are not authorized to access the configuration";
+        include("includes/footer.php");
+        die();
+    }
+    DbUtil::switchRestore($saved_db);
 }
 //echo "Lab Config Id ".$lab_config_id;
 $lab_config = LabConfig::getById($lab_config_id);
@@ -284,16 +284,15 @@ $custom_field_list_patients = get_lab_config_patient_custom_fields($lab_config->
 $custom_field_list_specimen = get_lab_config_specimen_custom_fields($lab_config->id);
 $custom_field_list_labTitle = get_lab_config_labtitle_custom_fields($lab_config->id);
 //echo "custom fields = ".$custom_field_list[0]->id;
-if($lab_config == null)
-{
-	?>
+if ($lab_config == null) {
+    ?>
 	<br><br>
 	<div class='sidetip_nopos'>
 	<?php echo LangUtil::$generalTerms['MSG_NOTFOUND']; ?>
 	</div>
 	<?php
-	include("includes/footer.php");
-	return;
+    include("includes/footer.php");
+    return;
 }
 
 $field_odering_patients = field_order_update::install_first_order($lab_config, 1);
@@ -318,7 +317,7 @@ $field_odering_specimen = field_order_update::install_first_order($lab_config, 2
     input.text { margin-bottom:12px; width:95%; padding: .4em; }
     fieldset { padding:0; border:0; margin-top:25px; }
     h1 { font-size: 1.2em; margin: .6em 0; }
-    
+
     .validateTips { border: 1px solid transparent; padding: 0.3em; } */
 
 .range_field {
@@ -345,7 +344,7 @@ alert("Invalid key, please upload the key provided by BLIS Software.");
 return;
 }
   formData.append('keys', file, file.name);
-formData.append("lab_name", lab_name.value);    
+formData.append("lab_name", lab_name.value);
 }
 var xhr = new XMLHttpRequest();
 xhr.open('POST', '../ajax/add_keys.php', true);
@@ -374,295 +373,202 @@ xhr.send(formData);
 	$('#revert_done_msg').hide();
 	$('#reorder_fields').hide();
 	$('#doctor_reorder_fields').hide();
-	
-	
+
+
 	$('#cat_code12').change( function() { get_test_types_bycat() });
 	get_test_types_bycat
 	<?php
-	if(isset($_REQUEST['show_u']))
-	{
-		# Preload user accounts pane
-		?>
+    if (isset($_REQUEST['show_u'])) {
+        # Preload user accounts pane
+        ?>
 		right_load(3, 'users_div');
-		<?php		
-	}
-	else if(isset($_REQUEST['show_f']))
-	{
-		# Preload custom fields pane
-		?>
+		<?php
+    } elseif (isset($_REQUEST['show_f'])) {
+        # Preload custom fields pane
+        ?>
 		right_load(4, 'fields_div');
 		<?php
-	}
-	
-	else if(isset($_REQUEST['show_df']))
-	{
-	# Preload custom fields pane
-	?>
+    } elseif (isset($_REQUEST['show_df'])) {
+        # Preload custom fields pane
+    ?>
 			right_load(4, 'doctor_fields_div');
 			<?php
-		}
-		
-	else if(isset($_REQUEST['show_i']))
-	{
-		# Preload the inventory pane
-		?>
+    } elseif (isset($_REQUEST['show_i'])) {
+        # Preload the inventory pane
+        ?>
 		right_load(15, 'inventory_div');
-		<?
-	}
-	else if(isset($_REQUEST['set_locale']))
-	{
-		$locale = $_REQUEST['locale'];
-		?>
+		<?php
+    } elseif (isset($_REQUEST['set_locale'])) {
+        $locale = $_REQUEST['locale']; ?>
 		language_div_load();
 		<?php
-	}
-	else if (isset($_REQUEST['setup_server']))
-	{
-		?>
+    } elseif (isset($_REQUEST['setup_server'])) {
+        ?>
 			right_load(33, 'server_setup_div');
-		<?
-	}
-	else
-	{
-		$locale = $_SESSION['locale'];
-		?>
+		<?php
+    } else {
+        $locale = $_SESSION['locale']; ?>
 		right_load(1, 'site_info_div');
 		<?php
-	}
-	
-	if(isset($_REQUEST['aupdate']))
-	{
-		# Show user account updated message
-		?>
+    }
+
+    if (isset($_REQUEST['aupdate'])) {
+        # Show user account updated message?>
 		$('#user_acc_msg').html("'<?php echo $_REQUEST['aupdate']; ?>' - <?php echo LangUtil::$generalTerms['MSG_ACC_UPDATED']; ?>&nbsp;&nbsp;&nbsp;<a href=\"javascript:toggle('user_acc_msg');\"><?php echo LangUtil::$generalTerms['CMD_HIDE']; ?></a>");
 		$('#user_acc_msg').show();
 		<?php
-	}
-	else if(isset($_REQUEST['aupdatetype']))
-	{
-		# Show user account updated message
-		?>
+    } elseif (isset($_REQUEST['aupdatetype'])) {
+        # Show user account updated message?>
 		$('#user_acc_msg1').html("'<?php echo $_REQUEST['aupdatetype']; ?>' - <?php echo 'Account updated'; ?>&nbsp;&nbsp;&nbsp;<a href=\"javascript:toggle('user_acc_msg1');\"><?php echo LangUtil::$generalTerms['CMD_HIDE']; ?></a>");
 		$('#user_acc_msg1').show();
 		<?php
-	}
-
-	else if(isset($_REQUEST['adel']))
-	{
-		# Show user account deleted message
-		?>
+    } elseif (isset($_REQUEST['adel'])) {
+        # Show user account deleted message?>
 		$('#user_acc_msg').html("<?php echo LangUtil::$generalTerms['MSG_ACC_DELETED']; ?>&nbsp;&nbsp;&nbsp;<a href=\"javascript:toggle('user_acc_msg');\"><?php echo LangUtil::$generalTerms['CMD_HIDE']; ?></a>");
 		$('#user_acc_msg').show();
 		<?php
-	}
-		else if(isset($_REQUEST['adeltype']))
-	{
-		# Show user account deleted message
-		?>
+    } elseif (isset($_REQUEST['adeltype'])) {
+            # Show user account deleted message?>
 		$('#user_acc_msg1').html("<?php echo LangUtil::$generalTerms['MSG_ACC_DELETED']; ?>&nbsp;&nbsp;&nbsp;<a href=\"javascript:toggle('user_acc_msg1');\"><?php echo LangUtil::$generalTerms['CMD_HIDE']; ?></a>");
 		$('#user_acc_msg1').show();
 		<?php
-	}
-	else if(isset($_REQUEST['aadd']))
-	{
-		# Show user account added message
-		?>
+        } elseif (isset($_REQUEST['aadd'])) {
+        # Show user account added message?>
 		$('#user_acc_msg').html("'<?php echo $_REQUEST['aadd']; ?>' - <?php echo LangUtil::$generalTerms['MSG_ACC_ADDED']; ?>&nbsp;&nbsp;&nbsp;<a href=\"javascript:toggle('user_acc_msg');\"><?php echo LangUtil::$generalTerms['CMD_HIDE']; ?></a>");
 		$('#user_acc_msg').show();
 		<?php
-	}
-	else if(isset($_REQUEST['aaddtype']))
-	{
-		# Show user account added message
-		if ($_REQUEST['typeflag']=='1'){
-			?>
+    } elseif (isset($_REQUEST['aaddtype'])) {
+        # Show user account added message
+        if ($_REQUEST['typeflag']=='1') {
+            ?>
 			$('#user_acc_msg1').html("'<?php echo 'User type already exists'; ?>&nbsp;&nbsp;&nbsp;<a href=\"javascript:toggle('user_acc_msg1');\"><?php echo LangUtil::$generalTerms['CMD_HIDE']; ?></a>");
 			$('#user_acc_msg1').show();
 			<?php
-		}
-		else{
-			?>
+        } else {
+            ?>
 			$('#user_acc_msg1').html("'<?php echo $_REQUEST['aaddtype']; ?>' - <?php echo 'User type added'; ?>&nbsp;&nbsp;&nbsp;<a href=\"javascript:toggle('user_acc_msg1');\"><?php echo LangUtil::$generalTerms['CMD_HIDE']; ?></a>");
 			$('#user_acc_msg1').show();
 			<?php
-		}
-
-		
-	}
-	else if(isset($_REQUEST['siteupdate']))
-	{
-		?>
+        }
+    } elseif (isset($_REQUEST['siteupdate'])) {
+        ?>
 		$('#site_config_msg').html("<?php echo LangUtil::$generalTerms['MSG_UPDATED']; ?>&nbsp;&nbsp;&nbsp;<a href=\"javascript:toggle('site_config_msg');\"><?php echo LangUtil::$generalTerms['CMD_HIDE']; ?></a>");
 		$('#site_config_msg').show();
 		right_load(54, 'site_config_div');
 		<?php
-	}
-	else if(isset($_REQUEST['tupdate']))
-	{
-		# Show TAT values updated message
-		?>
+    } elseif (isset($_REQUEST['tupdate'])) {
+        # Show TAT values updated message?>
 		$('#tat_msg').html("<?php echo LangUtil::$generalTerms['MSG_UPDATED']; ?>&nbsp;&nbsp;&nbsp;<a href=\"javascript:toggle('tat_msg');\"><?php echo LangUtil::$generalTerms['CMD_HIDE']; ?></a>");
 		$('#tat_msg').show();
 		right_load(5, 'target_tat_div');
 		<?php
-	}
-	else if(isset($_REQUEST['fupdate']))
-	{
-		# Show custom field updated message
-		?>
+    } elseif (isset($_REQUEST['fupdate'])) {
+        # Show custom field updated message?>
 		$('#cfield_msg').html("<?php echo LangUtil::$generalTerms['MSG_UPDATED']; ?>&nbsp;&nbsp;&nbsp;<a href=\"javascript:toggle('cfield_msg');\"><?php echo LangUtil::$generalTerms['CMD_HIDE']; ?></a>");
 		$('#cfield_msg').show();
 		right_load(4, 'fields_div');
 		<?php
-	}
-	else if(isset($_REQUEST['dfupdate']))
-	{
-	# Show custom field updated message
-	?>
+    } elseif (isset($_REQUEST['dfupdate'])) {
+        # Show custom field updated message?>
 			$('#cfield_msg').html("<?php echo LangUtil::$generalTerms['MSG_UPDATED']; ?>&nbsp;&nbsp;&nbsp;<a href=\"javascript:toggle('cfield_msg');\"><?php echo LangUtil::$generalTerms['CMD_HIDE']; ?></a>");
 			$('#cfield_msg').show();
 			right_load(4, 'doctor_fields_div');
 			<?php
-		}
-	else if(isset($_REQUEST['fadd']))
-	{
-		# Show custom field added message
-		?>
+    } elseif (isset($_REQUEST['fadd'])) {
+        # Show custom field added message?>
 		$('#cfield_msg').html("<?php echo LangUtil::$generalTerms['MSG_ADDED']; ?>&nbsp;&nbsp;&nbsp;<a href=\"javascript:toggle('cfield_msg');\"><?php echo LangUtil::$generalTerms['CMD_HIDE']; ?></a>");
 		$('#cfield_msg').show();
 		right_load(4, 'fields_div');
 		<?php
-	}
-	else if(isset($_REQUEST['dfadd']))
-	{
-	# Show custom field added message
-	?>
+    } elseif (isset($_REQUEST['dfadd'])) {
+        # Show custom field added message?>
 			$('#cfield_msg').html("<?php echo LangUtil::$generalTerms['MSG_ADDED']; ?>&nbsp;&nbsp;&nbsp;<a href=\"javascript:toggle('cfield_msg');\"><?php echo LangUtil::$generalTerms['CMD_HIDE']; ?></a>");
 			$('#cfield_msg').show();
 			right_load(4, 'doctor_fields_div');
 			<?php
-		}
-	else if(isset($_REQUEST['stupdate']))
-	{
-		# Show custom field updated message
-		?>
+    } elseif (isset($_REQUEST['stupdate'])) {
+        # Show custom field updated message?>
 		$('#sttypes_msg').html("<?php echo LangUtil::$generalTerms['MSG_UPDATED']; ?>&nbsp;&nbsp;&nbsp;<a href=\"javascript:toggle('sttypes_msg');\"><?php echo LangUtil::$generalTerms['CMD_HIDE']; ?></a>");
 		$('#sttypes_msg').show();
 		right_load(2, 'st_types_div');
 		<?php
-	}
-        else if(isset($_REQUEST['billingupdate']))
-        {
-                ?>
+    } elseif (isset($_REQUEST['billingupdate'])) {
+            ?>
                 $('#billing_msg').html("<?php echo LangUtil::$generalTerms['MSG_UPDATED']; ?>&nbsp;&nbsp;&nbsp;<a href=\"javascript:toggle('billing_msg');\"><?php echo LangUtil::$generalTerms['CMD_HIDE']; ?></a>");
 		$('#billing_msg').show();
                 right_load(22, 'billing_div');
                 <?php
-        }
-        
-        else if(isset($_REQUEST['addedCurrency']))
-        {
-        	?>
+        } elseif (isset($_REQUEST['addedCurrency'])) {
+            ?>
                 $('#billing_msg').html("New Currecy added. &nbsp;&nbsp;&nbsp;<a href=\"javascript:toggle('billing_msg');\"><?php echo LangUtil::$generalTerms['CMD_HIDE']; ?></a>");
         		$('#billing_msg').show();
                 right_load(22, 'billing_div');
             <?php
-         }
-	else if(isset($_REQUEST['adupdate']))
-	{
-		# Show custom field updated message
-		?>
+        } elseif (isset($_REQUEST['adupdate'])) {
+        # Show custom field updated message?>
 		$('#admin_msg').html("<?php echo LangUtil::$generalTerms['MSG_UPDATED']; ?>&nbsp;&nbsp;&nbsp;<a href=\"javascript:toggle('admin_msg');\"><?php echo LangUtil::$generalTerms['CMD_HIDE']; ?></a>");
 		$('#admin_msg').show();
 		right_load(7, 'change_admin_div');
 		<?php
-	}
-	else if(isset($_REQUEST['aggupdate']))
-	{
-		# Show custom field updated message
-		?>
+    } elseif (isset($_REQUEST['aggupdate'])) {
+        # Show custom field updated message?>
 		$('#agg_msg').html("<?php echo LangUtil::$generalTerms['MSG_UPDATED']; ?>&nbsp;&nbsp;&nbsp;<a href=\"javascript:toggle('agg_msg');\"><?php echo LangUtil::$generalTerms['CMD_HIDE']; ?></a>");
 		$('#agg_msg').show();
 		right_load(8, 'agg_report_div');
 		<?php
-	}
-        else if(isset($_REQUEST['grouped_count_update']))
-	{
-		# Show custom field updated message
-		?>
+    } elseif (isset($_REQUEST['grouped_count_update'])) {
+            # Show custom field updated message?>
 		$('#grouped_count_msg').html("<?php echo LangUtil::$generalTerms['MSG_UPDATED']; ?>&nbsp;&nbsp;&nbsp;<a href=\"javascript:toggle('grouped_count_msg');\"><?php echo LangUtil::$generalTerms['CMD_HIDE']; ?></a>");
 		$('#grouped_count_msg').show();
 		right_load(36, 'grouped_count_div');
 		<?php
-	}
-	else if(isset($_REQUEST['miscupdate']))
-	{
-		# Show general settings updated message
-		?>
+        } elseif (isset($_REQUEST['miscupdate'])) {
+        # Show general settings updated message?>
 		$('#misc_msg').html("<?php echo LangUtil::$generalTerms['MSG_UPDATED']; ?>&nbsp;&nbsp;&nbsp;<a href=\"javascript:toggle('misc_msg');\"><?php echo LangUtil::$generalTerms['CMD_HIDE']; ?></a>");
 		$('#misc_msg').show();
 		right_load(9, 'misc_div');
 		<?php
-	}
-	else if(isset($_REQUEST['langupd']))
-	{
-		# Show locale updated message
-		?>
+    } elseif (isset($_REQUEST['langupd'])) {
+        # Show locale updated message?>
 		$('#main_msg').html("<?php echo LangUtil::$pageTerms['MSG_LANGUPDATED']; ?>&nbsp;&nbsp;&nbsp;<a href=\"javascript:toggle('main_msg');\"><?php echo LangUtil::$generalTerms['CMD_HIDE']; ?></a>");
 		$('#main_msg').show();
 		<?php
-	}
-	else if(isset($_REQUEST['ofupdate']))
-	{
-		# Show other fields updated message
-		?>
+    } elseif (isset($_REQUEST['ofupdate'])) {
+        # Show other fields updated message?>
 		$('#cfield_msg').html("<?php echo LangUtil::$generalTerms['MSG_UPDATED']; ?>&nbsp;&nbsp;&nbsp;<a href=\"javascript:toggle('cfield_msg');\"><?php echo LangUtil::$generalTerms['CMD_HIDE']; ?></a>");
 		$('#cfield_msg').show();
 		right_load(4, 'fields_div');
 		<?php
-	}
-	else if(isset($_REQUEST['brfupdate']))
-	{
-		# Show batch results fields updated message
-		?>
+    } elseif (isset($_REQUEST['brfupdate'])) {
+        # Show batch results fields updated message?>
 		$('#batch_results_fields_msg').html("<?php echo LangUtil::$generalTerms['MSG_UPDATED']; ?>&nbsp;&nbsp;&nbsp;<a href=\"javascript:toggle('batch_results_fields_msg');\"><?php echo LangUtil::$generalTerms['CMD_HIDE']; ?></a>");
 		$('#batch_results_fields_msg').show();
 		right_load(54, 'batch_results_div');
 		<?php
-	}
-	else if(isset($_REQUEST['odfupdate']))
-	{
-	# Show other fields updated message
-	?>
+    } elseif (isset($_REQUEST['odfupdate'])) {
+        # Show other fields updated message?>
 			$('#cfield_msg').html("<?php echo LangUtil::$generalTerms['MSG_UPDATED']; ?>&nbsp;&nbsp;&nbsp;<a href=\"javascript:toggle('cfield_msg');\"><?php echo LangUtil::$generalTerms['CMD_HIDE']; ?></a>");
 			$('#cfield_msg').show();
 			right_load(4, 'doctor_fields_div');
 			<?php
-		}
+    }
         //NC3065
-        else if(isset($_REQUEST['sfcupdate']))
-	{
-		# Show other fields updated message
-		?>
+        elseif (isset($_REQUEST['sfcupdate'])) {
+            # Show other fields updated message?>
 		$('#searchfield_msg').html("<?php echo LangUtil::$generalTerms['MSG_UPDATED']; ?>&nbsp;&nbsp;&nbsp;<a href=\"javascript:toggle('searchfield_msg');\"><?php echo LangUtil::$generalTerms['CMD_HIDE']; ?></a>");
 		$('#searchfield_msg').show();
 		right_load(21, 'search_div');
 		<?php
-	}
-        else if(isset($_REQUEST['brcupdate']))
-	{
-		# Show other fields updated message
-		?>
+        } elseif (isset($_REQUEST['brcupdate'])) {
+            # Show other fields updated message?>
 		$('#barcodefield_msg').html("<?php echo LangUtil::$generalTerms['MSG_UPDATED']; ?>&nbsp;&nbsp;&nbsp;<a href=\"javascript:toggle('barcodefield_msg');\"><?php echo LangUtil::$generalTerms['CMD_HIDE']; ?></a>");
 		$('#barcodefield_msg').show();
 		right_load(28, 'barcode_div');
 		<?php
-	}
+        }
         //-NC3065
-	else if(isset($_REQUEST['rcfgupdate']))
-	{
-		# Show report config updated message
-		?>
+    elseif (isset($_REQUEST['rcfgupdate'])) {
+        # Show report config updated message?>
 		$('#report_config_msg').html("<?php echo LangUtil::$generalTerms['MSG_UPDATED']; ?>&nbsp;&nbsp;&nbsp;<a href=\"javascript:toggle('report_config_msg');\"><?php echo LangUtil::$generalTerms['CMD_HIDE']; ?></a>");
 		$('#report_config_msg').show();
 		var report_type=<?php echo $_REQUEST['rcfgupdate']; ?>;
@@ -671,85 +577,69 @@ xhr.send(formData);
 		//fetch_report_config();
 		fetch_report_summary();
 		<?php
-	}
-	else if(isset($_REQUEST['ttrupdate']))
-	{
-		?>
+    } elseif (isset($_REQUEST['ttrupdate'])) {
+        ?>
 		$('#toggle_test_reports_msg').html("<?php echo LangUtil::$generalTerms['MSG_UPDATED']; ?>&nbsp;&nbsp;&nbsp;<a href=\"javascript:toggle('toggle_test_reports_msg');\"><?php echo LangUtil::$generalTerms['CMD_HIDE']; ?></a>");
     	$('#toggle_test_reports_msg').show();
 		right_load(52, 'toggle_test_reports_div');
 		<?php
-	}
-	else if(isset($_REQUEST['treport_conf_update']))
-	{
-		?>
+    } elseif (isset($_REQUEST['treport_conf_update'])) {
+        ?>
 		$('#test_agg_report_msg').html("<?php echo LangUtil::$generalTerms['MSG_UPDATED']; ?>&nbsp;&nbsp;&nbsp;<a href=\"javascript:toggle('test_agg_report_msg');\"><?php echo LangUtil::$generalTerms['CMD_HIDE']; ?></a>");
 		$('#test_agg_report_msg').show();
 		<?php
-	}
-	else if(isset($_REQUEST['rpfoupdate']))
-	{
-		# Show updated ordered patient fields on reports
-		?>
+    } elseif (isset($_REQUEST['rpfoupdate'])) {
+        # Show updated ordered patient fields on reports?>
 		$('#patient_fields_msg').html("<?php echo LangUtil::$generalTerms['MSG_UPDATED']; ?>&nbsp;&nbsp;&nbsp;<a href=\"javascript:toggle('patient_fields_msg');\"><?php echo LangUtil::$generalTerms['CMD_HIDE']; ?></a>");
-		$('#patient_fields_msg').show();				
-		right_load(40, 'patient_fields_config_div');		
+		$('#patient_fields_msg').show();
+		right_load(40, 'patient_fields_config_div');
 		//fetch_report_summary();
 		<?php
-	}
-	else if(isset($_REQUEST['wcfgupdate']))
-	{
-		# Show report config updated message
-		?>
+    } elseif (isset($_REQUEST['wcfgupdate'])) {
+        # Show report config updated message?>
 		$('#worksheet_config_msg').html("<?php echo LangUtil::$generalTerms['MSG_UPDATED']; ?>&nbsp;&nbsp;&nbsp;<a href=\"javascript:toggle('worksheet_config_msg');\"><?php echo LangUtil::$generalTerms['CMD_HIDE']; ?></a>");
 		$('#worksheet_config_msg').show();
-		<?php 
-		$post_parts = explode(",", $_REQUEST['wcfgupdate']); 
-		?>
+		<?php
+        $post_parts = explode(",", $_REQUEST['wcfgupdate']); ?>
 		right_load(12, 'worksheet_config_div');
 		$('#cat_code12').attr("value", "<?php echo $post_parts[0]; ?>");
 		$('#test_type12').attr("value", "<?php echo $post_parts[1]; ?>");
 		fetch_worksheet_summary();
 		<?php
-	}
-        else if(isset($_REQUEST['importupdate']))
-	{
-		# Show report config updated message
-		?>
+    } elseif (isset($_REQUEST['importupdate'])) {
+            # Show report config updated message?>
 		$('#worksheet_config_msg').html("<?php echo LangUtil::$generalTerms['MSG_UPDATED']; ?>&nbsp;&nbsp;&nbsp;<a href=\"javascript:toggle('worksheet_config_msg');\"><?php echo LangUtil::$generalTerms['CMD_HIDE']; ?></a>");
 		$('#worksheet_config_msg').show();
-		<?php 
-		$post_parts = explode(",", $_REQUEST['wcfgupdate']); 
-		?>
+		<?php
+        $post_parts = explode(",", $_REQUEST['wcfgupdate']); ?>
 		right_load(12, 'worksheet_config_div');
 		$('#cat_code12').attr("value", "<?php echo $post_parts[0]; ?>");
 		$('#test_type12').attr("value", "<?php echo $post_parts[1]; ?>");
 		fetch_worksheet_summary();
 		<?php
-	}
-	else if( isset($_REQUEST['revert']) ) {
-		if( isset($_REQUEST['updateChange'])) { ?>
+        } elseif (isset($_REQUEST['revert'])) {
+        if (isset($_REQUEST['updateChange'])) { ?>
 			right_load(18, 'update_database_div');
-			<?php 
-				if($_REQUEST['revert'] == 1) { ?>
+			<?php
+                if ($_REQUEST['revert'] == 1) { ?>
 					$('#update_success').show();
 				<?php } else { ?>
 					$('#update_failure').show();
 			<?php }
-		} else { ?>
+        } else { ?>
 			right_load(13, 'backup_revert_div');
-			<?php if($_REQUEST['revert'] == 1) { ?>
-				//$('#backup_revert_msg').html("<?php #echo LangUtil::$generalTerms['MSG_UPDATED']; ?>&nbsp;&nbsp;&nbsp;<a href=\"javascript:toggle('backup_revert_msg');\"><?php #echo LangUtil::$generalTerms['CMD_HIDE']; ?></a>");
+			<?php if ($_REQUEST['revert'] == 1) { ?>
+				//$('#backup_revert_msg').html("<?php #echo LangUtil::$generalTerms['MSG_UPDATED'];?>&nbsp;&nbsp;&nbsp;<a href=\"javascript:toggle('backup_revert_msg');\"><?php #echo LangUtil::$generalTerms['CMD_HIDE'];?></a>");
 				$('#revert_done_msg').show();
 				<?php
-				} else { ?>
+                } else { ?>
 					$('#backup_revert_msg').html("<?php echo LangUtil::$generalTerms['ERROR']; ?>&nbsp;&nbsp;&nbsp;<a href=\"javascript:toggle('backup_revert_msg');\"><?php echo LangUtil::$generalTerms['CMD_HIDE']; ?></a>");
 					$('#backup_revert_msg').show();
 				<?php
-				}
-		}
-	}
-	?>
+                }
+        }
+    }
+    ?>
 	$('#lab_admin').attr("value", "<?php echo $lab_config->adminUserId; ?>");
 	/*$('.stype_entry').change(function() {
 		check_compatible();
@@ -827,7 +717,7 @@ function get_testbox2(stype_id)
 	}
 	$('#test_list_by_site').html("<?php $page_elems->getProgressSpinner(LangUtil::$generalTerms['CMD_FETCHING']); ?>");
 	$('#test_list_by_site').load(
-		"ajax/test_list_by_site.php", 
+		"ajax/test_list_by_site.php",
 		{
 			site_id: stype_val
 		}
@@ -896,7 +786,7 @@ if(document.getElementById('api_setup').style.display =='none')
 $('#api_setup').show();
 else
 $('#api_setup').hide();
- 
+
 }
 
 function check_compatible()
@@ -907,12 +797,12 @@ function blis_update_t()
 {
     $('#update_button').hide();
     $('#update_spinner').show();
-    setTimeout( "blis_update();", 5000); 
+    setTimeout( "blis_update();", 5000);
 }
 
 function blis_update()
 {
-    
+
     $.ajax({
 		type : 'POST',
 		url : 'update/blis_update.php',
@@ -930,7 +820,7 @@ function blis_update()
 			}
 		}
 	});
-        
+
     $('#update_button').show();
 }
 function load_key_table()
@@ -939,7 +829,7 @@ function load_key_table()
     $.ajax({
       type: "GET",
       dataType: "json",
-      url: "ajax/get_keys.php", 
+      url: "ajax/get_keys.php",
 //      data: data,
       success: function(data) {
 col=["LabName","AddedBy","ModOn"];
@@ -966,7 +856,7 @@ th.setAttribute("style","border: solid 1px #DDD;border-collapse: collapse;paddin
 
                 for (var j = 0; j < col.length; j++) {
                     var tabCell = tr.insertCell(-1);
-                    tabCell.innerHTML = data[i][col[j]];	
+                    tabCell.innerHTML = data[i][col[j]];
   tabCell.setAttribute("style","border: solid 1px #DDD;border-collapse: collapse;padding: 2px 3px;text-align: center;");
 }
 var tabCell = tr.insertCell(-1);
@@ -975,7 +865,7 @@ var tabCell = tr.insertCell(-1);
 //tabCell = tr.insertCell(-1);
                     tabCell.innerHTML = "<a onclick='delete_key("+data[i]['ID']+")'>Delete</a>";
   tabCell.setAttribute("style","border: solid 1px #DDD;border-collapse: collapse;padding: 2px 3px;text-align: center;font: 15px Calibri;cursor: pointer;border: none;color: #FFF;");
-}                
+}
             var div = document.getElementById('container');
             div.innerHTML = '';
             div.appendChild(table);    // ADD THE TABLE TO THE WEB PAGE.
@@ -1027,7 +917,7 @@ function delete_key(id)
     $.ajax({
       type: "GET",
 //      dataType: "json",
-      url: "../ajax/delete_keys.php?id="+id, 
+      url: "../ajax/delete_keys.php?id="+id,
 //      data: data,
       success: function(data) {
 alert(data);
@@ -1069,13 +959,13 @@ function export_html()
 <?php
 $myFile = "../../BlisSetup.html";
 $fh = fopen($myFile, 'w') or die("can't open file");
-$content =('<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">  
-<html xmlns="http://www.w3.org/1999/xhtml">  
+$content =('<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
 <head>
 <META HTTP-EQUIV="Refresh"
 CONTENT="1; URL=');
 $content1=('">
-</head> 
+</head>
 </html>');
 $content=$content.StatsLib::get_ip().$content1;
 fwrite($fh, $content);
@@ -1176,7 +1066,7 @@ function updateCurrencyRatio(row_id)
 		alert("Enter a valid exchange rate");
 		return;
 	}
-	
+
 	var url_string = "ajax/add_currency_rate.php?lid=<?php echo $lab_config->id; ?>&defaultCurrency="+
 	defaultCurrency+"&secondaryCurrency="+secondaryCurrency+"&exchangeRate="+exchangeRate;
 	var reload_url = "lab_config_home.php?id=<?php echo $lab_config_id; ?>&billingupdate=1";
@@ -1189,7 +1079,7 @@ function deleteCurrencyRatio(row_id)
 {
 	var defaultCurrency = $("#default_currency").val();
 	var secondaryCurrency= $("#currency"+row_id).text();
-	
+
 	var url_string = "ajax/delete_currency_rate.php?lid=<?php echo $lab_config->id; ?>&defaultCurrency="+
 	defaultCurrency+"&secondaryCurrency="+secondaryCurrency;
 	var reload_url = "lab_config_home.php?id=<?php echo $lab_config_id; ?>&billingupdate=1";
@@ -1329,7 +1219,7 @@ function generateICfile()
 		async: false,
 		success : function(data) {
 			alert("Equipment configuration has been saved in ../BLISInterfaceClient/BLISInterfaceClient.ini")
-		}	
+		}
 	});
 }
 function updateICFields(prop_count)
@@ -1356,7 +1246,7 @@ function updateICFields(prop_count)
 		async: false,
 		success : function(data) {
 			alert("Interface details updated!");
-		}	
+		}
 	});
 }
 
@@ -1380,18 +1270,18 @@ $(function() {
 					var field_name = $this.text();
 					orders = orders+encodeURIComponent(field_name)+"="+index+"&";
 				});
-				
+
 				orders = orders.match(/(.*).$/)[1];
-								
+
 				$.ajax({
 					url : "ajax/process-field-ordering.php?"+orders,
 					async: false,
 					success : function(data) {
 						alert("Patient Field Order Updated");
 						window.location="lab_config_home.php?id=<?php echo $lab_config->id; ?>";
-					}	
+					}
 				});
-   		     
+
 				},
             Cancel: function() {
                 $( this ).dialog( "close" );
@@ -1402,7 +1292,7 @@ $(function() {
         }
     });
 
-    
+
 
     $( "#field_reorder_link_patient" ).click(function() {
             $( "#dialog-form-patients" ).dialog( "open" );
@@ -1428,18 +1318,18 @@ $(function() {
 					var field_name = $this.text();
 					orders = orders+encodeURIComponent(field_name)+"="+index+"&";
 				});
-				
+
 				orders = orders.match(/(.*).$/)[1];
-								
+
 				$.ajax({
 					url : "ajax/process-field-ordering.php?"+orders,
 					async: false,
 					success : function(data) {
 						alert("Specimen Field Order Updated");
 						window.location="lab_config_home.php?id=<?php echo $lab_config->id; ?>";
-					}	
+					}
 				});
-   		     
+
 				},
             Cancel: function() {
                 $( this ).dialog( "close" );
@@ -1450,12 +1340,12 @@ $(function() {
         }
     });
 
-    
+
     $("#sortablePatients").sortable({     	});
     $("#sortableSpecimen").sortable({     	});
     $( "#sortablePatients" ).disableSelection();
     $( "#sortableSpecimen" ).disableSelection();
-    
+
 });
 
 $(function() {
@@ -1478,18 +1368,18 @@ $(function() {
 					var field_name = $this.text();
 					orders = orders+encodeURIComponent(field_name)+"="+index+"&";
 				});
-				
+
 				orders = orders.match(/(.*).$/)[1];
-								
+
 				$.ajax({
 					url : "ajax/process-field-ordering.php?"+orders,
 					async: false,
 					success : function(data) {
 						alert("Patient Field Order Updated");
 						window.location="lab_config_home.php?id=<?php echo $lab_config->id; ?>";
-					}	
+					}
 				});
-   		     
+
 				},
             Cancel: function() {
                 $( this ).dialog( "close" );
@@ -1500,7 +1390,7 @@ $(function() {
         }
     });
 
-    
+
 
     $( "#doctor_field_reorder_link_patient" ).click(function() {
             $( "#doctor-dialog-form-patients" ).dialog( "open" );
@@ -1526,18 +1416,18 @@ $(function() {
 					var field_name = $this.text();
 					orders = orders+encodeURIComponent(field_name)+"="+index+"&";
 				});
-				
+
 				orders = orders.match(/(.*).$/)[1];
-								
+
 				$.ajax({
 					url : "ajax/process-field-ordering.php?"+orders,
 					async: false,
 					success : function(data) {
 						alert("Specimen Field Order Updated");
 						window.location="lab_config_home.php?id=<?php echo $lab_config->id; ?>";
-					}	
+					}
 				});
-   		     
+
 				},
             Cancel: function() {
                 $( this ).dialog( "close" );
@@ -1548,12 +1438,12 @@ $(function() {
         }
     });
 
-    
+
     $("#doctor_sortablePatients").sortable({     	});
     $("#doctor_sortableSpecimen").sortable({     	});
     $( "#doctor_sortablePatients" ).disableSelection();
     $( "#sortableSpecimen" ).disableSelection();
-    
+
 });
 function add_new_currency(action)
 {
@@ -1571,7 +1461,7 @@ function stype_toggle()
 	$('#stype_box').toggle();
 	if($('#stype_link').html() == "Show")
 	{
-		$('#stype_link').html("Hide");		
+		$('#stype_link').html("Hide");
 	}
 	else
 	{
@@ -1584,7 +1474,7 @@ function ttype_toggle()
 	$('#ttype_box').toggle();
 	if($('#ttype_link').html() == "Show")
 	{
-		$('#ttype_link').html("Hide");		
+		$('#ttype_link').html("Hide");
 	}
 	else
 	{
@@ -1667,14 +1557,14 @@ function submit_new_currency()
     			}
     			else {
     				$('#billing_progress').hide();
-    				alert("Currency already exists. Enter a different currency name");	
+    				alert("Currency already exists. Enter a different currency name");
     			}
     		}
     	});
 }
 
 function cancel_new_currency(){
-	
+
 }
 
 function delete_config()
@@ -1790,7 +1680,7 @@ function misc_checkandsubmit()
 		$('#misc_errormsg').html(err_msg);
 		$('#misc_errormsg').show();
 		return;
-	}	
+	}
 	//All okay
 	$('#misc_progress').show();
 	$('#misc_form').submit();
@@ -1937,7 +1827,7 @@ function test_report_conf_submit()
 }
 
 function update_file()
-{ 
+{
 var report_id = $('#report_type11').attr("value");
 	$('#submit_report_config_progress').show();
 	$('#report_config_submit_form').ajaxSubmit({
@@ -1948,7 +1838,7 @@ var report_id = $('#report_type11').attr("value");
 	});
 }
  function update_report_config()
-{ 
+{
 	var report_id = $('#report_type11').attr("value");
 	$('#submit_report_config_progress').show();
 	$('#report_config_submit_form').ajaxSubmit({
@@ -1997,36 +1887,36 @@ function submit_batch_results_fields_form()
 }
 
 function submit_ordered_fields_form()
-{ 
+{
 	$('#ordered_fields_submit_progress').show();
-	
+
 	var p_fields = document.getElementById('p_fields');
 	var o_fields = document.getElementById('o_fields');
 	var p_fields_left="";
 	var o_fields_left="";
-		
-	
+
+
 	for(var i=0;i<p_fields.options.length;i++)
 	{
-		
+
 		p_fields_left = p_fields_left + ","+ p_fields.options[i].value;
-	}	
-	
+	}
+
 	for(var i=0;i<o_fields.options.length;i++)
 	{
 		o_fields_left = o_fields_left + ","+ o_fields.options[i].value;
 	}
-	
 
-	
-	$('#p_fields_left').attr('value',p_fields_left);	
-	$('#o_fields_left').attr('value',o_fields_left);		
-	
+
+
+	$('#p_fields_left').attr('value',p_fields_left);
+	$('#o_fields_left').attr('value',o_fields_left);
+
 	$('#patient_fields_order_from').ajaxSubmit({
 		success: function() {
 		$('#ordered_fields_submit_progress').hide();
 			window.location="lab_config_home.php?id=<?php echo $lab_config->id; ?>&rpfoupdate=orderedfields";
-			
+
 		}
 	});
 }
@@ -2107,7 +1997,7 @@ function right_load_1(option_num, div_id)
 	$('.menu_option').removeClass('current_menu_option');
 	$('#'+div_id).show();
 	$('#option'+option_num).addClass('current_menu_option');
-	
+
 }
 function authenticateDHIMS2()
 {
@@ -2115,88 +2005,88 @@ function authenticateDHIMS2()
     $('#dhims2Authenticate').attr({
     disabled: 'disabled',
     value: 'Processing'});
-    
+
     var username= $('#dhims2username').attr("value");
-    var password= $('#dhims2password').attr("value"); 
-    $.ajax({        
-        url :'api/dhims2Authenticate.php?dhims2username='+username+"&dhims2password="+password,               
-        success : function (user) {         
+    var password= $('#dhims2password').attr("value");
+    $.ajax({
+        url :'api/dhims2Authenticate.php?dhims2username='+username+"&dhims2password="+password,
+        success : function (user) {
             $('#DHIMS2AuthenticateProgress').hide();
             if ( user=="false" ) {
                 $('#dhims2Authenticate').removeAttr('disabled');
                 $('#dhims2Authenticate').attr('value',"Authenticate");
-                alert("Authentication Error: Invalid Login credentials");             
+                alert("Authentication Error: Invalid Login credentials");
             }
-            else if ( user=="404" ) {             
+            else if ( user=="404" ) {
                 $('#dhims2Authenticate').removeAttr('disabled');
                 $('#dhims2Authenticate').attr('value',"Authenticate");
                 alert("The DHIMS2 server cannot be found! Please check your internet connection");
             }
-            else if ( user=="502" ) {             
+            else if ( user=="502" ) {
                 $('#dhims2Authenticate').removeAttr('disabled');
                 $('#dhims2Authenticate').attr('value',"Authenticate");
                 alert("The DHIMS2 server returned Error 502! BAD GATEWAY\n Server might be down for maintenance");
             }
-            else 
+            else
             {
-                $('#dhims2Authenticate').attr('value',"Success"); 
-                        
+                $('#dhims2Authenticate').attr('value',"Success");
+
                     var objUser = JSON.parse( user );
                     for(var i=0;i<objUser.organisationUnits.length;i++)
                     {
                         var opt = document.createElement("option");
-                        document.getElementById("dhims2orgunit").options.add(opt);       
+                        document.getElementById("dhims2orgunit").options.add(opt);
                         opt.text = objUser.organisationUnits[i].name;
-                        opt.value = objUser.organisationUnits[i].id;    
+                        opt.value = objUser.organisationUnits[i].id;
                     }
                     getDHIMS2DataSet(null);
-                    
+
                     $('#addtolist').removeAttr('disabled');
-                    
+
             }
-        }       
-    });     
+        }
+    });
 }
- 
+
 function getDHIMS2DataSet(userID)
 {
     $('#DHIMS2orgunitProgress').show();
-    document.getElementById("dhims2dataset").options.length=0;    
+    document.getElementById("dhims2dataset").options.length=0;
     if(null == userID)
     {
         userID = $('#dhims2orgunit').attr('value');
     }
     var username= $('#dhims2username').attr("value");
-    var password= $('#dhims2password').attr("value");     
-    $.ajax({        
-        url :'api/dhims2get_datasets.php?dhims2username='+username+"&dhims2password="+password+"&orgunitid="+userID,                
-        success : function (orgunit) {          
+    var password= $('#dhims2password').attr("value");
+    $.ajax({
+        url :'api/dhims2get_datasets.php?dhims2username='+username+"&dhims2password="+password+"&orgunitid="+userID,
+        success : function (orgunit) {
             $('#DHIMS2orgunitProgress').hide();
-            if ( orgunit=="false" ) {             
-                alert("Authentication Error: Invalid Login credentials");             
+            if ( orgunit=="false" ) {
+                alert("Authentication Error: Invalid Login credentials");
             }
-            else if ( orgunit=="404" ) {                          
+            else if ( orgunit=="404" ) {
                 alert("The DHIMS2 server cannot be found! Please check your internet connection");
             }
-            else 
-            {               
-                        
-                    var orgunitObj = JSON.parse( orgunit );                                 
+            else
+            {
+
+                    var orgunitObj = JSON.parse( orgunit );
                     for(var i=0;i<orgunitObj.dataSets.length;i++)
                     {
                         var opt = document.createElement("option");
-                        document.getElementById("dhims2dataset").options.add(opt);       
+                        document.getElementById("dhims2dataset").options.add(opt);
                         opt.text = orgunitObj.dataSets[i].name;
-                        opt.value = orgunitObj.dataSets[i].id;  
+                        opt.value = orgunitObj.dataSets[i].id;
                     }
-                    
+
                     getDHIMS2DataElements(null);
-                    
+
             }
-        }       
-    }); 
+        }
+    });
 }
- 
+
 function getDHIMS2DataElements(dataSetID)
 {
     $('#DHIMS2datasetProgress').show();
@@ -2209,46 +2099,46 @@ function getDHIMS2DataElements(dataSetID)
         dataSetID = $('#dhims2dataset').attr('value');
     }
     var username= $('#dhims2username').attr("value");
-    var password= $('#dhims2password').attr("value");     
-    $.ajax({        
-        url :'api/dhims2get_data_elements.php?dhims2username='+username+"&dhims2password="+password+"&datasetid="+dataSetID,                
-        success : function (dataset) {          
+    var password= $('#dhims2password').attr("value");
+    $.ajax({
+        url :'api/dhims2get_data_elements.php?dhims2username='+username+"&dhims2password="+password+"&datasetid="+dataSetID,
+        success : function (dataset) {
             $('#DHIMS2datasetProgress').hide();
-            if ( dataset=="false" ) {             
-                alert("Authentication Error: Invalid Login credentials");             
+            if ( dataset=="false" ) {
+                alert("Authentication Error: Invalid Login credentials");
             }
-            else if ( dataset=="404" ) {                          
+            else if ( dataset=="404" ) {
                 alert("The DHIMS2 server cannot be found! Please check your internet connection");
                 $('#DHIMS2datasetProgressRetry').show();
             }
-            else 
-            {           
-                    
+            else
+            {
+
                     var datasetObj = JSON.parse( dataset );
                     $('#entryperiod').attr('value',datasetObj.periodType);
-                                                        
+
                     for(var i=0;i<datasetObj.dataElements.length;i++)
                     {
                         var opt = document.createElement("option");
-                        document.getElementById("dhims2dataelement").options.add(opt);       
+                        document.getElementById("dhims2dataelement").options.add(opt);
                         opt.text = datasetObj.dataElements[i].name;
-                        opt.value = datasetObj.dataElements[i].id;  
+                        opt.value = datasetObj.dataElements[i].id;
                     }
-                    
+
                     getDHIMS2CatComboOptions(null);
             }
-        }       
-    }); 
+        }
+    });
 }
- 
- 
+
+
 function getDHIMS2CatComboOptions(dataElementID)
 {
     $('#DHIMS2ElementProgress').show();
     $('#DHIMS2ElementProgressRetry').hide();
-    
+
     document.getElementById("blistestSelected").options.length=0;
-            
+
     //$('#entryperiod').attr('value','');
     document.getElementById("dhims2catCombo").options.length=0;
     if(null == dataElementID)
@@ -2256,44 +2146,44 @@ function getDHIMS2CatComboOptions(dataElementID)
         dataElementID = $('#dhims2dataelement').attr('value');
     }
     var username= $('#dhims2username').attr("value");
-    var password= $('#dhims2password').attr("value");     
-    $.ajax({        
-        url :'api/dhims2get_data_elements_combo.php?dhims2username='+username+"&dhims2password="+password+"&dataElementID="+dataElementID,              
-        success : function (dataset) {     
-        	//console.log(dataset);     
+    var password= $('#dhims2password').attr("value");
+    $.ajax({
+        url :'api/dhims2get_data_elements_combo.php?dhims2username='+username+"&dhims2password="+password+"&dataElementID="+dataElementID,
+        success : function (dataset) {
+        	//console.log(dataset);
             $('#DHIMS2ElementProgress').hide();
-            if ( dataset=="false" ) {             
-                alert("Authentication Error: Invalid Login credentials");             
+            if ( dataset=="false" ) {
+                alert("Authentication Error: Invalid Login credentials");
             }
-            else if ( dataset=="404" ) {                          
+            else if ( dataset=="404" ) {
                 alert("The DHIMS2 server cannot be found! Please check your internet connection");
                 $('#DHIMS2ElementProgressRetry').show();
             }
-            else 
-            {           
-                    
+            else
+            {
+
                     var datasetObj = JSON.parse( dataset );
                     console.log(datasetObj);
                     //$('#entryperiod').attr('value',datasetObj.periodType);
-                                
+
                     for(var i=0;i<datasetObj.categoryOptionCombos.length;i++)
                     {
                         if(!alreadyInList(dataElementID,datasetObj.categoryOptionCombos[i].id))
                         {
-                        	
+
                             var opt = document.createElement("option");
-                            document.getElementById("dhims2catCombo").options.add(opt);       
+                            document.getElementById("dhims2catCombo").options.add(opt);
                             opt.text = datasetObj.categoryOptionCombos[i].name;
-                            opt.value = datasetObj.categoryOptionCombos[i].id;  
+                            opt.value = datasetObj.categoryOptionCombos[i].id;
                         }
                     }
-                    
+
             }
-        }       
-    }); 
+        }
+    });
 }
- 
- 
+
+
 function alreadyInList(dataelementID,comboId)
 {
     var flag = false;
@@ -2304,22 +2194,22 @@ function alreadyInList(dataelementID,comboId)
         var node;
         var value = comboId;
         var keyType = "id";
-        nodeList = zTree.getNodesByParam(keyType, value);       
-        for( var i=0, l=nodeList.length; i<l; i++) 
-        {           
+        nodeList = zTree.getNodesByParam(keyType, value);
+        for( var i=0, l=nodeList.length; i<l; i++)
+        {
                 if(startsWith(nodeList[i].pId,dataelementID))
-                {                   
+                {
                     flag = true;
                     break;
-                }               
+                }
         }
- 
+
     }
-    
+
     return flag;
 }
- 
-function startsWith(s,starter) {    
+
+function startsWith(s,starter) {
   for (var i = 0,cur_c; i < starter.length; i++) {
     cur_c = starter[i];
     if (s[i] !== starter[i]) {
@@ -2328,41 +2218,41 @@ function startsWith(s,starter) {
   }
   return true;
 }
- 
+
 function getSelBLISTests()
 {
     var tests = "";
-    var o_fields = document.getElementById("blistestSelected");       
+    var o_fields = document.getElementById("blistestSelected");
     for(var i=0;i<o_fields.options.length;i++)
     {
         if(tests.length > 0)
         {
-            tests = tests +"|"; 
+            tests = tests +"|";
         }
         tests = tests + o_fields.options[i].value + "^";
-        tests = tests + o_fields.options[i].text;                   
-    }   
-                
-    
-    
+        tests = tests + o_fields.options[i].text;
+    }
+
+
+
     return tests;
-    
+
 }
 function AddnewDHIMS2Config()
 {
-    
+
     //I need the text as well. Set the text to the hidden textboxes
     $('#dhims2orgunit_text').attr('value',$('#dhims2orgunit option:selected').text());
     $('#dhims2dataset_text').attr('value',$('#dhims2dataset option:selected').text());
     $('#dhims2dataelement_text').attr('value',$('#dhims2dataelement option:selected').text());
     $('#blis2dataelement_text').attr('value',getSelBLISTests());
     $('#dhims2catCombo_text').attr('value',$('#dhims2catCombo option:selected').text());
-        
+
     var  dataset = $('#dhims2dataset').attr('value');
     var  dhims2dataelement = $('#dhims2dataelement').attr('value');
     var  dhims2catCombo = $('#dhims2catCombo').attr('value');
     var testsSelected = $('#blis2dataelement_text').attr('value');
-    
+
     //return;
     if(null == dataset || dataset.length == 0)
     {
@@ -2379,7 +2269,7 @@ function AddnewDHIMS2Config()
         alert("No DHIMS2 Category Combo Option selected!");
         return;
     }
-    
+
     if(null == testsSelected || testsSelected.length == 0)
     {
         alert("No Corresponding  BLIS test selected!");
@@ -2390,12 +2280,12 @@ function AddnewDHIMS2Config()
         success: function() {
             $('#dhims2catCombo option:selected').remove();
             //alert("Submited");
-            showTree(); 
-            
+            showTree();
+
         }
     });
-    
-    
+
+
     $('#DHIMS2ApplyProgress').hide();
 }
 </script>
@@ -2408,15 +2298,15 @@ function AddnewDHIMS2Config()
 			<td class='left_menu' id='left_pane' width='160px'><ul>
 				<a id='option1' class='menu_option' href="javascript:right_load(1, 'site_info_div');"><?php echo LangUtil::$pageTerms['MENU_SUMMARY']; ?></a>
 				<br>
-				
+
 				<?php
-				# If super-admin or country-dir, show option to Delete this configuration
-				# If super-admin or country-dir, show option to Change lab manager/admin
-				# If super-admin or country-dir, show option to Back up Data
-				# For lab admin, the option appears as a separate tab
-				$user = get_user_by_id($_SESSION['user_id']);
-				if(is_super_admin($user) || is_country_dir($user)) {			
-					?>
+                # If super-admin or country-dir, show option to Delete this configuration
+                # If super-admin or country-dir, show option to Change lab manager/admin
+                # If super-admin or country-dir, show option to Back up Data
+                # For lab admin, the option appears as a separate tab
+                $user = get_user_by_id($_SESSION['user_id']);
+                if (is_super_admin($user) || is_country_dir($user)) {
+                    ?>
 					<br>
 					<a id='option9' class='menu_option' href="javascript:right_load(9, 'misc_div');"><?php echo LangUtil::$pageTerms['MENU_GENERAL']; ?></a>
 					<br><br>
@@ -2424,11 +2314,11 @@ function AddnewDHIMS2Config()
 					<br><br>
 					<a id='option6' class='menu_option' href="javascript:right_load(6, 'del_config_div');"><?php echo LangUtil::$pageTerms['MENU_DEL']; ?></a></li>
 					<br>
-					<?php					
-				}
-				?>
+					<?php
+                }
+                ?>
 				<br>
-				
+
 				<a id='test' class='menu_option' href="javascript:test_setup();"><?php echo LangUtil::$pageTerms['Tests']; ?> </a>
 				<br><br>
 				<div id='test_setup' name='test_setup' style='display:none;'>
@@ -2439,10 +2329,10 @@ function AddnewDHIMS2Config()
 					-<a href='remarks_edit.php?id=<?php echo $_REQUEST['id']; ?>'><?php echo "Results Interpretation"; ?></a>
 					<br><br>
 				</div>
-                                
+
                 <a id='option21' class='menu_option' href="javascript:right_load(21, 'search_div');"><?php echo "Search" ?></a>
                 <br><br>
-                                
+
 				<a id='report' class='menu_option' href="javascript:report_setup();"><?php echo LangUtil::$pageTerms['Reports']; ?> </a>
 				<br><br></li>
 				<div id='report_setup' name='report_setup' style='display:none;'>
@@ -2489,7 +2379,7 @@ function AddnewDHIMS2Config()
 				<a id='option4' class='menu_option' href="javascript:right_load(4, 'fields_div');"><?php echo LangUtil::$pageTerms['MENU_CUSTOM']; ?></a>
 				<br><br>
 				<a id='option50' class='menu_option' href="javascript:right_load(50, 'doctor_fields_div');">Doctor Registration Fields</a>
-				<br><br>			
+				<br><br>
 				<a id='option19' class='menu_option' href="javascript:language_div_load();"><?php echo LangUtil::getPageTerm("MODIFYLANG"); ?></a>
 				<br><br>
 				<a id='option14' class='menu_option' href="javascript:export_html();"><?php echo "Setup Local Network" ?></a>
@@ -2505,27 +2395,27 @@ function AddnewDHIMS2Config()
                     <br><br>
                 </div>
 				<?php
-					if($SERVER != $ON_ARC) {
-						?>
+                    if ($SERVER != $ON_ARC) {
+                        ?>
 						<a id='option13' class='menu_option' href="javascript:right_load(13, 'backup_revert_div');"><?php echo LangUtil::$pageTerms['MENU_BACKUP_REVERT']; ?></a><br><br></li>
 						<a id='option131' class='menu_option' href="javascript:right_load(131, 'key_management_div');"><?php echo LangUtil::$pageTerms['MENU_KEY_MANAGEMENT']; ?></a><br><br></li>
-						<?php if(is_super_admin($user) || is_country_dir($user)) { ?>
+						<?php if (is_super_admin($user) || is_country_dir($user)) { ?>
 								<a id='option18' class='menu_option' href="javascript:right_load(18, 'update_database_div');"><?php echo 'Update Data'; ?></a><br><br></li>
                                                                 <a id='option34' class='menu_option' href="javascript:right_load(34, 'import_config_div');"><?php echo 'Import Configuration' ?></a><br><br></li>
 
 						<?php }
-					}
-				?>
-				
+                    }
+                ?>
+
 				<a href='export_config?id=<?php echo $_REQUEST['id']; ?>' target='_blank'><?php echo LangUtil::$pageTerms['MENU_EXPORTCONFIG']; ?></a><br><br></li>
                                 <div id="old_update_div" style="display:none;">
 				<a id='option39' class='menu_option' href="javascript:right_load(39, 'blis_update_div');">Update to New Version</a>
 				<br><br>
 				</div>
 				<?php /* Enable for Data Merging
-				<a rel='facebox' id='option18' class='menu_option' href="updateCountryDbAtLocalUI.php">Update National Database</a>
-				</ul>
-				*/ ?>
+                <a rel='facebox' id='option18' class='menu_option' href="updateCountryDbAtLocalUI.php">Update National Database</a>
+                </ul>
+                */ ?>
 			</td>
 			<td>
 				<br><br><br><br><br>
@@ -2539,13 +2429,13 @@ function AddnewDHIMS2Config()
 					</div>
 					<br>
 					<?php
-					$page_elems->getLabConfigInfo($lab_config->id);
-					?>
+                    $page_elems->getLabConfigInfo($lab_config->id);
+                    ?>
 					<form id='backup_form' name='backup_form' action='data_backup' method='post' target='_blank'>
 						<input type='hidden' name='id' value='<?php echo $_REQUEST['id']; ?>'></input>
 					</form>
 				</div>
-                            
+
                                 <div class='right_pane' id='blis_update_div' style='display:none;margin-left:10px;'>
 				<p style="text-align: right;"><a rel='facebox' href='#Summary_config'>Page Help</a></p>
 				<b><?php echo "BLIS Update"; ?></b>
@@ -2554,7 +2444,7 @@ function AddnewDHIMS2Config()
                                         <br>
                                         <div id='update_spinner' style='display:none;'>
                                         <?php
-					$spinner_message = "Updating to C4G BLIS v2.2"."<br>";
+                    $spinner_message = "Updating to C4G BLIS v2.2"."<br>";
                                         $page_elems->getProgressSpinnerBig($spinner_message);
                                         ?>
                                         </div>
@@ -2566,7 +2456,7 @@ function AddnewDHIMS2Config()
                                             Update to v2.2 Failed! Try Again.
                                         </div>
 				</div>
-				
+
 				<div class='right_pane' id='st_types_div' style='display:none;margin-left:10px;'>
 				<p style="text-align: right;"><a rel='facebox' href='#Tests_config'>Page Help</a></p>
 					<b><?php echo LangUtil::$pageTerms['MENU_ST_TYPES']; ?></b>
@@ -2575,7 +2465,7 @@ function AddnewDHIMS2Config()
 					</div>
 					<br>
 					<form id='st_types_form' name='st_types_form' action='ajax/st_types_update.php' method='post'>
-					<input type='hidden' name='lid' value='<?php echo $lab_config->id; ?>'></input>					
+					<input type='hidden' name='lid' value='<?php echo $lab_config->id; ?>'></input>
 					<?php echo LangUtil::$generalTerms['SPECIMEN_TYPES']; ?>
 					<small><a id='stype_link' href='javascript:stype_toggle();'><?php echo LangUtil::$generalTerms['CMD_SHOW']; ?></a></small>
 					<div class='pretty_box' id='stype_box' style='display:none'>
@@ -2588,38 +2478,35 @@ function AddnewDHIMS2Config()
 					<small><a id='ttype_link' href='javascript:ttype_toggle();'><?php echo LangUtil::$generalTerms['CMD_SHOW']; ?></a></small>
 					<div class='pretty_box' id='ttype_box' style='display:none'>
 					<b><u><?php echo LangUtil::$generalTerms['TEST_TYPES']; ?></u></b>
-                                        
+
                                         <?php
                                         //NC3065
-                                        
+
                                         $user = get_user_by_id($_SESSION['user_id']);
-                                        if(is_super_admin($user) || is_country_dir($user))
-                                        {
+                                        if (is_super_admin($user) || is_country_dir($user)) {
                                             $page_elems->getTestTypeCheckboxes_dir($lab_config->id);
-                                        }
-                                        else
-                                        {
-                                            $page_elems->getTestTypeCheckboxes($lab_config->id); 
+                                        } else {
+                                            $page_elems->getTestTypeCheckboxes($lab_config->id);
                                         }
                                         //NC3065
-					?>
-                                        
-                                         <?php //$page_elems->getTestTypeCheckboxes($lab_config->id); ?>
-                                        
+                    ?>
+
+                                         <?php //$page_elems->getTestTypeCheckboxes($lab_config->id);?>
+
 					</div>
 					<br><br>
 					<input type='button' value='<?php echo LangUtil::$generalTerms['CMD_SUBMIT']; ?>' onclick='checkandsubmit_st_types()'>
 					</input>
 					&nbsp;&nbsp;&nbsp;&nbsp;
 					<span id='st_types_progress' style='display:none;'>
-                                  
+
 						<?php $page_elems->getProgressSpinner(LangUtil::$generalTerms['CMD_SUBMITTING']); ?>
 					</span>
 					</form>
 				</div>
-			
+
                                 <!--NC3065-->
-                                
+
                                 <div class='right_pane' id='search_div' style='display:none;margin-left:10px;'>
 				<p style="text-align: right;"><a rel='facebox' href='#search_config'>Page Help</a></p>
 					<b><?php echo "Configure Fields for search results"; ?></b>
@@ -2627,7 +2514,7 @@ function AddnewDHIMS2Config()
                                         <div id='searchfield_msg' class='clean-orange' style='display:none;width:350px;'>
 					</div>
 					<form id='searchfields_form' name='searchfields_form' action='ajax/search_config_update.php' method='post'>
-					<input type='hidden' name='lab_config_id' value='<?php echo $lab_config->id; ?>'></input>					
+					<input type='hidden' name='lab_config_id' value='<?php echo $lab_config->id; ?>'></input>
 						<?php $page_elems->getSearchFieldsCheckboxes($lab_config->id); ?>
 					<br><br>
 					<input type='button' value='<?php echo LangUtil::$generalTerms['CMD_SUBMIT']; ?>' onclick='submit_searchconfig()'>
@@ -2640,7 +2527,7 @@ function AddnewDHIMS2Config()
 					</span>
 					</form>
 				</div>
-                                
+
                                 <div class='right_pane' id='barcode_div' style='display:none;margin-left:10px;'>
 				<p style="text-align: right;"><a rel='facebox' href='#barcode_config'>Page Help</a></p>
 					<b><?php echo "Configure Barcode Format Settings"; ?></b>
@@ -2648,9 +2535,9 @@ function AddnewDHIMS2Config()
                                         <div id='barcodefield_msg' class='clean-orange' style='display:none;width:350px;'>
 					</div>
 					<form id='barcodefields_form' name='barcodefields_form' action='ajax/update_barcode_settings.php' method='post'>
-					<input type='hidden' name='lab_config_id' value='<?php echo $lab_config->id; ?>'></input>					
+					<input type='hidden' name='lab_config_id' value='<?php echo $lab_config->id; ?>'></input>
 						<?php $page_elems->getBarcodeFields($lab_config->id);
-                                                //$page_elems->getSearchFieldsCheckboxes($lab_config->id); ?>
+                                                //$page_elems->getSearchFieldsCheckboxes($lab_config->id);?>
 					<br><br>
 					<input type='button' value='<?php echo LangUtil::$generalTerms['CMD_SUBMIT']; ?>' onclick='submit_barcodeconfig()'>
 					</input>
@@ -2662,14 +2549,14 @@ function AddnewDHIMS2Config()
 					</span>
 					</form>
 				</div>
-                                
+
                                 <!--NC3065-->
 
-                            
+
 				<div class='right_pane' id='users_div' style='display:none;margin-left:10px;'>
 					<?php
-					$reload_url = "lab_config_home.php?id=$lab_config_id";
-					?>
+                    $reload_url = "lab_config_home.php?id=$lab_config_id";
+                    ?>
 					<p style="text-align: right;"><a rel='facebox' href='#UserAccounts_config'>Page Help</a></p>
 					<b><?php echo LangUtil::$pageTerms['MENU_USERS']; ?></b>
 					 | <a rel='facebox' href='lab_user_new.php?ru=<?php echo $reload_url; ?>&lid=<?php echo $lab_config_id; ?>'><?php echo LangUtil::$generalTerms['CMD_ADDNEWACCOUNT']; ?></a>
@@ -2678,9 +2565,9 @@ function AddnewDHIMS2Config()
 					</div>
 					<div id='user_list_table'>
 					<?php
-					$user_list = $lab_config->getUsers();
-					$page_elems->getLabUsersTable($user_list, $lab_config_id);
-					?>
+                    $user_list = $lab_config->getUsers();
+                    $page_elems->getLabUsersTable($user_list, $lab_config_id);
+                    ?>
 					</div>
 					<br>
 					<b><?php echo "User Types" ?></b>
@@ -2690,10 +2577,10 @@ function AddnewDHIMS2Config()
 					</div>
 					<div id='user_list_table1'>
 					<?php
-					//$user_list = $lab_config->getUsers();
-					$user_type_list = $lab_config->getUserTypes();
-					$page_elems->getLabUserTypesTable($user_type_list, $lab_config_id);
-					?>
+                    //$user_list = $lab_config->getUsers();
+                    $user_type_list = $lab_config->getUserTypes();
+                    $page_elems->getLabUserTypesTable($user_type_list, $lab_config_id);
+                    ?>
 					</div>
 				</div>
 
@@ -2708,8 +2595,8 @@ function AddnewDHIMS2Config()
 							  method="post">
 							<br> <?php echo LangUtil::$pageTerms['MODIFY_SITE'];  ?> :<br>
 							<?php
-							$page_elems->getSiteConfigForm($_SESSION['lab_config_id']);
-							?>
+                            $page_elems->getSiteConfigForm($_SESSION['lab_config_id']);
+                            ?>
 							<br><br>
 							<input type='button' value='<?php echo LangUtil::$generalTerms['CMD_SUBMIT']; ?>'
 								   onsubmit="return confirm('Are you sure?');"
@@ -2735,16 +2622,16 @@ function AddnewDHIMS2Config()
 						</form>
 					</div>
 				</div>
-					
+
 				<div class='right_pane' id='inventory_div' style='display:none;margin-left:10px;'>
 				</div>
-                                
+
                                 <div class='right_pane' id='billing_div' style='display:none;margin-left:10px;'>
-                                         
+
                                     <p style="text-align: right;"><a rel='facebox' href='#Billing_config'>Page Help</a></p>
                                     <div id='billing_msg' class='clean-orange' style='display:none;width:350px;'>
                                     </div>
-                           
+
 									<form id='billing_form' name='billing_form' action='ajax/billing_update.php' method='post'>
                                         <input type='hidden' name='lid' value='<?php echo $lab_config->id; ?>'></input>
                                         <div class="pretty_box">
@@ -2763,19 +2650,19 @@ function AddnewDHIMS2Config()
                                         <select name='default_currency' id='default_currency'>
                                         <?php $allCurrencies = currencyConfig::getAllDifferenctCurrencies($lab_config_id);
                                         $defaultCurrency = "";
-                                        foreach ($allCurrencies as $currency){ 
-										//echo $currency->getFlag1(). " " . $currency->getCurrencyFrom();
-                                        if($currency->getFlag1()){
-										$defaultCurrency = $currency; 
-                                        ?>
+                                        foreach ($allCurrencies as $currency) {
+                                            //echo $currency->getFlag1(). " " . $currency->getCurrencyFrom();
+                                            if ($currency->getFlag1()) {
+                                                $defaultCurrency = $currency; ?>
 											<option value='<?php echo $currency->getCurrencyFrom(); ?>' selected><?php echo $currency->getCurrencyFrom(); ?></option>
-										<?php } 
-										else {
-                                        ?>
+										<?php
+                                            } else {
+                                                ?>
                                         	<option value='<?php echo $currency->getCurrencyFrom(); ?>'><?php echo $currency->getCurrencyFrom(); ?></option>
-                                        <?php } 
-										}?>
-											
+                                        <?php
+                                            }
+                                        }?>
+
 										</select>
                                         <br><br>
                                         <?php echo LangUtil::$generalTerms['CURRENCY_DELIMITER']; ?>
@@ -2783,16 +2670,16 @@ function AddnewDHIMS2Config()
                                         <br><br>
                                         Currency will display as: 00<?php echo get_currency_delimiter_from_lab_config_settings(); ?>00 <?php echo get_currency_type_from_lab_config_settings() ?>
                                         <br/><br/>
-                                        <?php if($defaultCurrency==""){?>
+                                        <?php if ($defaultCurrency=="") {?>
                                         <div id="exchange_rate" style='display:none;' ></div><?php } else {?>
-                                        <?php 
+                                        <?php
                                         $alreadyExistingExchangeRates = array();
-                                        if($defaultCurrency!=""){
-                                        $exchangeRates = currencyConfig::getExchangeRateSnap($lab_config_id, $defaultCurrency->getCurrencyFrom());
-                                        $totalCurrencies = count($allCurrencies);
-                                        $totalExchangeRates = count($exchangeRates);
+                                        if ($defaultCurrency!="") {
+                                            $exchangeRates = currencyConfig::getExchangeRateSnap($lab_config_id, $defaultCurrency->getCurrencyFrom());
+                                            $totalCurrencies = count($allCurrencies);
+                                            $totalExchangeRates = count($exchangeRates);
                                         }?>
-										<?php if($totalExchangeRates <1){?>
+										<?php if ($totalExchangeRates <1) {?>
                                         <div id="exchange_rate" style='display:none;'></div>
 										<?php } else {?>
                                         <div id="exchange_rate" >
@@ -2803,10 +2690,10 @@ function AddnewDHIMS2Config()
                                         <th>&nbsp;&nbsp; <?php echo LangUtil::$generalTerms['UPDATED_DATE']; ?>&nbsp;&nbsp; </th>
                                         <th>&nbsp;&nbsp; <?php echo LangUtil::$generalTerms['ACTIONS']; ?>&nbsp;&nbsp; </th>
                                         </tr>
-                                        <?php 
+                                        <?php
                                         $row=0;
-                                        foreach($exchangeRates as $currencyExchageRow){?>
-                                        <tr> 
+                                        foreach ($exchangeRates as $currencyExchageRow) {?>
+                                        <tr>
                                         <td>&nbsp;&nbsp; <div id="currency<?php echo $row;?>"><?php echo $currencyExchageRow->getCurrencyTo();
                                                          array_push($alreadyExistingExchangeRates, $currencyExchageRow->getCurrencyTo()); ?> </div>&nbsp;&nbsp;</td>
                                         <td>&nbsp;&nbsp; <input type="text" id="exchangeRate<?php echo $row;?>" value="<?php echo $currencyExchageRow->getExchangeRate();?>" size="4" />&nbsp;&nbsp; </td>
@@ -2819,61 +2706,66 @@ function AddnewDHIMS2Config()
                                         <?php } ?>
                                         <a href="javascript:addCurrencyRatio();"><?php echo LangUtil::$generalTerms['ADD_CURRENCY_RATE']; ?></a><br/>
 										<?php }?>
-                                        
+
                                         <div id="addCurrencyRatioDiv">
                                         <?php
                                         $validAddableCurrency = array();
-                                        foreach ($allCurrencies as $currency){ 
-										if($currency->getCurrencyTo() != $defaultCurrency->getCurrencyFrom() && !(in_array($currency->getCurrencyTo(), $alreadyExistingExchangeRates))){
-										array_push($validAddableCurrency, $currency);
-										} 
-										}
-										if(count($validAddableCurrency)>0){?>
-                                        Secondary Currency&nbsp;&nbsp;&nbsp; 
+                                        foreach ($allCurrencies as $currency) {
+                                            if ($currency->getCurrencyTo() != $defaultCurrency->getCurrencyFrom() && !(in_array($currency->getCurrencyTo(), $alreadyExistingExchangeRates))) {
+                                                array_push($validAddableCurrency, $currency);
+                                            }
+                                        }
+                                        if (count($validAddableCurrency)>0) {?>
+                                        Secondary Currency&nbsp;&nbsp;&nbsp;
                                         <select name='added_currency' id='added_currency'>
                                         <?php
-                                        foreach ($validAddableCurrency as $currency){ 
-										?>
+                                        foreach ($validAddableCurrency as $currency) {
+                                            ?>
 											<option value='<?php echo $currency->getCurrencyFrom(); ?>'><?php echo $currency->getCurrencyFrom(); ?></option>
-										<?php } 
-										?>
-                                        </select> 
+										<?php
+                                        }
+                                        ?>
+                                        </select>
                                         &nbsp;&nbsp;&nbsp; <input type="text" id="added_currency_rate" size="12" placeholder="Exchange Rate">
                                         &nbsp;&nbsp;&nbsp; <input type="button" value="Add" onclick="add_new_currency_ratio(1)" />
                                         &nbsp;&nbsp;&nbsp; <input type="button" value="Cancel" onclick="add_new_currency_ratio(0)" />
-                                        <?php }  else {
-											echo "<br/>"."Add secondary currencies to enter the exchange rates";
-										}?>
+                                        <?php } else {
+                                            echo "<br/>"."Add secondary currencies to enter the exchange rates";
+                                        }?>
                                         </div>
-                                        <br/>                                       
+                                        <br/>
                                         <div>
                                     	<a href='javascript:add_new_currency(1);' id='add_new_currency_link'><?php echo LangUtil::$generalTerms['ADD_CURRENCY']; ?></a>
-                                    	                                    
+
                                    	 	<div id="new_currency" style='display:none;'>
                                    	 	<?php echo LangUtil::$generalTerms['NEW_CURRENCY']; ?>
-                                    	&nbsp;&nbsp;&nbsp;<input type="text" name="new_currency_name" id="new_currency_name" /> 
+                                    	&nbsp;&nbsp;&nbsp;<input type="text" name="new_currency_name" id="new_currency_name" />
                                     	&nbsp;&nbsp;&nbsp;<input type="button" value="Add Currency Type" onclick="submit_new_currency()" />
                                     	&nbsp;&nbsp;&nbsp; <input type="button" value="Cancel" onclick="add_new_currency(0)" />
                                     	</div>
                                     	</div>
-                                       
+
                                         <br/>
-                                        
+
                                         <!-- Billing logo upload code -->
                                         <?php $name="../logos/logo_billing_".$lab_config->id.".jpg";
-										 if (file_exists("../logos/logo_billing_".$lab_config->id.".jpg")==true)
-										 echo "LOGO being Used "; ?></h4>
+                                         if (file_exists("../logos/logo_billing_".$lab_config->id.".jpg")==true) {
+                                             echo "LOGO being Used ";
+                                         } ?></h4>
 	  									<h3>File Upload:</h3><?php
-			
-	 									if (file_exists("../logos/logo_billing_".$lab_config->id.".jpg")==false)
-										{echo "( Add a Logo)"; }else echo "(Change Logo)"; ?>
+
+                                        if (file_exists("../logos/logo_billing_".$lab_config->id.".jpg")==false) {
+                                            echo "( Add a Logo)";
+                                        } else {
+                                            echo "(Change Logo)";
+                                        } ?>
 										Choose a .jpg logo File to upload:
 										<input type="file" name="billingLogo" >
 										</>
-										<br />	
 										<br />
-	
-                                        
+										<br />
+
+
                                         <input type="button" value="Update" onclick="submit_billing_update()" />
 
                                         <span id='billing_progress' style='display:none;'>
@@ -2881,11 +2773,11 @@ function AddnewDHIMS2Config()
 										</span>
                                     </form>
                                     </div>
-								
+
                                 </div>
-				
+
 				<div class='right_pane' id='fields_div' style='display:none;margin-left:10px;'>
-				
+
 <div id="dialog-form-patients" title="Customize Field Order - Patient Registration Form">
 <!-- <table>
 <tr>
@@ -2893,13 +2785,13 @@ function AddnewDHIMS2Config()
 <div >Tips : Drag and Drop and click update to reorder patient fields</div>
 <div align="center">
    <ul id="sortablePatients">
-   <?php  
+   <?php
    $field_odering_form_names = explode(',', $field_odering_patients->form_field_inOrder);
-   foreach($field_odering_form_names as $value){
-   	echo "<li class='ui-state-default'><span class='ui-icon ui-icon-arrowthick-2-n-s'></span>".$value."</li>";
+   foreach ($field_odering_form_names as $value) {
+       echo "<li class='ui-state-default'><span class='ui-icon ui-icon-arrowthick-2-n-s'></span>".$value."</li>";
    }
    ?>
-  
+
 </ul> </div>
 <!-- </td><td width='30%'><div align='top'>Tips : Drag and Drop and click update to reorder the existing fields</div></td>
 </table> -->
@@ -2909,18 +2801,18 @@ function AddnewDHIMS2Config()
 <div >Tips : Drag and Drop and click update to reorder specimen fields</div>
 <div align="center">
    <ul id="sortableSpecimen">
-   <?php  
+   <?php
    $field_odering_form_names = explode(',', $field_odering_specimen->form_field_inOrder);
-   foreach($field_odering_form_names as $value){
-   	echo "<li class='ui-state-default'><span class='ui-icon ui-icon-arrowthick-2-n-s'></span>".$value."</li>";
+   foreach ($field_odering_form_names as $value) {
+       echo "<li class='ui-state-default'><span class='ui-icon ui-icon-arrowthick-2-n-s'></span>".$value."</li>";
    }
    ?>
-  
+
 </ul> </div>
 </div>
- 
- 
-		
+
+
+
 					<p style="text-align: right;"><a rel='facebox' href='#RegistrationFields_config'>Page Help</a></p>
 					<b><?php echo LangUtil::$pageTerms['MENU_CUSTOM']; ?></b>
 					 | <a href='javascript:toggle_ofield_div();' id='ofield_toggle_link'><?php echo LangUtil::$generalTerms['CMD_EDIT']; ?></a>
@@ -2945,36 +2837,41 @@ function AddnewDHIMS2Config()
 								<td><?php echo LangUtil::$generalTerms['PATIENTS']; ?> - <?php echo LangUtil::$generalTerms['PATIENT_ID']; ?></td>
 								<td>
 									<input type='checkbox' name='use_pid' id='use_pid' <?php
-									if($lab_config->pid != 0)
-										echo " checked ";
-									?>>
+                                    if ($lab_config->pid != 0) {
+                                        echo " checked ";
+                                    }
+                                    ?>>
 									</input>
 									<span id='use_pid_mand' style='display:none;'>
 										&nbsp;&nbsp;
 										<?php echo LangUtil::$generalTerms['MSG_MANDATORYFIELD']; ?>?
 										&nbsp;&nbsp;
 										<input type='radio' name='use_pid_radio' value='Y' <?php
-										if($lab_config->pid == 2 || $lab_config->pid == 4)
-											echo " checked ";
-										?>><?php echo LangUtil::$generalTerms['YES']; ?></input>
+                                        if ($lab_config->pid == 2 || $lab_config->pid == 4) {
+                                            echo " checked ";
+                                        }
+                                        ?>><?php echo LangUtil::$generalTerms['YES']; ?></input>
 										&nbsp;&nbsp;
 										<input type='radio' name='use_pid_radio' value='N' <?php
-										if($lab_config->pid == 1 || $lab_config->pid == 3 )
-											echo " checked ";
-										?>><?php echo LangUtil::$generalTerms['NO']; ?></input>
-                                        
+                                        if ($lab_config->pid == 1 || $lab_config->pid == 3) {
+                                            echo " checked ";
+                                        }
+                                        ?>><?php echo LangUtil::$generalTerms['NO']; ?></input>
+
                                         &nbsp;&nbsp;
 										<?php echo 'Allow Duplicate' ?>?
 										&nbsp;&nbsp;
 										<input type='radio' name='dup_pid_radio' value='Y' <?php
-										if($lab_config->pid == 1 || $lab_config->pid == 2)
-											echo " checked ";
-										?>><?php echo LangUtil::$generalTerms['YES']; ?></input>
+                                        if ($lab_config->pid == 1 || $lab_config->pid == 2) {
+                                            echo " checked ";
+                                        }
+                                        ?>><?php echo LangUtil::$generalTerms['YES']; ?></input>
 										&nbsp;&nbsp;
 										<input type='radio' name='dup_pid_radio' value='N' <?php
-										if($lab_config->pid == 3 || $lab_config->pid == 4)
-											echo " checked ";
-										?>><?php echo LangUtil::$generalTerms['NO']; ?></input>
+                                        if ($lab_config->pid == 3 || $lab_config->pid == 4) {
+                                            echo " checked ";
+                                        }
+                                        ?>><?php echo LangUtil::$generalTerms['NO']; ?></input>
 									</span>
 								</td>
 							</tr>
@@ -2982,23 +2879,26 @@ function AddnewDHIMS2Config()
 								<td><?php echo LangUtil::$generalTerms['PATIENTS']; ?> - <?php echo LangUtil::$generalTerms['ADDL_ID']; ?></td>
 								<td>
 									<input type='checkbox' name='use_p_addl' id='use_p_addl' <?php
-									if($lab_config->patientAddl != 0)
-										echo " checked ";
-									?>>
+                                    if ($lab_config->patientAddl != 0) {
+                                        echo " checked ";
+                                    }
+                                    ?>>
 									</input>
 									<span id='use_p_addl_mand' style='display:none;'>
 										&nbsp;&nbsp;
 										<?php echo LangUtil::$generalTerms['MSG_MANDATORYFIELD']; ?>?
 										&nbsp;&nbsp;
 										<input type='radio' name='use_p_addl_radio' value='Y' <?php
-										if($lab_config->patientAddl == 2)
-											echo " checked ";
-										?>><?php echo LangUtil::$generalTerms['YES']; ?></input>
+                                        if ($lab_config->patientAddl == 2) {
+                                            echo " checked ";
+                                        }
+                                        ?>><?php echo LangUtil::$generalTerms['YES']; ?></input>
 										&nbsp;&nbsp;
 										<input type='radio' name='use_p_addl_radio' value='N' <?php
-										if($lab_config->patientAddl != 2)
-											echo " checked ";
-										?>><?php echo LangUtil::$generalTerms['NO']; ?></input>
+                                        if ($lab_config->patientAddl != 2) {
+                                            echo " checked ";
+                                        }
+                                        ?>><?php echo LangUtil::$generalTerms['NO']; ?></input>
 									</span>
 								</td>
 							</tr>
@@ -3006,24 +2906,27 @@ function AddnewDHIMS2Config()
 								<td><?php echo LangUtil::$generalTerms['PATIENTS']; ?> - <?php echo LangUtil::$generalTerms['PATIENT_DAILYNUM']; ?></td>
 								<td>
 									<input type='checkbox' name='use_dnum' id='use_dnum'<?php
-									
-                                                                        if($lab_config->dailyNum == 1 || $lab_config->dailyNum == 2 || $lab_config->dailyNum == 11 || $lab_config->dailyNum == 12)
-										echo " checked ";
-									?>>
+
+                                                                        if ($lab_config->dailyNum == 1 || $lab_config->dailyNum == 2 || $lab_config->dailyNum == 11 || $lab_config->dailyNum == 12) {
+                                                                            echo " checked ";
+                                                                        }
+                                    ?>>
 									</input>
 									<span id='use_dnum_mand' style='display:none;'>
 										&nbsp;&nbsp;
 										<?php echo LangUtil::$generalTerms['MSG_MANDATORYFIELD']; ?>?
 										&nbsp;&nbsp;
 										<input type='radio' name='use_dnum_radio' value='Y'<?php
-										if($lab_config->dailyNum == 2 || $lab_config->dailyNum == 12)
-											echo " checked ";
-										?>><?php echo LangUtil::$generalTerms['YES']; ?></input>
+                                        if ($lab_config->dailyNum == 2 || $lab_config->dailyNum == 12) {
+                                            echo " checked ";
+                                        }
+                                        ?>><?php echo LangUtil::$generalTerms['YES']; ?></input>
 										&nbsp;&nbsp;
 										<input type='radio' name='use_dnum_radio' value='N' <?php
-										if($lab_config->dailyNum != 2 && $lab_config->dailyNum != 12)
-											echo " checked ";
-										?> ><?php echo LangUtil::$generalTerms['NO']; ?></input>
+                                        if ($lab_config->dailyNum != 2 && $lab_config->dailyNum != 12) {
+                                            echo " checked ";
+                                        }
+                                        ?> ><?php echo LangUtil::$generalTerms['NO']; ?></input>
 										&nbsp;&nbsp;
 										<?php echo LangUtil::$generalTerms['MSG_RESET']; ?>
 										<select name='dnum_reset' id='dnum_reset'>
@@ -3037,7 +2940,7 @@ function AddnewDHIMS2Config()
 											$('#dnum_reset').attr("value", "<?php echo $lab_config->dailyNumReset; ?>");
 											$("#addCurrencyRatioDiv").hide();
 											$("#updateCurrencyRatioDialog").hide();
-										});										
+										});
 										</script>
 									</span>
 								</td>
@@ -3046,23 +2949,26 @@ function AddnewDHIMS2Config()
 								<td><?php echo LangUtil::$generalTerms['PATIENTS']; ?> - <?php echo LangUtil::$generalTerms['NAME']; ?></td>
 								<td>
 									<input type='checkbox' name='use_pname' id='use_pname'<?php
-									if($lab_config->pname != 0)
-										echo " checked ";
-									?>>
+                                    if ($lab_config->pname != 0) {
+                                        echo " checked ";
+                                    }
+                                    ?>>
 									</input>
 									<span id='use_pname_mand' style='display:none;'>
 										&nbsp;&nbsp;
 										<?php echo LangUtil::$generalTerms['MSG_MANDATORYFIELD']; ?>?
 										&nbsp;&nbsp;
 										<input type='radio' name='use_pname_radio' value='Y'<?php
-										if($lab_config->pname == 2)
-											echo " checked ";
-										?>><?php echo LangUtil::$generalTerms['YES']; ?></input>
+                                        if ($lab_config->pname == 2) {
+                                            echo " checked ";
+                                        }
+                                        ?>><?php echo LangUtil::$generalTerms['YES']; ?></input>
 										&nbsp;&nbsp;
 										<input type='radio' name='use_pname_radio' value='N' <?php
-										if($lab_config->pname != 2)
-											echo " checked ";
-										?>><?php echo LangUtil::$generalTerms['NO']; ?></input>
+                                        if ($lab_config->pname != 2) {
+                                            echo " checked ";
+                                        }
+                                        ?>><?php echo LangUtil::$generalTerms['NO']; ?></input>
 									</span>
 								</td>
 							</tr>
@@ -3070,9 +2976,10 @@ function AddnewDHIMS2Config()
 								<td><?php echo LangUtil::$generalTerms['PATIENTS']; ?> - <?php echo LangUtil::$generalTerms['GENDER']; ?></td>
 								<td>
 									<input type='checkbox' name='use_sex' id='use_sex' <?php
-									if($lab_config->sex != 0)
-										echo " checked ";
-									?>>
+                                    if ($lab_config->sex != 0) {
+                                        echo " checked ";
+                                    }
+                                    ?>>
 									</input>
 									<span id='use_sex_mand' style='display:none;'>
 										&nbsp;&nbsp;
@@ -3084,23 +2991,26 @@ function AddnewDHIMS2Config()
 								<td><?php echo LangUtil::$generalTerms['PATIENTS']; ?> - <?php echo LangUtil::$generalTerms['DOB']; ?></td>
 								<td>
 									<input type='checkbox' name='use_dob' id='use_dob'<?php
-									if($lab_config->dob != 0)
-										echo " checked ";
-									?>>
+                                    if ($lab_config->dob != 0) {
+                                        echo " checked ";
+                                    }
+                                    ?>>
 									</input>
 									<span id='use_dob_mand' style='display:none;'>
 										&nbsp;&nbsp;
 										<?php echo LangUtil::$generalTerms['MSG_MANDATORYFIELD']; ?>?
 										&nbsp;&nbsp;
 										<input type='radio' name='use_dob_radio' value='Y'<?php
-										if($lab_config->dob == 2)
-											echo " checked ";
-										?>><?php echo LangUtil::$generalTerms['YES']; ?></input>
+                                        if ($lab_config->dob == 2) {
+                                            echo " checked ";
+                                        }
+                                        ?>><?php echo LangUtil::$generalTerms['YES']; ?></input>
 										&nbsp;&nbsp;
 										<input type='radio' name='use_dob_radio' value='N' <?php
-										if($lab_config->dob != 2)
-											echo " checked ";
-										?> ><?php echo LangUtil::$generalTerms['NO']; ?></input>
+                                        if ($lab_config->dob != 2) {
+                                            echo " checked ";
+                                        }
+                                        ?> ><?php echo LangUtil::$generalTerms['NO']; ?></input>
 									</span>
 								</td>
 							</tr>
@@ -3108,24 +3018,26 @@ function AddnewDHIMS2Config()
 								<td><?php echo LangUtil::$generalTerms['PATIENTS']; ?> - <?php echo LangUtil::$generalTerms['AGE']; ?></td>
 								<td>
 									<input type='checkbox' name='use_age' id='use_age'<?php
-                                                                        if($lab_config->age == 1 || $lab_config->age == 2 || $lab_config->age == 11 || $lab_config->age == 12)
-									
-										echo " checked ";
-									?>>
+                                                                        if ($lab_config->age == 1 || $lab_config->age == 2 || $lab_config->age == 11 || $lab_config->age == 12) {
+                                                                            echo " checked ";
+                                                                        }
+                                    ?>>
 									</input>
 									<span id='use_age_mand' style='display:none;'>
 										&nbsp;&nbsp;
 										<?php echo LangUtil::$generalTerms['MSG_MANDATORYFIELD']; ?>?
 										&nbsp;&nbsp;
 										<input type='radio' name='use_age_radio' value='Y'<?php
-										if($lab_config->age == 2 || $lab_config->age == 12)
-											echo " checked ";
-										?>><?php echo LangUtil::$generalTerms['YES']; ?></input>
+                                        if ($lab_config->age == 2 || $lab_config->age == 12) {
+                                            echo " checked ";
+                                        }
+                                        ?>><?php echo LangUtil::$generalTerms['YES']; ?></input>
 										&nbsp;&nbsp;
 										<input type='radio' name='use_age_radio' value='N' <?php
-										if($lab_config->age != 2 && $lab_config->age != 12)
-											echo " checked ";
-										?> ><?php echo LangUtil::$generalTerms['NO']; ?></input>
+                                        if ($lab_config->age != 2 && $lab_config->age != 12) {
+                                            echo " checked ";
+                                        }
+                                        ?> ><?php echo LangUtil::$generalTerms['NO']; ?></input>
 									</span>
 								</td>
 							</tr>
@@ -3141,10 +3053,11 @@ function AddnewDHIMS2Config()
 								<td><?php echo LangUtil::$generalTerms['SPECIMENS']; ?> - <?php echo LangUtil::$generalTerms['SPECIMEN_ID']; ?></td>
 								<td>
 									<input type='checkbox' name='use_sid' id='use_sid'<?php
-									//if($lab_config->sid != 0)
-									if(true)
-										echo " checked ";
-									?>>
+                                    //if($lab_config->sid != 0)
+                                    if (true) {
+                                        echo " checked ";
+                                    }
+                                    ?>>
 									</input>
 									<span id='use_sid_mand' style='display:none;'>
 										&nbsp;&nbsp;
@@ -3156,23 +3069,25 @@ function AddnewDHIMS2Config()
 								<td><?php echo LangUtil::$generalTerms['SPECIMENS']; ?> - <?php echo LangUtil::$generalTerms['SPECIMEN_ID']; ?></td>
 								<td>
 									<input type='checkbox' name='use_s_addl' id='use_s_addl'<?php
-							
-									?>>
-									
+
+                                    ?>>
+
 									</input>
 									<span id='use_s_addl_mand' style='display:none;'>
 										&nbsp;&nbsp;
 										<?php echo LangUtil::$generalTerms['MSG_MANDATORYFIELD']; ?>?
 										&nbsp;&nbsp;
 										<input type='radio' name='use_s_addl_radio' value='Y'<?php
-										if($lab_config->specimenAddl == 2)
-											echo " checked ";
-										?>><?php echo LangUtil::$generalTerms['YES']; ?></input>
+                                        if ($lab_config->specimenAddl == 2) {
+                                            echo " checked ";
+                                        }
+                                        ?>><?php echo LangUtil::$generalTerms['YES']; ?></input>
 										&nbsp;&nbsp;
 										<input type='radio' name='use_s_addl_radio' value='N' <?php
-										if($lab_config->specimenAddl != 2)
-											echo " checked ";
-										?>><?php echo LangUtil::$generalTerms['NO']; ?></input>
+                                        if ($lab_config->specimenAddl != 2) {
+                                            echo " checked ";
+                                        }
+                                        ?>><?php echo LangUtil::$generalTerms['NO']; ?></input>
 									</span>
 								</td>
 							</tr>
@@ -3180,23 +3095,26 @@ function AddnewDHIMS2Config()
 								<td><?php echo LangUtil::$generalTerms['SPECIMENS']; ?> - <?php echo LangUtil::$generalTerms['COMMENTS']; ?></td>
 								<td>
 									<input type='checkbox' name='use_comm' id='use_comm'<?php
-									if($lab_config->comm != 0)
-										echo " checked ";
-									?>>
+                                    if ($lab_config->comm != 0) {
+                                        echo " checked ";
+                                    }
+                                    ?>>
 									</input>
 									<span id='use_comm_mand' style='display:none;'>
 										&nbsp;&nbsp;
 										<?php echo LangUtil::$generalTerms['MSG_MANDATORYFIELD']; ?>?
 										&nbsp;&nbsp;
 										<input type='radio' name='use_comm_radio' value='Y'<?php
-										if($lab_config->comm == 2)
-											echo " checked ";
-										?>><?php echo LangUtil::$generalTerms['YES']; ?></input>
+                                        if ($lab_config->comm == 2) {
+                                            echo " checked ";
+                                        }
+                                        ?>><?php echo LangUtil::$generalTerms['YES']; ?></input>
 										&nbsp;&nbsp;
 										<input type='radio' name='use_comm_radio' value='N' <?php
-										if($lab_config->comm != 2)
-											echo " checked ";
-										?>><?php echo LangUtil::$generalTerms['NO']; ?></input>
+                                        if ($lab_config->comm != 2) {
+                                            echo " checked ";
+                                        }
+                                        ?>><?php echo LangUtil::$generalTerms['NO']; ?></input>
 									</span>
 								</td>
 							</tr>
@@ -3204,23 +3122,26 @@ function AddnewDHIMS2Config()
 								<td><?php echo LangUtil::$generalTerms['SPECIMENS']; ?> - <?php echo LangUtil::$generalTerms['R_DATE']; ?></td>
 								<td>
 									<input type='checkbox' name='use_rdate' id='use_rdate'<?php
-									if($lab_config->rdate != 0)
-										echo " checked ";
-									?>>
+                                    if ($lab_config->rdate != 0) {
+                                        echo " checked ";
+                                    }
+                                    ?>>
 									</input>
 									<span id='use_rdate_mand' style='display:none;'>
 										&nbsp;&nbsp;
 										<?php echo LangUtil::$generalTerms['MSG_MANDATORYFIELD']; ?>?
 										&nbsp;&nbsp;
 										<input type='radio' name='use_rdate_radio' value='Y'<?php
-										if($lab_config->rdate == 2)
-											echo " checked ";
-										?>><?php echo LangUtil::$generalTerms['YES']; ?></input>
+                                        if ($lab_config->rdate == 2) {
+                                            echo " checked ";
+                                        }
+                                        ?>><?php echo LangUtil::$generalTerms['YES']; ?></input>
 										&nbsp;&nbsp;
 										<input type='radio' name='use_rdate_radio' value='N' <?php
-										if($lab_config->rdate != 2)
-											echo " checked ";
-										?>><?php echo LangUtil::$generalTerms['NO']; ?></input>
+                                        if ($lab_config->rdate != 2) {
+                                            echo " checked ";
+                                        }
+                                        ?>><?php echo LangUtil::$generalTerms['NO']; ?></input>
 									</span>
 								</td>
 							</tr>
@@ -3228,23 +3149,26 @@ function AddnewDHIMS2Config()
 								<td><?php echo LangUtil::$generalTerms['SPECIMENS']; ?> - <?php echo LangUtil::$generalTerms['REF_OUT']; ?></td>
 								<td>
 									<input type='checkbox' name='use_refout' id='use_refout'<?php
-									if($lab_config->refout != 0)
-										echo " checked ";
-									?>>
+                                    if ($lab_config->refout != 0) {
+                                        echo " checked ";
+                                    }
+                                    ?>>
 									</input>
 									<span id='use_refout_mand' style='display:none;'>
 										&nbsp;&nbsp;
 										<?php echo LangUtil::$generalTerms['MSG_MANDATORYFIELD']; ?>?
 										&nbsp;&nbsp;
 										<input type='radio' name='use_refout_radio' value='Y'<?php
-										if($lab_config->refout == 2)
-											echo " checked ";
-										?>><?php echo LangUtil::$generalTerms['YES']; ?></input>
+                                        if ($lab_config->refout == 2) {
+                                            echo " checked ";
+                                        }
+                                        ?>><?php echo LangUtil::$generalTerms['YES']; ?></input>
 										&nbsp;&nbsp;
 										<input type='radio' name='use_refout_radio' value='N' <?php
-										if($lab_config->refout != 2)
-											echo " checked ";
-										?>><?php echo LangUtil::$generalTerms['NO']; ?></input>
+                                        if ($lab_config->refout != 2) {
+                                            echo " checked ";
+                                        }
+                                        ?>><?php echo LangUtil::$generalTerms['NO']; ?></input>
 									</span>
 								</td>
 							</tr>
@@ -3252,23 +3176,26 @@ function AddnewDHIMS2Config()
 								<td><?php echo LangUtil::$generalTerms['SPECIMENS']; ?> - <?php echo LangUtil::$generalTerms['DOCTOR']; ?></td>
 								<td>
 									<input type='checkbox' name='use_doctor' id='use_doctor'<?php
-									if($lab_config->doctor != 0)
-										echo " checked ";
-									?>>
+                                    if ($lab_config->doctor != 0) {
+                                        echo " checked ";
+                                    }
+                                    ?>>
 									</input>
 									<span id='use_doctor_mand' style='display:none;'>
 										&nbsp;&nbsp;
 										<?php echo LangUtil::$generalTerms['MSG_MANDATORYFIELD']; ?>?
 										&nbsp;&nbsp;
 										<input type='radio' name='use_doctor_radio' value='Y'<?php
-										if($lab_config->doctor == 2)
-											echo " checked ";
-										?>><?php echo LangUtil::$generalTerms['YES']; ?></input>
+                                        if ($lab_config->doctor == 2) {
+                                            echo " checked ";
+                                        }
+                                        ?>><?php echo LangUtil::$generalTerms['YES']; ?></input>
 										&nbsp;&nbsp;
 										<input type='radio' name='use_doctor_radio' value='N' <?php
-										if($lab_config->doctor != 2)
-											echo " checked ";
-										?>><?php echo LangUtil::$generalTerms['NO']; ?></input>
+                                        if ($lab_config->doctor != 2) {
+                                            echo " checked ";
+                                        }
+                                        ?>><?php echo LangUtil::$generalTerms['NO']; ?></input>
 									</span>
 								</td>
 							</tr>
@@ -3297,10 +3224,10 @@ function AddnewDHIMS2Config()
 					</div> <br/>
 					<div><a href='javascript:openReorder()'>Reorder Fields</div>
 					<div id='reorder_fields'>
-					
+
 					&nbsp;&nbsp;&nbsp;--&nbsp;&nbsp;&nbsp;<a href="#" id='field_reorder_link_patient'>Patient Registration Form</a><br/>
 					&nbsp;&nbsp;&nbsp;--&nbsp;&nbsp;&nbsp;<a href="#" id='field_reorder_link_specimen'>Specimen Registration Form</a>
-					 
+
 					<br/>
 					&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<input type="button" onclick='javascript:closeReorder();' value='cancel' />
 					</div>
@@ -3511,34 +3438,34 @@ function AddnewDHIMS2Config()
 					<?php echo LangUtil::$pageTerms['CUSTOMFIELDS']." - ".LangUtil::$generalTerms['SPECIMENS']; ?>
 					 | <a href='cfield_new.php?lid=<?php echo $lab_config_id; ?>'><?php echo LangUtil::$generalTerms['ADDNEW']; ?></a>[<a href='#new_help' rel='facebox'>?</a>]
 					<div id='specimen_custom_field_list'>
-					<?php 
-					
-					$page_elems->getCustomFieldTable($lab_config->id, $custom_field_list_specimen, 1); 
-					?>
+					<?php
+
+                    $page_elems->getCustomFieldTable($lab_config->id, $custom_field_list_specimen, 1);
+                    ?>
 					</div>
-					
+
 					<br>
 					<?php echo LangUtil::$pageTerms['CUSTOMFIELDS']." - ".LangUtil::$generalTerms['PATIENTS']; ?>
 					 | <a href='cfield_new.php?lid=<?php echo $lab_config_id; ?>'><?php echo LangUtil::$generalTerms['ADDNEW']; ?></a> [<a href='#new_help' rel='facebox'>?</a>]
 					<div id='patient_custom_field_list'>
-					<?php 
-						$page_elems->getCustomFieldTable($lab_config->id, $custom_field_list_patients, 2); 
-					?>
+					<?php
+                        $page_elems->getCustomFieldTable($lab_config->id, $custom_field_list_patients, 2);
+                    ?>
 					</div>
-					
+
 					<br>
 					<?php echo LangUtil::$pageTerms['CUSTOMFIELDS']." - Lab Titles"; ?>
 					 | <a href='cfield_new.php?lid=<?php echo $lab_config_id; ?>'><?php echo LangUtil::$generalTerms['ADDNEW']; ?></a> [<a href='#new_help' rel='facebox'>?</a>]
 					<div id='labtitle_custom_field_list'>
-					<?php 
-					
-					$page_elems->getCustomFieldTable($lab_config->id, $custom_field_list_labTitle, 3); 
-					?>
+					<?php
+
+                    $page_elems->getCustomFieldTable($lab_config->id, $custom_field_list_labTitle, 3);
+                    ?>
 					</div>
 				</div>
-	
+
 				<div class='right_pane' id='doctor_fields_div' style='display:none;margin-left:10px;'>
-				
+
 <div id="doctor-dialog-form-patients" title="Customize Field Order - Patient Registration Form">
 <!-- <table>
 <tr>
@@ -3546,13 +3473,13 @@ function AddnewDHIMS2Config()
 <div >Tips : Drag and Drop and click update to reorder patient fields</div>
 <div align="center">
    <ul id="doctor_sortablePatients">
-   <?php  
+   <?php
    $field_odering_form_names = explode(',', $field_odering_patients->form_field_inOrder);
-   foreach($field_odering_form_names as $value){
-   	echo "<li class='ui-state-default'><span class='ui-icon ui-icon-arrowthick-2-n-s'></span>".$value."</li>";
+   foreach ($field_odering_form_names as $value) {
+       echo "<li class='ui-state-default'><span class='ui-icon ui-icon-arrowthick-2-n-s'></span>".$value."</li>";
    }
    ?>
-  
+
 </ul> </div>
 <!-- </td><td width='30%'><div align='top'>Tips : Drag and Drop and click update to reorder the existing fields</div></td>
 </table> -->
@@ -3562,18 +3489,18 @@ function AddnewDHIMS2Config()
 <div >Tips : Drag and Drop and click update to reorder specimen fields</div>
 <div align="center">
    <ul id="sortableSpecimen">
-   <?php  
+   <?php
    $field_odering_form_names = explode(',', $field_odering_specimen->form_field_inOrder);
-   foreach($field_odering_form_names as $value){
-   	echo "<li class='ui-state-default'><span class='ui-icon ui-icon-arrowthick-2-n-s'></span>".$value."</li>";
+   foreach ($field_odering_form_names as $value) {
+       echo "<li class='ui-state-default'><span class='ui-icon ui-icon-arrowthick-2-n-s'></span>".$value."</li>";
    }
    ?>
-  
+
 </ul> </div>
 </div>
- 
- 
-		
+
+
+
 					<p style="text-align: right;"><a rel='facebox' href='#RegistrationFields_config'>Page Help</a></p>
 					<b>Doctor Registration Fields</b>
 					 | <a href='javascript:doctor_toggle_ofield_div();' id='doctor_ofield_toggle_link'><?php echo LangUtil::$generalTerms['CMD_EDIT']; ?></a>
@@ -3594,29 +3521,32 @@ function AddnewDHIMS2Config()
 							</tr>
 						</thead>
 						<tbody>
-							
+
 							<tr>
 								<td><?php echo LangUtil::$generalTerms['PATIENTS']; ?> - <?php echo LangUtil::$generalTerms['PATIENT_DAILYNUM']; ?></td>
 								<td>
 									<input type='checkbox' name='doctor_use_dnum' id='doctor_use_dnum'<?php
-									
-                                                                        if($doctor_lab_config->dailyNum == 1 || $doctor_lab_config->dailyNum == 2 || $doctor_lab_config->dailyNum == 11 || $doctor_lab_config->dailyNum == 12)
-										echo " checked ";
-									?>>
+
+                                                                        if ($doctor_lab_config->dailyNum == 1 || $doctor_lab_config->dailyNum == 2 || $doctor_lab_config->dailyNum == 11 || $doctor_lab_config->dailyNum == 12) {
+                                                                            echo " checked ";
+                                                                        }
+                                    ?>>
 									</input>
 									<span id='doctor_use_dnum_mand' style='display:none;'>
 										&nbsp;&nbsp;
 										<?php echo LangUtil::$generalTerms['MSG_MANDATORYFIELD']; ?>?
 										&nbsp;&nbsp;
 										<input type='radio' name='doctor_use_dnum_radio' value='Y'<?php
-										if($doctor_lab_config->dailyNum == 2 || $doctor_lab_config->dailyNum == 12)
-											echo " checked ";
-										?>><?php echo LangUtil::$generalTerms['YES']; ?></input>
+                                        if ($doctor_lab_config->dailyNum == 2 || $doctor_lab_config->dailyNum == 12) {
+                                            echo " checked ";
+                                        }
+                                        ?>><?php echo LangUtil::$generalTerms['YES']; ?></input>
 										&nbsp;&nbsp;
 										<input type='radio' name='doctor_use_dnum_radio' value='N' <?php
-										if($doctor_lab_config->dailyNum != 2 && $doctor_lab_config->dailyNum != 12)
-											echo " checked ";
-										?> ><?php echo LangUtil::$generalTerms['NO']; ?></input>
+                                        if ($doctor_lab_config->dailyNum != 2 && $doctor_lab_config->dailyNum != 12) {
+                                            echo " checked ";
+                                        }
+                                        ?> ><?php echo LangUtil::$generalTerms['NO']; ?></input>
 										&nbsp;&nbsp;
 										<?php echo LangUtil::$generalTerms['MSG_RESET']; ?>
 										<select name='dnum_reset' id='dnum_reset'>
@@ -3630,7 +3560,7 @@ function AddnewDHIMS2Config()
 											$('#dnum_reset').attr("value", "<?php echo $doctor_lab_config->dailyNumReset; ?>");
 											$("#addCurrencyRatioDiv").hide();
 											$("#updateCurrencyRatioDialog").hide();
-										});										
+										});
 										</script>
 									</span>
 								</td>
@@ -3639,23 +3569,26 @@ function AddnewDHIMS2Config()
 								<td><?php echo LangUtil::$generalTerms['PATIENTS']; ?> - <?php echo LangUtil::$generalTerms['NAME']; ?></td>
 								<td>
 									<input type='checkbox' name='doctor_use_pname' id='doctor_use_pname'<?php
-									if($doctor_lab_config->pname != 0)
-										echo " checked ";
-									?>>
+                                    if ($doctor_lab_config->pname != 0) {
+                                        echo " checked ";
+                                    }
+                                    ?>>
 									</input>
 									<span id='doctor_use_pname_mand' style='display:none;'>
 										&nbsp;&nbsp;
 										<?php echo LangUtil::$generalTerms['MSG_MANDATORYFIELD']; ?>?
 										&nbsp;&nbsp;
 										<input type='radio' name='doctor_use_pname_radio' value='Y'<?php
-										if($doctor_lab_config->pname == 2)
-											echo " checked ";
-										?>><?php echo LangUtil::$generalTerms['YES']; ?></input>
+                                        if ($doctor_lab_config->pname == 2) {
+                                            echo " checked ";
+                                        }
+                                        ?>><?php echo LangUtil::$generalTerms['YES']; ?></input>
 										&nbsp;&nbsp;
 										<input type='radio' name='doctor_use_pname_radio' value='N' <?php
-										if($doctor_lab_config->pname != 2)
-											echo " checked ";
-										?>><?php echo LangUtil::$generalTerms['NO']; ?></input>
+                                        if ($doctor_lab_config->pname != 2) {
+                                            echo " checked ";
+                                        }
+                                        ?>><?php echo LangUtil::$generalTerms['NO']; ?></input>
 									</span>
 								</td>
 							</tr>
@@ -3663,9 +3596,10 @@ function AddnewDHIMS2Config()
 								<td><?php echo LangUtil::$generalTerms['PATIENTS']; ?> - <?php echo LangUtil::$generalTerms['GENDER']; ?></td>
 								<td>
 									<input type='checkbox' name='doctor_use_sex' id='doctor_use_sex' <?php
-									if($doctor_lab_config->sex != 0)
-										echo " checked ";
-									?>>
+                                    if ($doctor_lab_config->sex != 0) {
+                                        echo " checked ";
+                                    }
+                                    ?>>
 									</input>
 									<span id='doctor_use_sex_mand' style='display:none;'>
 										&nbsp;&nbsp;
@@ -3677,23 +3611,26 @@ function AddnewDHIMS2Config()
 								<td><?php echo LangUtil::$generalTerms['PATIENTS']; ?> - <?php echo LangUtil::$generalTerms['DOB']; ?></td>
 								<td>
 									<input type='checkbox' name='doctor_use_dob' id='doctor_use_dob'<?php
-									if($doctor_lab_config->dob != 0)
-										echo " checked ";
-									?>>
+                                    if ($doctor_lab_config->dob != 0) {
+                                        echo " checked ";
+                                    }
+                                    ?>>
 									</input>
 									<span id='doctor_use_dob_mand' style='display:none;'>
 										&nbsp;&nbsp;
 										<?php echo LangUtil::$generalTerms['MSG_MANDATORYFIELD']; ?>?
 										&nbsp;&nbsp;
 										<input type='radio' name='doctor_use_dob_radio' value='Y'<?php
-										if($doctor_lab_config->dob == 2)
-											echo " checked ";
-										?>><?php echo LangUtil::$generalTerms['YES']; ?></input>
+                                        if ($doctor_lab_config->dob == 2) {
+                                            echo " checked ";
+                                        }
+                                        ?>><?php echo LangUtil::$generalTerms['YES']; ?></input>
 										&nbsp;&nbsp;
 										<input type='radio' name='doctor_use_dob_radio' value='N' <?php
-										if($doctor_lab_config->dob != 2)
-											echo " checked ";
-										?> ><?php echo LangUtil::$generalTerms['NO']; ?></input>
+                                        if ($doctor_lab_config->dob != 2) {
+                                            echo " checked ";
+                                        }
+                                        ?> ><?php echo LangUtil::$generalTerms['NO']; ?></input>
 									</span>
 								</td>
 							</tr>
@@ -3701,24 +3638,26 @@ function AddnewDHIMS2Config()
 								<td><?php echo LangUtil::$generalTerms['PATIENTS']; ?> - <?php echo LangUtil::$generalTerms['AGE']; ?></td>
 								<td>
 									<input type='checkbox' name='doctor_use_age' id='doctor_use_age'<?php
-                                                                        if($doctor_lab_config->age == 1 || $doctor_lab_config->age == 2 || $doctor_lab_config->age == 11 || $doctor_lab_config->age == 12)
-									
-										echo " checked ";
-									?>>
+                                                                        if ($doctor_lab_config->age == 1 || $doctor_lab_config->age == 2 || $doctor_lab_config->age == 11 || $doctor_lab_config->age == 12) {
+                                                                            echo " checked ";
+                                                                        }
+                                    ?>>
 									</input>
 									<span id='doctor_use_age_mand' style='display:none;'>
 										&nbsp;&nbsp;
 										<?php echo LangUtil::$generalTerms['MSG_MANDATORYFIELD']; ?>?
 										&nbsp;&nbsp;
 										<input type='radio' name='doctor_use_age_radio' value='Y'<?php
-										if($doctor_lab_config->age == 2 || $doctor_lab_config->age == 12)
-											echo " checked ";
-										?>><?php echo LangUtil::$generalTerms['YES']; ?></input>
+                                        if ($doctor_lab_config->age == 2 || $doctor_lab_config->age == 12) {
+                                            echo " checked ";
+                                        }
+                                        ?>><?php echo LangUtil::$generalTerms['YES']; ?></input>
 										&nbsp;&nbsp;
 										<input type='radio' name='doctor_use_age_radio' value='N' <?php
-										if($doctor_lab_config->age != 2 && $doctor_lab_config->age != 12)
-											echo " checked ";
-										?> ><?php echo LangUtil::$generalTerms['NO']; ?></input>
+                                        if ($doctor_lab_config->age != 2 && $doctor_lab_config->age != 12) {
+                                            echo " checked ";
+                                        }
+                                        ?> ><?php echo LangUtil::$generalTerms['NO']; ?></input>
 									</span>
 								</td>
 							</tr>
@@ -3734,10 +3673,11 @@ function AddnewDHIMS2Config()
 								<td><?php echo LangUtil::$generalTerms['SPECIMENS']; ?> - <?php echo LangUtil::$generalTerms['SPECIMEN_ID']; ?></td>
 								<td>
 									<input type='checkbox' name='doctor_use_sid' id='doctor_use_sid'<?php
-									//if($doctor_lab_config->sid != 0)
-									if(true)
-										echo " checked ";
-									?>>
+                                    //if($doctor_lab_config->sid != 0)
+                                    if (true) {
+                                        echo " checked ";
+                                    }
+                                    ?>>
 									</input>
 									<span id='doctor_use_sid_mand' style='display:none;'>
 										&nbsp;&nbsp;
@@ -3749,24 +3689,27 @@ function AddnewDHIMS2Config()
 								<td><?php echo LangUtil::$generalTerms['SPECIMENS']; ?> - <?php echo LangUtil::$generalTerms['SPECIMEN_ID']; ?></td>
 								<td>
 									<input type='checkbox' name='doctor_use_s_addl' id='doctor_use_s_addl'<?php
-									if($doctor_lab_config->specimenAddl != 0)
-										echo " checked ";
-									?>>
-									
+                                    if ($doctor_lab_config->specimenAddl != 0) {
+                                        echo " checked ";
+                                    }
+                                    ?>>
+
 									</input>
 									<span id='doctor_use_s_addl_mand' style='display:none;'>
 										&nbsp;&nbsp;
 										<?php echo LangUtil::$generalTerms['MSG_MANDATORYFIELD']; ?>?
 										&nbsp;&nbsp;
 										<input type='radio' name='doctor_use_s_addl_radio' value='Y'<?php
-										if($doctor_lab_config->specimenAddl == 2)
-											echo " checked ";
-										?>><?php echo LangUtil::$generalTerms['YES']; ?></input>
+                                        if ($doctor_lab_config->specimenAddl == 2) {
+                                            echo " checked ";
+                                        }
+                                        ?>><?php echo LangUtil::$generalTerms['YES']; ?></input>
 										&nbsp;&nbsp;
 										<input type='radio' name='doctor_use_s_addl_radio' value='N' <?php
-										if($doctor_lab_config->specimenAddl != 2)
-											echo " checked ";
-										?>><?php echo LangUtil::$generalTerms['NO']; ?></input>
+                                        if ($doctor_lab_config->specimenAddl != 2) {
+                                            echo " checked ";
+                                        }
+                                        ?>><?php echo LangUtil::$generalTerms['NO']; ?></input>
 									</span>
 								</td>
 							</tr>
@@ -3774,23 +3717,26 @@ function AddnewDHIMS2Config()
 								<td><?php echo LangUtil::$generalTerms['SPECIMENS']; ?> - <?php echo LangUtil::$generalTerms['COMMENTS']; ?></td>
 								<td>
 									<input type='checkbox' name='doctor_use_comm' id='doctor_use_comm'<?php
-									if($doctor_lab_config->comm != 0)
-										echo " checked ";
-									?>>
+                                    if ($doctor_lab_config->comm != 0) {
+                                        echo " checked ";
+                                    }
+                                    ?>>
 									</input>
 									<span id='doctor_use_comm_mand' style='display:none;'>
 										&nbsp;&nbsp;
 										<?php echo LangUtil::$generalTerms['MSG_MANDATORYFIELD']; ?>?
 										&nbsp;&nbsp;
 										<input type='radio' name='doctor_use_comm_radio' value='Y'<?php
-										if($doctor_lab_config->comm == 2)
-											echo " checked ";
-										?>><?php echo LangUtil::$generalTerms['YES']; ?></input>
+                                        if ($doctor_lab_config->comm == 2) {
+                                            echo " checked ";
+                                        }
+                                        ?>><?php echo LangUtil::$generalTerms['YES']; ?></input>
 										&nbsp;&nbsp;
 										<input type='radio' name='doctor_use_comm_radio' value='N' <?php
-										if($doctor_lab_config->comm != 2)
-											echo " checked ";
-										?>><?php echo LangUtil::$generalTerms['NO']; ?></input>
+                                        if ($doctor_lab_config->comm != 2) {
+                                            echo " checked ";
+                                        }
+                                        ?>><?php echo LangUtil::$generalTerms['NO']; ?></input>
 									</span>
 								</td>
 							</tr>
@@ -3798,23 +3744,26 @@ function AddnewDHIMS2Config()
 								<td><?php echo LangUtil::$generalTerms['SPECIMENS']; ?> - <?php echo LangUtil::$generalTerms['R_DATE']; ?></td>
 								<td>
 									<input type='checkbox' name='doctor_use_rdate' id='doctor_use_rdate'<?php
-									if($doctor_lab_config->rdate != 0)
-										echo " checked ";
-									?>>
+                                    if ($doctor_lab_config->rdate != 0) {
+                                        echo " checked ";
+                                    }
+                                    ?>>
 									</input>
 									<span id='doctor_use_rdate_mand' style='display:none;'>
 										&nbsp;&nbsp;
 										<?php echo LangUtil::$generalTerms['MSG_MANDATORYFIELD']; ?>?
 										&nbsp;&nbsp;
 										<input type='radio' name='doctor_use_rdate_radio' value='Y'<?php
-										if($doctor_lab_config->rdate == 2)
-											echo " checked ";
-										?>><?php echo LangUtil::$generalTerms['YES']; ?></input>
+                                        if ($doctor_lab_config->rdate == 2) {
+                                            echo " checked ";
+                                        }
+                                        ?>><?php echo LangUtil::$generalTerms['YES']; ?></input>
 										&nbsp;&nbsp;
 										<input type='radio' name='doctor_use_rdate_radio' value='N' <?php
-										if($doctor_lab_config->rdate != 2)
-											echo " checked ";
-										?>><?php echo LangUtil::$generalTerms['NO']; ?></input>
+                                        if ($doctor_lab_config->rdate != 2) {
+                                            echo " checked ";
+                                        }
+                                        ?>><?php echo LangUtil::$generalTerms['NO']; ?></input>
 									</span>
 								</td>
 							</tr>
@@ -3822,23 +3771,26 @@ function AddnewDHIMS2Config()
 								<td><?php echo LangUtil::$generalTerms['SPECIMENS']; ?> - <?php echo LangUtil::$generalTerms['REF_OUT']; ?></td>
 								<td>
 									<input type='checkbox' name='doctor_use_refout' id='doctor_use_refout'<?php
-									if($doctor_lab_config->refout != 0)
-										echo " checked ";
-									?>>
+                                    if ($doctor_lab_config->refout != 0) {
+                                        echo " checked ";
+                                    }
+                                    ?>>
 									</input>
 									<span id='doctor_use_refout_mand' style='display:none;'>
 										&nbsp;&nbsp;
 										<?php echo LangUtil::$generalTerms['MSG_MANDATORYFIELD']; ?>?
 										&nbsp;&nbsp;
 										<input type='radio' name='doctor_use_refout_radio' value='Y'<?php
-										if($doctor_lab_config->refout == 2)
-											echo " checked ";
-										?>><?php echo LangUtil::$generalTerms['YES']; ?></input>
+                                        if ($doctor_lab_config->refout == 2) {
+                                            echo " checked ";
+                                        }
+                                        ?>><?php echo LangUtil::$generalTerms['YES']; ?></input>
 										&nbsp;&nbsp;
 										<input type='radio' name='doctor_use_refout_radio' value='N' <?php
-										if($doctor_lab_config->refout != 2)
-											echo " checked ";
-										?>><?php echo LangUtil::$generalTerms['NO']; ?></input>
+                                        if ($doctor_lab_config->refout != 2) {
+                                            echo " checked ";
+                                        }
+                                        ?>><?php echo LangUtil::$generalTerms['NO']; ?></input>
 									</span>
 								</td>
 							</tr>
@@ -3846,23 +3798,26 @@ function AddnewDHIMS2Config()
 								<td><?php echo LangUtil::$generalTerms['SPECIMENS']; ?> - <?php echo LangUtil::$generalTerms['DOCTOR']; ?></td>
 								<td>
 									<input type='checkbox' name='doctor_use_doctor' id='doctor_use_doctor'<?php
-									if($doctor_lab_config->doctor != 0)
-										echo " checked ";
-									?>>
+                                    if ($doctor_lab_config->doctor != 0) {
+                                        echo " checked ";
+                                    }
+                                    ?>>
 									</input>
 									<span id='doctor_use_doctor_mand' style='display:none;'>
 										&nbsp;&nbsp;
 										<?php echo LangUtil::$generalTerms['MSG_MANDATORYFIELD']; ?>?
 										&nbsp;&nbsp;
 										<input type='radio' name='doctor_use_doctor_radio' value='Y'<?php
-										if($doctor_lab_config->doctor == 2)
-											echo " checked ";
-										?>><?php echo LangUtil::$generalTerms['YES']; ?></input>
+                                        if ($doctor_lab_config->doctor == 2) {
+                                            echo " checked ";
+                                        }
+                                        ?>><?php echo LangUtil::$generalTerms['YES']; ?></input>
 										&nbsp;&nbsp;
 										<input type='radio' name='doctor_use_doctor_radio' value='N' <?php
-										if($doctor_lab_config->doctor != 2)
-											echo " checked ";
-										?>><?php echo LangUtil::$generalTerms['NO']; ?></input>
+                                        if ($doctor_lab_config->doctor != 2) {
+                                            echo " checked ";
+                                        }
+                                        ?>><?php echo LangUtil::$generalTerms['NO']; ?></input>
 									</span>
 								</td>
 							</tr>
@@ -4092,11 +4047,11 @@ function AddnewDHIMS2Config()
 					});
 					</script>
 					<br>
-					
+
 					<br>
-					
+
 				</div>
-				
+
 				<div class='right_pane' id='network_setup_div' style='display:none;margin-left:10px;'>
 				<p style="text-align: right;"><a rel='facebox' href='#SetupNet'>Page Help</a></p>
 				<p>Setup for a local network for your hospital or laboratory can be accessed from BlisSetup.html in the main folder.</p>
@@ -4112,11 +4067,11 @@ function AddnewDHIMS2Config()
 						name="lab_config_id"
 						value="<?php echo $lab_config_id; ?>">
 					<?php echo LangUtil::$pageTerms['ADD_ONLINE_SERVER']; ?>
-                    <input type="text" id="server_ip" 
+                    <input type="text" id="server_ip"
 						name="server_ip"
 						value='<?php $query = "select server_ip from lab_config where lab_config_id = ".$lab_config_id;
-								$result = query_associative_one($query);
-								echo reset($result); ?>'>
+                                $result = query_associative_one($query);
+                                echo reset($result); ?>'>
 					<br><br>
 					<input type="button"
 							value="<?php echo LangUtil::$pageTerms['SAVE_BUTTON']; ?>"
@@ -4146,10 +4101,10 @@ function AddnewDHIMS2Config()
 						</span>
 					</form>
 				</div>
-				
+
 
                             <div id='view_stocks_help' class='right_pane' style='display:none;margin-left:10px;'>
-                                    <ul>	
+                                    <ul>
                                             <?php
 
                                                     echo "<li>";
@@ -4165,8 +4120,8 @@ function AddnewDHIMS2Config()
                                     </ul>
                                     </div>
 
-                                
-                                
+
+
 				<div class='right_pane' id='del_config_div' style='display:none;margin-left:10px;'>
 					<b><?php echo LangUtil::$pageTerms['MENU_DEL']; ?></b>
 					<br><br>
@@ -4178,7 +4133,7 @@ function AddnewDHIMS2Config()
 					<input type='button' onclick="javascript:right_load(1, 'site_info_div');" value='<?php echo LangUtil::$generalTerms['CMD_CANCEL']; ?>'>
 					</div>
 				</div>
-				
+
 				<div class='right_pane' id='change_admin_div' style='display:none;margin-left:10px;'>
 					<b><?php echo LangUtil::$pageTerms['MENU_MGR']; ?></b>
 					<br><br>
@@ -4186,17 +4141,17 @@ function AddnewDHIMS2Config()
 					</div>
 					<br>
 					<select name='lab_admin' id='lab_admin' class='uniform_width'>
-					<?php 
-						# Fetch list of existing lab admins 
-						$page_elems->getAdminUserOptions();
-					?>
+					<?php
+                        # Fetch list of existing lab admins
+                        $page_elems->getAdminUserOptions();
+                    ?>
 					</select>
 					<br><br>
 					<input type='button' onclick='javascript:change_admin();' value='<?php echo LangUtil::$generalTerms['CMD_SUBMIT']; ?>'>
 					&nbsp;&nbsp;&nbsp;
 					<small><a href="javascript:right_load(1, 'site_info_div');"><?php echo LangUtil::$generalTerms['CMD_CANCEL']; ?></a></small>
 				</div>
-				
+
 				<div class='right_pane' id='agg_report_div' style='display:none;margin-left:10px;'>
 				<p style="text-align: right;"><a rel='facebox' href='#IR_rc'>Page Help</a></p>
 					<b><?php echo LangUtil::$pageTerms['MENU_INFECTION']; ?></b>
@@ -4211,13 +4166,13 @@ function AddnewDHIMS2Config()
 					<div id='agg_report_form_div' style='display:none;'>
 						<form id='agg_report_form' name='agg_report_form' action='ajax/report_agg_update.php' method='post'>
 							<?php $page_elems->getAggregateReportConfigureForm($lab_config); ?>
-						</form>	
-						<form id='agg_preview_form' style='display:none;' name='agg_preview_form' action='report_disease_preview.php' method='post' target='_blank'>					
-							<?php # This form is cloned from agg_report_form in javascript:agg_preview() function ?>
+						</form>
+						<form id='agg_preview_form' style='display:none;' name='agg_preview_form' action='report_disease_preview.php' method='post' target='_blank'>
+							<?php # This form is cloned from agg_report_form in javascript:agg_preview() function?>
 						</form>
 					</div>
 				</div>
-				
+
                                 <div class='right_pane' id='grouped_count_div' style='display:none;margin-left:10px;'>
 				<p style="text-align: right;"><a rel='facebox' href='#IR_rc'>Page Help</a></p>
 					<b><?php echo "Test/Specimen Count Grouped Reports"; ?></b>
@@ -4232,11 +4187,11 @@ function AddnewDHIMS2Config()
 					<div id='grouped_count_report_form_div' style='display:none;'>
 						<form id='grouped_count_report_form' name='grouped_count_report_form' action='ajax/grouped_count_reports_update.php' method='post'>
 							<?php $page_elems->getGroupedCountReportConfigureForm($lab_config); ?>
-						</form>	
-						
+						</form>
+
 					</div>
 				</div>
-                                
+
 				<div class='right_pane' id='misc_div' style='display:none;margin-left:10px;'>
 					<b><?php echo LangUtil::$pageTerms['MENU_GENERAL']; ?></b>
 					<br><br>
@@ -4284,7 +4239,7 @@ function AddnewDHIMS2Config()
 								<tr valign='top' class='random_params' style='display:none;'>
 									<td>Total Specimens</td>
 									<td>
-										<input type='text' class='uniform_width' name='num_s' value='<?php echo "2000"; #$MAX_NUM_SPECIMENS/2; ?>'></input>
+										<input type='text' class='uniform_width' name='num_s' value='<?php echo "2000"; #$MAX_NUM_SPECIMENS/2;?>'></input>
 									</td>
 								</tr>
 								<tr>
@@ -4310,14 +4265,14 @@ function AddnewDHIMS2Config()
 								<tr>
 									<td></td>
 									<td>
-										
+
 									</td>
 								</tr>
 							</tbody>
 						</table>
-					</form>			
+					</form>
 				</div>
-				
+
 				<!--  Daily Report Settings Pane -->
 				<div class='right_pane' id='report_config_div' style='display:none;margin-left:10px;'>
 				<p style="text-align: right;"><a rel='facebox' href='#DRS_rc'>Page Help</a></p>
@@ -4332,19 +4287,17 @@ function AddnewDHIMS2Config()
 						<select name='report_type' id='report_type11'>
 							<option value='1'><?php echo $LANG_ARRAY['reports']['MENU_PATIENT']; ?></option>
 							<?php
-							if($SHOW_SPECIMEN_REPORT === true)
-							{
-								?>
+                            if ($SHOW_SPECIMEN_REPORT === true) {
+                                ?>
 								<option value='2'><?php echo $LANG_ARRAY['reports']['MENU_SPECIMEN']; ?></option>
 								<?php
-							}
-							if($SHOW_TESTRECORD_REPORT === true)
-							{
-								?>
+                            }
+                            if ($SHOW_TESTRECORD_REPORT === true) {
+                                ?>
 								<option value='3'><?php echo $LANG_ARRAY['reports']['MENU_TESTRECORDS']; ?></option>
 								<?php
-							}
-							?>
+                            }
+                            ?>
 							<option value='4'><?php echo $LANG_ARRAY['reports']['MENU_DAILYLOGS']."-".LangUtil::$generalTerms['SPECIMENS']; ?></option>
 							<option value='6'><?php echo $LANG_ARRAY['reports']['MENU_DAILYLOGS']."-".LangUtil::$generalTerms['PATIENTS']; ?></option>
 							<!-- <option value='77'><?php echo $LANG_ARRAY['reports']['MENU_DAILYLOGS']."-".LangUtil::$generalTerms['PATIENT_BARCODE']; ?></option> -->
@@ -4358,7 +4311,7 @@ function AddnewDHIMS2Config()
 						<br><br>
 						<div id='report_config_content'>
 						</div>
-					</form>	
+					</form>
 
 				</div>
 
@@ -4397,7 +4350,7 @@ function AddnewDHIMS2Config()
 					<div id='test_report_configuration_msg' class='clean-orange' style='display:none;width:350px;'>
 					</div>
 					<br>
-					<div><input type="checkbox" class="sfields_entry" id="print_verified" <?php if(($page_elems->getPrintUnverified($lab_config->id))==1) { ?> checked <?php }?>  onchange="javascript:savePrintPending();"><?php echo LangUtil::$pageTerms['PRINT_UNVERIFIED']; ?></div>
+					<div><input type="checkbox" class="sfields_entry" id="print_verified" <?php if (($page_elems->getPrintUnverified($lab_config->id))==1) { ?> checked <?php }?>  onchange="javascript:savePrintPending();"><?php echo LangUtil::$pageTerms['PRINT_UNVERIFIED']; ?></div>
 					<br>
 					<div id="test_report_configuration_form_div"
 						 style="text-align: center;">
@@ -4407,8 +4360,8 @@ function AddnewDHIMS2Config()
 							<select id="select_test_for_config"
 									name="select_test_for_config[]">
 								<?php
-								$page_elems->getTestTypesByReportingStatusOptions(1);
-								?>
+                                $page_elems->getTestTypesByReportingStatusOptions(1);
+                                ?>
 							</select>
 							<input type='button' id='test_report_config_button'
 								   value="<?php echo LangUtil::$generalTerms['CMD_SEARCH']; ?>"
@@ -4429,7 +4382,7 @@ function AddnewDHIMS2Config()
 				<div class='right_pane' id='batch_results_div' style='display:none;margin-left:10px;'>
 				<p style="text-align: right;"><a rel='facebox' href='#BRC'>Page Help</a></p>
 					<!-- configure the echo below to something like this LangUtil::$pageTerms['MENU_BATCHRESULTSFIELDS'] -->
-					<b><?php echo LangUtil::$pageTerms['MENU_BATCHRESULTSFIELDS']; ?></b> 
+					<b><?php echo LangUtil::$pageTerms['MENU_BATCHRESULTSFIELDS']; ?></b>
 					<br><br>
 					<div id='batch_results_fields_msg' class='clean-orange' style='display:none;width:350px;'>
 					</div>
@@ -4437,7 +4390,7 @@ function AddnewDHIMS2Config()
                     <div class='pretty_box' style='width:300px;'>
 					<form id='batch_results_form' name='batch_results_form' action='ajax/batch_results_config_update.php' method='post'>
 						<?php $page_elems->getBatchResultsFieldsForm() ?>
-						
+
 					</form>
                     </div>
 				</div>
@@ -4452,7 +4405,7 @@ function AddnewDHIMS2Config()
 					<br>
                     <div class='pretty_box'>
 					<form id='patient_fields_order_from' name='patient_fields_order_from' action='ajax/report_fields_order.php' method='post'>
-						<?php $page_elems->getPatientFieldsOrderForm(); ?>                         
+						<?php $page_elems->getPatientFieldsOrderForm(); ?>
 					</form>
                     </div>
 				</div>
@@ -4542,13 +4495,13 @@ function AddnewDHIMS2Config()
 							</tbody>
 						</table>
 					</form>
-	
+
 					<br><br>
 					<div class='clean-orange' id='revert_done_msg' style='width:300px' style='display:none;'>
 						<?php echo LangUtil::$pageTerms['TIPS_REVERTDONE']; ?>
 					</div>
 				</div>
-				
+
 				<div class='right_pane' id='update_database_div' style='display:none;margin-left:10px;'>
 					<p style="text-align: right;"><a rel='facebox' href='#Revert'>Page Help</a></p>
 					<b><?php echo "Update Data"; ?></b>
@@ -4591,7 +4544,7 @@ function AddnewDHIMS2Config()
 						Update Failed&nbsp;&nbsp;&nbsp;<a href="javascript:toggle_div('update_failure');"><?php echo LangUtil::$generalTerms['CMD_HIDE']; ?></a>
 					</div>
 				</div>
-                                
+
                                 <div class='right_pane' id='import_config_div' style='display:none;margin-left:10px;'>
 					<p style="text-align: right;"><a rel='facebox' href='#importconfig'>Page Help</a></p>
 					<b><?php echo "Import Configuration"; ?></b>
@@ -4618,11 +4571,11 @@ function AddnewDHIMS2Config()
                                                                         $page_elems->getSiteOptions();
                                                                     ?>
                                                                     </select>
-                                                                    
-                                                                        
+
+
                                                                 </td>
 									<td>
-										<?php //echo $lab_config->id; ?>
+										<?php //echo $lab_config->id;?>
 									</td>
 								</tr>
                                                                 <tr valign='top'>
@@ -4641,7 +4594,7 @@ function AddnewDHIMS2Config()
 										<?php echo ""; ?>
 									</td>
 								</tr>
-								
+
 								<tr valign='top'>
 									<td><?php echo 'Import test catalog'; ?></td>
 									<td>
@@ -4691,7 +4644,7 @@ function AddnewDHIMS2Config()
 						Update Failed&nbsp;&nbsp;&nbsp;<a href="javascript:toggle_div('update_failure');"><?php echo LangUtil::$generalTerms['CMD_HIDE']; ?></a>
 					</div>
 				</div>
-				
+
 				<div class='right_pane' id='worksheet_config_div' style='display:none;margin-left:10px;'>
 				<p style="text-align: right;"><a rel='facebox' href='#WS_rc'>Page Help</a></p>
 					<b><?php echo LangUtil::$pageTerms['MENU_WORKSHEETCONFIG']; ?></b>
@@ -4741,38 +4694,38 @@ function AddnewDHIMS2Config()
 					<br>
 					<small><a href='worksheet_custom_new.php?id=<?php echo $lab_config->id; ?>'><?php echo LangUtil::$pageTerms['NEW_CUSTOMWORKSHEET']; ?> &raquo;</a></small>
 				</div>
-				
+
 				<div class='right_pane' id='language_div' style='display:none;margin-left:10px;'>
 					<div id='language_contents'></div>
 					<?php
-						include('lang/lang_edit.php'); 
-					?>
+                        include('lang/lang_edit.php');
+                    ?>
 				</div>
 				<div class='right_pane' id='dhims2_config_div' style='display:none;margin-left:10px;'>
                 <p style="text-align: right;"><a rel='facebox' href='#DHIMS2INFO'>Page Help</a></p>
                     <b><?php echo "DHIMS 2 Configurations" ?></b> | <a href='javascript:toggle_DHIMS2();' id='DHIMS2_edit_link'><?php echo LangUtil::$generalTerms['CMD_EDIT']; ?></a>
-                    <br><br>                        
-        
+                    <br><br>
+
                     <div id='DHIMS2_msg' class='clean-orange' style='display:none;width:350px;'>
-                    </div>                        
+                    </div>
                     <div id='DHIMS2_summary_div'>
                         <?php echo $page_elems->DHIMS2ConfigsSummary($lab_config); ?>
                     </div>
-                   
+
                     <div id='DHIMS2_form_div' style='display:none;'>
                     <form id='DHIMSconf_from' name='DHIMSconf_from' action='ajax/DHIMS2conf_add.php' method='post'>
-                        <?php $page_elems->DHIMS2ConfigsForm($lab_config); ?>                         
+                        <?php $page_elems->DHIMS2ConfigsForm($lab_config); ?>
                     </form>
-                    
-                    </div>                      
-                                 
+
+                    </div>
+
                 </div>
-                 
+
                   <div class='right_pane' id='analyzer_setup_config_div' style='display:none;margin-left:10px;'>
                 	<p style="text-align: right;"><a rel='facebox' href='#analyzer_setup_INFO'>Page Help</a></p>
                     <form id="analyzer_setup">
                     <table>
-                            <tbody>                           
+                            <tbody>
                                 <tr valign='top'>
                                     <td><?php echo 'Select Equipment to be interfaced through BLISInterfaceClient' ?><br></td>
                                 </tr>
@@ -4790,17 +4743,17 @@ function AddnewDHIMS2Config()
                                 </tbody>
                                 </table>
                     </form>
-                    
+
                     <script type="text/javascript">
                         function fetch_equipment_details()
                         {
-                            $('#eq_con_details').html("");                            
+                            $('#eq_con_details').html("");
                             $selected_equ = $('#eq_list').attr('value');
                             if($selected_equ !='0')
                             {
                                 $.ajax({
-                                    url : "ajax/getEquipmentDetails.php?id="+$selected_equ,                                   
-                                    success : function(data) {                                  
+                                    url : "ajax/getEquipmentDetails.php?id="+$selected_equ,
+                                    success : function(data) {
                                         var objData = JSON.parse(data);
                                         if(objData.length > 0)
                                         {
@@ -4845,8 +4798,8 @@ function AddnewDHIMS2Config()
 										        "<tbody>";
 
 										        $.ajax({
-                                    				url : "ajax/getEquipmentProps.php?id="+$selected_equ,                                   
-				                                    success : function(data1) {                               
+                                    				url : "ajax/getEquipmentProps.php?id="+$selected_equ,
+				                                    success : function(data1) {
 				                                        var objData1 = JSON.parse(data1);
 				                                        for (var c_i = 0; c_i < objData1.length; c_i++){
 				                                        	html +=  "<tr>"+
@@ -4868,11 +4821,11 @@ function AddnewDHIMS2Config()
 				                                });
 
                                         }
-                                    }   
+                                    }
                                 });
-                                
+
                             }
-                            
+
                         }
                     </script>
                 </div>

--- a/htdocs/includes/db_lib.php
+++ b/htdocs/includes/db_lib.php
@@ -1,5 +1,5 @@
 ﻿<?php
-# 
+#
 # (c) C4G, Santosh Vempala, Ruban Monu and Amol Shintre
 # This file contains entity classes and functions for DB queries
 #
@@ -73,15 +73,15 @@ class UserType{
 		$usertype->defaultdisplay = $record['defaultdisplay'];
 		$usertype->level = $record['level'];
 		$usertype->name = $record['name'];
-		$usertype->createdBy = $record['created_by'];		
-		$usertype->rwoption = $record['rwoption'];	
+		$usertype->createdBy = $record['created_by'];
+		$usertype->rwoption = $record['rwoption'];
 		return $usertype;
 	}
 }
 class User
 {
 	public $userId;
-	
+
 public $username;
 	public $password;
 	public $actualName;
@@ -92,9 +92,9 @@ public $username;
 	public $labConfigId;
 	public $langId;
 	public $country;
-	
+
 	public $rwoption;
-	
+
 	public static function getObject($record)
 	{
 		global $DEFAULT_LANG;
@@ -115,18 +115,18 @@ public $username;
 			$user->langId = $record['lang_id'];
 		else
 			$user->langId = $DEFAULT_LANG;
-			
+
 		/*if( $user->labConfigId == 128 || $user->labConfigId == 129 || $user->labConfig == 131 ) */
 			$user->country = LabConfig::getUserCountry($user->labConfigId);
 	global $LIS_TECH_RO, $LIS_TECH_RW, $LIS_ADMIN, $LIS_SUPERADMIN, $LIS_VERIFIER, $LIS_COUNTRYDIR, $LIS_CLERK, $READONLYMODE, $LIS_PHYSICIAN;
 	global $LIS_001, $LIS_010, $LIS_011, $LIS_100, $LIS_101, $LIS_110, $LIS_111, $LIS_TECH_SHOWPNAME;
 		if($user->level!=$LIS_PHYSICIAN&&$user->level!=$READONLYMODE&&$user->level!=$LIS_VERIFIER&&$user->level!=$LIS_TECH_SHOWPNAME&&$user->level!=$LIS_CLERK&&$user->level!=$LIS_COUNTRYDIR&&$user->level!=$LIS_SUPERADMIN&&$user->level!=$LIS_ADMIN&&$user->level!=$LIS_TECH_RO&&$user->level!=$LIS_TECH_RW)
 {
-		$user->rwoptions =get_user_by_level($user->level)->rwoption; 
+		$user->rwoptions =get_user_by_level($user->level)->rwoption;
 }
 else
 		$user->rwoptions=$record['rwoptions'];
-		
+
 		return $user;
 	}
 
@@ -140,13 +140,13 @@ else
 
         return self::getObject($user);
     }
-	
+
 	public static function onlyOneLabConfig($user_id, $user_level)
 	{
 		# Checks if only one lab config exists for this admin level user
 		global $LIS_ADMIN;
 		$lab_config_list = get_lab_configs($user_id, $user_level);
-		
+
 		if(count($lab_config_list) == 1 && $user_level == $LIS_ADMIN)
 			return true;
 		else
@@ -157,14 +157,14 @@ else
 
 class currencyConfig{
 	public $currencyFrom;
-	public $currencyTo; 
+	public $currencyTo;
 	public $exchangeRate;
 	public $lastUpdatedOn;
 	public $flag1;
 	public $flag2;
 	public $setting1;
 	public $setting2;
-	
+
 	public static function getObject($record)
 	{
 		global $DEFAULT_DATE_FORMAT;
@@ -176,32 +176,32 @@ class currencyConfig{
 		$currency_config->currencyTo = $record['currencyb'];
 		$currency_config->exchangeRate = $record['exchangerate'];
 		$currency_config->lastUpdatedOn = $record['updatedts'];
-		
+
 		if(isset($record['flag1']))
 			$currency_config->flag1 = $record['flag1'];
 		else
 			$currency_config->flag1 = 0;
-		
+
 		if(isset($record['flag2']))
 			$currency_config->flag2 = $record['flag2'];
 		else
 			$currency_config->flag2 = 0;
-		
+
 		if(isset($record['setting1']))
 			$currency_config->setting1 = $record['setting1'];
 		else
 			$currency_config->setting1 = 0;
-		
+
 		if(isset($record['setting2']))
 			$currency_config->setting2 = $record['setting2'];
 		else
 			$currency_config->setting2 = 0;
-		
+
 		return $currency_config;
-		
+
 	}
-	
-	
+
+
 	public function getCurrencyFrom()
 	{
 		if($this->currencyFrom == null || trim($this->currencyFrom) == "")
@@ -209,7 +209,7 @@ class currencyConfig{
 		else
 			return $this->currencyFrom;
 	}
-	
+
 	public function getCurrencyTo()
 	{
 		if($this->currencyTo == null || trim($this->currencyTo) == "")
@@ -238,7 +238,7 @@ class currencyConfig{
 		else
 			return $this->flag1;
 	}
-	
+
 	public function getFlag2()
 	{
 		if($this->flag2 == null || trim($this->flag2) == "")
@@ -246,7 +246,7 @@ class currencyConfig{
 		else
 			return $this->flag2;
 	}
-	
+
 	public function getSetting1()
 	{
 		if($this->setting1 == null || trim($this->setting1) == "")
@@ -254,7 +254,7 @@ class currencyConfig{
 		else
 			return $this->setting1;
 	}
-	
+
 	public function getSetting2()
 	{
 		if($this->setting2 == null || trim($this->setting2) == "")
@@ -262,7 +262,7 @@ class currencyConfig{
 		else
 			return $this->setting2;
 	}
-	
+
 	public static function getExchangeRateSnap($lab_config_id, $currencyFrom) {
 		$saved_db = DbUtil::switchToLabConfig($lab_config_id);
 		$retval = array();
@@ -275,7 +275,7 @@ class currencyConfig{
 		DbUtil::switchRestore($saved_db);
 		return $retval;
 	}
-	
+
 	public static function getExchangeRateValue($lab_config_id, $currencyFrom, $currencyTo) {
 		$saved_db = DbUtil::switchToLabConfig($lab_config_id);
 		global $con;
@@ -284,7 +284,7 @@ class currencyConfig{
 		DbUtil::switchRestore($saved_db);
 		return currencyConfig::getObject($record);
 	}
-	
+
 	public static function getDefaultCurrency($lab_config_id) {
 		$saved_db = DbUtil::switchToLabConfig($lab_config_id);
 		global $con;
@@ -293,7 +293,7 @@ class currencyConfig{
 		DbUtil::switchRestore($saved_db);
 		return currencyConfig::getObject($record);
 	}
-	
+
 	public static function setDefaultCurrency($lab_config_id, $default_currency_name) {
 		$saved_db = DbUtil::switchToLabConfig($lab_config_id);
 		$query_string = "update currency_conversion set flag1='0' where flag1='1'";
@@ -303,7 +303,7 @@ class currencyConfig{
 		DbUtil::switchRestore($saved_db);
 		return 1;
 	}
-	
+
 	public static function getAllDifferenctCurrencies($lab_config_id) {
 		//echo "TEST";
 		$saved_db = DbUtil::switchToLabConfig($lab_config_id);
@@ -323,12 +323,12 @@ class currencyConfig{
 		DbUtil::switchRestore($saved_db);
 		return $record_c;
 	}
-	
-	
+
+
 	public static function getAllSecondaryCurrencies($lab_config_id, $default_currency) {
 		$saved_db = DbUtil::switchToLabConfig($lab_config_id);
 		$query_string = "SELECT distinct currencyb FROM currency_conversion where currencya='$default_currency'";
-		
+
 		$resultset = query_associative_all($query_string);
 		$record_c=array();
 		foreach($resultset as $record)
@@ -342,8 +342,8 @@ class currencyConfig{
 		DbUtil::switchRestore($saved_db);
 		return $record_c;
 	}
-	
-	
+
+
 }
 
 
@@ -367,33 +367,33 @@ class FieldOrdering
 	public $field15;
 	public $field16; */
 	public $form_field_inOrder;
-	
+
 	public $form_id;
-	
-	
+
+
 	public static function getObject($record)
 	{
 		# Converts a lab_config record in DB into a LabConfig object
 		if($record == null)
 			return null;
-		
+
 		$field_ordering = new FieldOrdering();
-		
+
 		if(isset($record['lab_config_id']))
 			$field_ordering->id = $record['lab_config_id'];
 		else
 			$field_ordering->id = null;
-		
+
 		if(isset($record['form_id']))
 			$field_ordering->form_id = $record['form_id'];
 		else
 			$field_ordering->form_id = -1;
-		
+
 		if(isset($record['field_order']))
 			$field_ordering->form_field_inOrder = $record['field_order'];
 		else
 			$field_ordering->form_field_inOrder = -1;
-		
+
 		return $field_ordering;
 	}
 
@@ -406,7 +406,7 @@ class FieldOrdering
 		DbUtil::switchRestore($saved_db);
 		return FieldOrdering::getObject($record);
 	}
-	
+
 	public static function deleteFieldOrderEntry($lab_config_id, $form_id){
 		$saved_db = DbUtil::switchToLabConfig($lab_config_id);
 		//$query_delete = "DELETE FROM field_ordering WHERE lab_config_id=$lab_config_id AND form_id=$form_id";
@@ -417,26 +417,26 @@ class FieldOrdering
 
 	public static function add_fieldOrdering($fieldOrder, $importOn = false)
 	{
-		# Adds a new patient/ specimen field order to DB 
-		
+		# Adds a new patient/ specimen field order to DB
+
 		$field_order = db_escape($fieldOrder->form_field_inOrder);
 		$lab_config_id = db_escape($fieldOrder->id);
 		$form_id = db_escape($fieldOrder->form_id);
-			
-		
+
+
 		/* $query_string =
 			"INSERT INTO `field_ordering`(`lab_config_id`, `field1`, `field2`, `field3`, `field4`, `field5`, `field6`, `field7`,`field8`,`field9`,`field10`,`field11`,`field12`,`field13`,`field14`,`field15`,`field16`,`form_id`) ".
 			"VALUES ($lab_config_id, '$field1', '$field2', '$field3', '$field4', '$field5', '$field6', '$field7', '$field8', '$field9', '$field10', '$field11', '$field12', '$field13', '$field14', '$field15', '$field16', $form_id)";
 		 */
 		$saved_db = DbUtil::switchToLabConfig($_SESSION['lab_config_id']);
-		
+
 		$query_string =
 		"INSERT INTO `field_order`(`lab_config_id`, `field_order`,`form_id`) ".
 		"VALUES ($lab_config_id, '$field_order', $form_id)";
 		//echo $query_string;
 		//print $query_string;
 		query_insert_one($query_string);
-		
+
 		DbUtil::switchRestore($saved_db);
 		return true;
 	}
@@ -585,10 +585,10 @@ class LabConfig
 	public $ageLimit;
 	public $country;
     public $site_choice_enabled;
-	
+
 	public static $ID_AUTOINCR = 1;
 	public static $ID_MANUAL = 2;
-	
+
 	public static $RESET_DAILY = 1;
 	public static $RESET_MONTHLY = 2;
 	public static $RESET_YEARLY = 3;
@@ -687,7 +687,7 @@ class LabConfig
         $lab_config->site_choice_enabled = $record['site_choice_enabled'];
 		return $lab_config;
 	}
-	
+
 	public static function getDoctorUserOptions() {
 		$saved_db = DbUtil::switchToGlobal();
 		//global $con;
@@ -703,7 +703,7 @@ class LabConfig
 			return '0122011111121';
 		}
 	}
-	
+
 	public static function getDoctorObject($record)
 	{
 		global $DEFAULT_DATE_FORMAT;
@@ -726,10 +726,10 @@ class LabConfig
 			## TODO: Reflect the following attribs in DB backend
 			$lab_config->collectionDateUsed = false;
 			$lab_config->collectionTimeUsed = false;
-			
-			
+
+
 			$arr1 = str_split(LabConfig::getDoctorUserOptions());
-		
+
 			$lab_config->patientAddl = $arr1[0];
 			$lab_config->specimenAddl = $arr1[1];
 			$lab_config->dailyNum = $arr1[2];
@@ -744,22 +744,22 @@ class LabConfig
 			$lab_config->sex = $arr1[11];
 			$lab_config->doctor = $arr1[12];
 
-			
+
 			if(isset($record['dnum_reset']))
 				$lab_config->dailyNumReset = $record['dnum_reset'];
 			else
 				$lab_config_id->dailyNumReset = LabConfig::$RESET_DAILY;
-			
+
 			if(isset($record['dformat']))
 				$lab_config->dateFormat = $record['dformat'];
 			else
 				$lab_config->dateFormat = $DEFAULT_DATE_FORMAT;
-			
+
 			if(isset($record['pnamehide']))
 				$lab_config->hidePatientName = $record['pnamehide'];
 			else
 				$lab_config->hidePatientName = 1;
-			
+
 			if(isset($record['ageLimit']))
 				$lab_config->ageLimit = $record['ageLimit'];
 			else
@@ -784,7 +784,7 @@ $lc->name=$record['name'];
 	return $retval;
     }
     //AS 09/04/2018 END
-	
+
 	public static function getById($lab_config_id) {
 		$saved_db = DbUtil::switchToGlobal();
 		//global $con;
@@ -806,7 +806,7 @@ $lc->name=$record['name'];
 	// 	//echo "from db sid ".$record['sid'];
 	// 	return LabConfig::getObject($record);
 	// }
-	
+
 	public static function getDoctorConfig($lab_config_id) {
 		$saved_db = DbUtil::switchToGlobal();
 		//global $con;
@@ -817,9 +817,9 @@ $lc->name=$record['name'];
 		//echo "from db sid ".$record['sid'];
 		return LabConfig::getDoctorObject($record);
 	}
-	
-	
-	
+
+
+
 	public function getUserCountry($lab_config_id) {
 		global $con;
 		$lab_config_id = mysql_real_escape_string($lab_config_id, $con);
@@ -835,12 +835,12 @@ $lc->name=$record['name'];
 		DbUtil::switchRestore($saved_db);
 		return $record['country'];
 	}
-	
+
 	public function changeAdmin($new_admin_id)
 	{
 		global $con;
 		$new_admin_id = mysql_real_escape_string($new_admin_id, $con);
-		$query_string = 
+		$query_string =
 			"UPDATE lab_config ".
 			"SET admin_user_id=$new_admin_id ".
 			"WHERE lab_config_id=$this->id ";
@@ -848,16 +848,16 @@ $lc->name=$record['name'];
 		query_blind($query_string);
 		DbUtil::switchRestore($saved_db);
 	}
-		
+
 	public function getUsers()
 	{
 		$saved_db = DbUtil::switchToGlobal();
 		$lab_config_id = $this->id;
 		$retval = array();
-		$query_string = 
+		$query_string =
 			"SELECT u.* FROM user u ".
 			"WHERE lab_config_id=$lab_config_id ORDER BY u.username";
-			
+
 		$resultset = query_associative_all($query_string);
 		if($resultset != null)
 		{
@@ -875,9 +875,9 @@ $lc->name=$record['name'];
 		$saved_db = DbUtil::switchToGlobal();
 		$lab_config_id = $this->id;
 		$retval = array();
-		$query_string = 
+		$query_string =
 			"SELECT * FROM user_type";
-			
+
 		$resultset = query_associative_all($query_string);
 		if($resultset != null)
 		{
@@ -889,13 +889,13 @@ $lc->name=$record['name'];
 		DbUtil::switchRestore($saved_db);
 		return $retval;
 	}
-	
+
 	public function getSiteName()
 	{
 		# Returns site-name string
 		return $this->name." - ".$this->location;
 	}
-	
+
 	public function getGoalTatValues()
 	{
 		# Returns a list of latest goal TAT values for all tests in the lab
@@ -906,11 +906,11 @@ $lc->name=$record['name'];
 		foreach($test_type_list as $test_type)
 		{
 			/*
-			$query_string = 
+			$query_string =
 				"SELECT tat FROM test_type_tat ".
 				"WHERE test_type_id=$test_type->testTypeId ORDER BY ts DESC LIMIT 1";
 			*/
-			$query_string = 
+			$query_string =
 				"SELECT target_tat FROM test_type ".
 				"WHERE test_type_id=$test_type->testTypeId";
 			$record = query_associative_one($query_string);
@@ -969,7 +969,7 @@ $lc->name=$record['name'];
 			$retval = $record['tat'];
 		}
 		DbUtil::switchRestore($saved_db);
-		return $retval;		
+		return $retval;
 	}
 
 
@@ -983,8 +983,8 @@ $lc->name=$record['name'];
 		$record = query_associative_one($query_string);
 		return $record['target_tat'];
 	}
-	
-	
+
+
 	/*
 	public function getGoalTatValue($test_type_id, $timestamp="")
 	{
@@ -995,14 +995,14 @@ $lc->name=$record['name'];
 		if($timestamp == "")
 		{
 			# Fetch latest entry
-			$query_string = 
+			$query_string =
 				"SELECT target_tat FROM test_type ".
 				"WHERE test_type_id=$test_type_id ORDER BY ts DESC LIMIT 1";
 		}
 		else
 		{
 			# Fetch entry closest before or at the timestamp value
-			$query_string = 
+			$query_string =
 				"SELECT target_tat FROM test_type ttt ".
 				"WHERE ttt.test_type_id=$test_type_id ".
 				"AND ( ".
@@ -1029,9 +1029,9 @@ $lc->name=$record['name'];
 		return $retval;
 	}
 	*/
-	
+
 	public function updateGoalTatValue($test_type_id, $tat_value)
-	{	
+	{
 		# Updates goal TAT value for a single test type
 		## Adds a new entry for every update to have time-versioned goal TAT values
 		$saved_db = DbUtil::switchToLabConfig($this->id);
@@ -1040,7 +1040,7 @@ $lc->name=$record['name'];
 		$tat_value = mysql_real_escape_string($tat_value, $con);
 		# Create new entry
 		/*
-		$query_string = 
+		$query_string =
 			"SELECT tat FROM test_type_tat ".
 			"WHERE test_type_id=$test_type_id ORDER BY ts DESC LIMIT 1";
 		*/
@@ -1051,7 +1051,7 @@ $lc->name=$record['name'];
 		if($existing_record) {
 			if($existing_record['target_tat'] != $tat_value) {
 				# Update TAT value
-				$query_string = 
+				$query_string =
 					"UPDATE test_type SET target_tat=$tat_value WHERE test_type_id=$test_type_id";
 				query_update($query_string);
 			}
@@ -1059,7 +1059,7 @@ $lc->name=$record['name'];
 			else
 			{
 				# New record to append for TAT (keeping timestamp wise progression of entries)
-				$query_string = 
+				$query_string =
 					"INSERT INTO test_type_tat (test_type_id, tat) ".
 					"VALUES ($test_type_id, $tat_value)";
 				;
@@ -1071,7 +1071,7 @@ $lc->name=$record['name'];
 		else
 		{
 			# New record to add (first entry for this test type)
-			$query_string = 
+			$query_string =
 				"INSERT INTO test_type_tat (test_type_id, tat) ".
 				"VALUES ($test_type_id, $tat_value)";
 			;
@@ -1085,7 +1085,7 @@ $lc->name=$record['name'];
 	{
 		$saved_db = DbUtil::switchToLabConfigRevamp($lab_config);
 		# Returns a list of all test type IDs added to the lab configuration
-		$query_string = 
+		$query_string =
 			"SELECT distinct print_unverified FROM lab_config_test_type ".
 			"WHERE lab_config_id=".$lab_config;
 		$resultset = query_associative_one($query_string);
@@ -1096,7 +1096,7 @@ $lc->name=$record['name'];
 	public function setPrintUnverified($lab_config, $print_unverified)
 	{
 		$saved_db = DbUtil::switchToLabConfigRevamp($lab_config);
-		$query_string = 
+		$query_string =
 			"UPDATE lab_config_test_type ".
 			"SET print_unverified=".$print_unverified.
 			" WHERE lab_config_id=$lab_config";
@@ -1104,12 +1104,12 @@ $lc->name=$record['name'];
 		DbUtil::switchRestore($saved_db);
 	}
 
-	
+
 	public function getTestTypeIds()
 	{
 		$saved_db = DbUtil::switchToLabConfigRevamp($this->id);
 		# Returns a list of all test type IDs added to the lab configuration
-		$query_string = 
+		$query_string =
 			"SELECT test_type_id FROM lab_config_test_type ".
 			"WHERE lab_config_id=$this->id";
 		$resultset = query_associative_all($query_string);
@@ -1121,12 +1121,12 @@ $lc->name=$record['name'];
 		DbUtil::switchRestore($saved_db);
 		return $retval;
 	}
-	
+
 	public function getTestTypes()
 	{
 		$saved_db = DbUtil::switchToLabConfigRevamp($this->id);
 		# Returns a list of all test type objects added to the lab configuration
-		$query_string = 
+		$query_string =
 			"SELECT tt.* FROM test_type tt, lab_config_test_type lctt ".
 			"WHERE lctt.lab_config_id=$this->id ".
 			"AND lctt.test_type_id=tt.test_type_id";
@@ -1139,202 +1139,202 @@ $lc->name=$record['name'];
 		DbUtil::switchRestore($saved_db);
 		return $retval;
 	}
-	
+
 	public function changeName($new_name)
 	{
 		# Changes facility name for this lab configuration
 		global $con;
 		$new_name = mysql_real_escape_string($new_name, $con);
 		$saved_db = DbUtil::switchToGlobal();
-		$query_string = 
+		$query_string =
 			"UPDATE lab_config SET name='$new_name' WHERE lab_config_id=$this->id";
 		query_blind($query_string);
 		DbUtil::switchRestore($saved_db);
 	}
-	
+
 	public function changeLocation($new_location)
 	{
 		# Changes location value for this lab configuration
 		global $con;
 		$new_location = mysql_real_escape_string($new_location, $con);
 		$saved_db = DbUtil::switchToGlobal();
-		$query_string = 
+		$query_string =
 			"UPDATE lab_config SET location='$new_location' WHERE lab_config_id=$this->id";
 		query_blind($query_string);
 		DbUtil::switchRestore($saved_db);
 	}
-	
+
 	public function updatePatientAddl($new_value)
 	{
 		$saved_db = DbUtil::switchToGlobal();
 		global $con;
 		$new_value = mysql_real_escape_string($new_value, $con);
-		$query_string = 
+		$query_string =
 			"UPDATE lab_config SET p_addl=$new_value WHERE lab_config_id=$this->id";
 		query_blind($query_string);
 		DbUtil::switchRestore($saved_db);
 	}
-	
+
 	public function updateSpecimenAddl($new_value)
 	{
 		$saved_db = DbUtil::switchToGlobal();
 		global $con;
 		$new_value = mysql_real_escape_string($new_value, $con);
-		$query_string = 
+		$query_string =
 			"UPDATE lab_config SET s_addl=$new_value WHERE lab_config_id=$this->id";
 		query_blind($query_string);
 		DbUtil::switchRestore($saved_db);
 	}
-	
+
 	public function updateDailyNum($new_value)
 	{
 		$saved_db = DbUtil::switchToGlobal();
 		global $con;
 		$new_value = mysql_real_escape_string($new_value, $con);
-		$query_string = 
+		$query_string =
 			"UPDATE lab_config SET daily_num=$new_value WHERE lab_config_id=$this->id";
 		query_blind($query_string);
 		DbUtil::switchRestore($saved_db);
 	}
-	
+
 	public function updatePid($new_value)
 	{
 		$saved_db = DbUtil::switchToGlobal();
 		global $con;
 		$new_value = mysql_real_escape_string($new_value, $con);
-		$query_string = 
+		$query_string =
 			"UPDATE lab_config SET pid=$new_value WHERE lab_config_id=$this->id";
 		query_blind($query_string);
 		DbUtil::switchRestore($saved_db);
 	}
-	
+
 	public function updateSid($new_value)
 	{
 		$saved_db = DbUtil::switchToGlobal();
 		global $con;
 		$new_value = mysql_real_escape_string($new_value, $con);
-		$query_string = 
+		$query_string =
 			"UPDATE lab_config SET sid=$new_value WHERE lab_config_id=$this->id";
 		query_blind($query_string);
 		DbUtil::switchRestore($saved_db);
 	}
-	
+
 	public function updateComm($new_value)
 	{
 		$saved_db = DbUtil::switchToGlobal();
 		global $con;
 		$new_value = mysql_real_escape_string($new_value, $con);
-		$query_string = 
+		$query_string =
 			"UPDATE lab_config SET comm=$new_value WHERE lab_config_id=$this->id";
 		query_blind($query_string);
 		DbUtil::switchRestore($saved_db);
 	}
-	
+
 	public function updateRdate($new_value)
 	{
 		$saved_db = DbUtil::switchToGlobal();
 		global $con;
 		$new_value = mysql_real_escape_string($new_value, $con);
-		$query_string = 
+		$query_string =
 			"UPDATE lab_config SET rdate=$new_value WHERE lab_config_id=$this->id";
 		query_blind($query_string);
 		DbUtil::switchRestore($saved_db);
 	}
-	
+
 	public function updateRefout($new_value)
 	{
 		$saved_db = DbUtil::switchToGlobal();
 		global $con;
 		$new_value = mysql_real_escape_string($new_value, $con);
-		$query_string = 
+		$query_string =
 			"UPDATE lab_config SET refout=$new_value WHERE lab_config_id=$this->id";
 		query_blind($query_string);
 		DbUtil::switchRestore($saved_db);
 	}
-	
+
 	public function updateDoctor($new_value)
 	{
 		$saved_db = DbUtil::switchToGlobal();
 		global $con;
 		$new_value = mysql_real_escape_string($new_value, $con);
-		$query_string = 
+		$query_string =
 			"UPDATE lab_config SET doctor=$new_value WHERE lab_config_id=$this->id";
 		query_blind($query_string);
 		DbUtil::switchRestore($saved_db);
 	}
-	
+
 	public function updateHidePatientName($new_value)
 	{
 		$saved_db = DbUtil::switchToGlobal();
 		global $con;
 		$new_value = mysql_real_escape_string($new_value, $con);
-		$query_string = 
+		$query_string =
 			"UPDATE lab_config SET pnamehide=$new_value WHERE lab_config_id=$this->id";
 		query_blind($query_string);
 		DbUtil::switchRestore($saved_db);
 	}
-	
+
 	public function updateAge($new_value)
 	{
 		$saved_db = DbUtil::switchToGlobal();
 		global $con;
 		$new_value = mysql_real_escape_string($new_value, $con);
-		$query_string = 
+		$query_string =
 			"UPDATE lab_config SET age=$new_value WHERE lab_config_id=$this->id";
 		query_blind($query_string);
 		DbUtil::switchRestore($saved_db);
 	}
-	
+
 	public function updateSex($new_value)
 	{
 		$saved_db = DbUtil::switchToGlobal();
 		global $con;
 		$new_value = mysql_real_escape_string($new_value, $con);
-		$query_string = 
+		$query_string =
 			"UPDATE lab_config SET sex=$new_value WHERE lab_config_id=$this->id";
 		query_blind($query_string);
 		DbUtil::switchRestore($saved_db);
 	}
-	
+
 	public function updateDob($new_value)
 	{
 		$saved_db = DbUtil::switchToGlobal();
 		global $con;
 		$new_value = mysql_real_escape_string($new_value, $con);
-		$query_string = 
+		$query_string =
 			"UPDATE lab_config SET dob=$new_value WHERE lab_config_id=$this->id";
 		query_blind($query_string);
 		DbUtil::switchRestore($saved_db);
 	}
-	
+
 	public function updatePname($new_value)
 	{
 		$saved_db = DbUtil::switchToGlobal();
 		global $con;
 		$new_value = mysql_real_escape_string($new_value, $con);
-		$query_string = 
+		$query_string =
 			"UPDATE lab_config SET pname=$new_value WHERE lab_config_id=$this->id";
 		query_blind($query_string);
 		DbUtil::switchRestore($saved_db);
 	}
-	
+
 	public function updateDateFormat($new_format)
 	{
 		$saved_db = DbUtil::switchToGlobal();
 		global $con;
 		$new_format = mysql_real_escape_string($new_format, $con);
-		$query_string = 
+		$query_string =
 			"UPDATE lab_config SET dformat='$new_format' WHERE lab_config_id=$this->id";
 		query_blind($query_string);
 		DbUtil::switchRestore($saved_db);
 	}
-	
+
 	public function updateAgeLimit($ageLimit)
 	{
 		$saved_db = DbUtil::switchToGlobal();
 		global $con;
 		$ageLimit = mysql_real_escape_string($ageLimit, $con);
-		$query_string = 
+		$query_string =
 			"UPDATE lab_config SET ageLimit=$ageLimit WHERE lab_config_id=$this->id";
 		query_blind($query_string);
 		DbUtil::switchRestore($saved_db);
@@ -1353,18 +1353,18 @@ $lc->name=$record['name'];
 		# otherwise return any row present
 		return ReportConfig::getOneWorksheetRow($this->id);
 	}
-	
+
 	public function getReportConfig($report_id)
 	{
 		# Returns report config parameters getByIdfor this lab
 		return ReportConfig::getById($this->id, $report_id);
 	}
-	
+
 	public function getWorksheetConfig($test_type_id)
 	{
 		return ReportConfig::getByTestTypeId($this->id, $test_type_id);
 	}
-	
+
 	public function getCustomFields($target_entity)
 	{
 		# Returns list of custom fields being used at this lab
@@ -1375,9 +1375,9 @@ $lc->name=$record['name'];
 		$target_table = "patient_custom_field";
 		if($target_entity == 1)
 			$target_table = "specimen_custom_field";
-		if($target_entity == 3)	
+		if($target_entity == 3)
 			$target_table = "labtitle_custom_field";
-		$query_string = 
+		$query_string =
 			"SELECT * FROM $target_table ORDER BY id";
 		$resultset = query_associative_all($query_string);
 		$retval = array();
@@ -1388,52 +1388,52 @@ $lc->name=$record['name'];
 		DbUtil::switchRestore($saved_db);
 		return $retval;
 	}
-	
-	
+
+
 	public function getPatientCustomFields()
 	{
 		# Returns list of patient custom fields being used at this lab
 		return $this->getCustomFields(2);
 	}
-	
+
 	public function getSpecimenCustomFields()
 	{
 		# Returns list of specimen custom fields being used at this lab
 		return $this->getCustomFields(1);
 	}
-	
+
 	public function getLabTitleCustomFields()
 	{
 		# Returns list of specimen custom fields being used at this lab
 		return $this->getCustomFields(3);
 	}
-	
+
 	public function updateDailyNumReset($new_value)
 	{
 		$saved_db = DbUtil::switchToGlobal();
 		global $con;
 		$new_value = mysql_real_escape_string($new_value, $con);
-		$query_string = 
+		$query_string =
 			"UPDATE lab_config SET dnum_reset=$new_value WHERE lab_config_id=$this->id";
 		query_blind($query_string);
 		DbUtil::switchRestore($saved_db);
 	}
-	
+
 	public function worksheetConfigGenerate()
 	{
 		$test_ids = $this->getTestTypeIds();
 		$saved_db = DbUtil::switchToLabConfig($this->id);
 		echo $saved_db;
 		foreach($test_ids as $test_id)
-		{	
+		{
 			$test_entry = TestType::getById($test_id);
-			$query_string = 
+			$query_string =
 				"SELECT report_id FROM report_config WHERE test_type_id='$test_id' LIMIT 1";
 			$record = query_associative_one($query_string);
 			if($record == null)
-			{	
+			{
 				# Add new entry
-				$query_string_add = 
+				$query_string_add =
 					"INSERT INTO report_config (".
 						"test_type_id, header, footer, margins, ".
 						"p_fields, s_fields, t_fields, p_custom_fields, s_custom_fields ".
@@ -1446,11 +1446,11 @@ $lc->name=$record['name'];
 		}
 		DbUtil::switchRestore($saved_db);
 	}
-	
+
 	public function getCustomWorksheets()
 	{
 		$saved_db = DbUtil::switchToLabConfig($this->id);
-		$query_string = 
+		$query_string =
 			"SELECT * FROM worksheet_custom";
 		$resultset = query_associative_all($query_string);
 		$retval = array();
@@ -1527,7 +1527,7 @@ class Sites
             $query = "SELECT * FROM sites ".
                 "WHERE lab_id=".$id;
             $result = query_associative_all($query);
-			if ($result == NULL)        
+			if ($result == NULL)
    			{
                 $lab_config = LabConfig::getById($id);
                 $lab_name = mysql_real_escape_string($lab_config->name, $con);
@@ -1584,7 +1584,7 @@ class Sites
         $district = mysql_real_escape_string($site_district, $con);
         echo $site_region;
         echo $site_district;
-       
+
         $query = "UPDATE sites SET Region = '".$region."' , District = '".$district."' where id = '$site_id' ";
         echo $query;
         query_insert_one($query);
@@ -1688,7 +1688,7 @@ class ReportConfig
 	public $reportId;
 	public $testTypeId;
 	public $title;
-		
+
 	public $headerText;
 	public $titleText;
 	public $footerText;
@@ -1701,7 +1701,7 @@ class ReportConfig
 	public $specimenCustomFields;
 	public $margins;
 	public static $TOP=0, $BOTTOM=1, $LEFT=2, $RIGHT=3;
-	
+
 	public $usePatientId;
 	public $usePatientBarcode;
 	public $usePatientSignature;
@@ -1715,7 +1715,7 @@ class ReportConfig
 	public $usePatientRegistrationDate;
 	public $useViewPatientReport;
 	public $useEnterResults;
-	
+
 	public $useSpecimenId;
 	public $useSpecimenAddlId;
 	public $useDateRecvd;
@@ -1723,7 +1723,7 @@ class ReportConfig
 	public $useReferredTo;
 	public $useDoctor;
 	public $useSpecimenName;
-	
+
 	public $useMeasures;
 	public $useResults;
 	public $useRange;
@@ -1736,13 +1736,13 @@ class ReportConfig
 	public $useClinicalData;
 	public $usePrintConfirm;
 	public $useResultConfirm;
-	
+
 	public $useRequesterName;
 	public $useReferredToHospital;
-	
+
 	public $landscape;
 	public $logoUrl;
-	
+
 	//Appearance
 	public $rowItems;
 	public $showBorder;
@@ -1750,31 +1750,31 @@ class ReportConfig
 	public $showResultBorder;
 	public $resultborderVertical;
 	public $resultborderHorizontal;
-	
-		
-		
+
+
+
 	public static function getObject($record, $lab_config_id)
 	{
 		global $LANG_ARRAY, $LOCAL_PATH;
-		
+
 		if($record == null)
 			return null;
-		
+
 		$report_config = new ReportConfig();
-		
+
 		$report_config->labConfigId = $lab_config_id;
 		$report_config->reportId = $record['report_id'];
 		$report_config->testTypeId = $record['test_type_id'];
-		
+
 		$report_config->rowItems = (int)$record['row_items'];
 		$report_config->showBorder = $record['show_border'];
 		$report_config->patientFields = $record['p_fields'];
-		$report_config->showResultBorder = $record['show_result_border'];		
+		$report_config->showResultBorder = $record['show_result_border'];
 		$report_config->resultborderHorizontal = $record['result_border_horizontal'];
-		$report_config->resultborderVertical = $record['result_border_vertical'];		
-		
-		
-		
+		$report_config->resultborderVertical = $record['result_border_vertical'];
+
+
+
 		switch($report_config->reportId)
 		{
 			case 1:
@@ -1790,20 +1790,20 @@ class ReportConfig
 				$report_config->name = $LANG_ARRAY["reports"]["MENU_DAILYLOGS"];
 				break;
 		}
-		
+
 		$alignment_header=$record['header'];
-		
+
 		if(strpos($alignment_header, "??")!=-1)
-		{	
+		{
 			$split_alignment_header=explode("??",$alignment_header);
 			$report_config->headerText =$split_alignment_header[0];
-			$report_config->alignment_header=$split_alignment_header[1];	
+			$report_config->alignment_header=$split_alignment_header[1];
 		}
 		else
 			$report_config->headerText=$alignment_header;
-		
+
 		$footer_designation=$record['footer'];
-		
+
 		if(strpos($footer_designation, "#")!=-1)
 		{
 			$split= explode("#", $footer_designation);
@@ -1813,21 +1813,21 @@ class ReportConfig
 		else
 		$report_config->footerText = $record['footer'];
 		$report_config->titleText = $record['title'];
-		
+
 		$report_config->logoUrl = $LOCAL_PATH."logos/logo_".$lab_config_id;
 		$report_config->landscape = false;
 		if($record['landscape'] == 1)
 			$report_config->landscape = true;
-		
+
 		$margins_csv = $record['margins'];
 		$report_config->margins = explode(",", $margins_csv);
-		
+
 		$patient_custom_csv = $record['p_custom_fields'];
 		$report_config->patientCustomFields = explode(",", $patient_custom_csv);
-		
+
 		$specimen_custom_csv = $record['s_custom_fields'];
 		$report_config->specimenCustomFields = explode(",", $specimen_custom_csv);
-		
+
 		# Patient main fields
 		$patient_field_list = explode(",", $record['p_fields']);
 		if(!isset($patient_field_list[0]))
@@ -1879,7 +1879,7 @@ class ReportConfig
 			$report_config->useRequesterName = 0;
 		else
 			$report_config->useRequesterName = $patient_field_list[11];
-		
+
 		if(!isset($patient_field_list[12]))
 			$report_config->useReferredToHospital = 0;
 		else
@@ -1892,10 +1892,10 @@ class ReportConfig
 			$report_config->useEnterResults = 0;
 		else
 			$report_config->useEnterResults = $patient_field_list[14];
-		
 
-		
-		
+
+
+
 		# Specimen main fields
 		$specimen_field_list = explode(",", $record['s_fields']);
 		if(!isset($specimen_field_list[0]))
@@ -1926,7 +1926,7 @@ class ReportConfig
 			$report_config->useDoctor = 0;
 		else
 			$report_config->useDoctor = $specimen_field_list[6];
-		
+
 		# Test main fields
 		$test_field_list = explode(",", $record['t_fields']);
 		if(!isset($test_field_list[0]))
@@ -1948,7 +1948,7 @@ class ReportConfig
 		if(!isset($test_field_list[4]))
 			$report_config->useEnteredBy = 0;
 		else
-			$report_config->useEnteredBy = $test_field_list[4];	
+			$report_config->useEnteredBy = $test_field_list[4];
 		if(!isset($test_field_list[5]))
 			$report_config->useVerifiedBy = 0;
 		else
@@ -1977,9 +1977,9 @@ class ReportConfig
 			$report_config->useResultConfirm = 0;
 		else
 			$report_config->useResultConfirm =$test_field_list[11];
-		
+
 		# Return data object
-		return $report_config;		
+		return $report_config;
 	}
 
 	# return a row from report_config with test_type_id!=0
@@ -1997,9 +1997,9 @@ class ReportConfig
 		}
 		$retval = ReportConfig::getObject($record, $lab_config_id);
 		DbUtil::switchRestore($saved_db);
-		return $retval;	
+		return $retval;
 	}
-	
+
     public static function getAllRows($lab_config_id)
 	{
 		global $con;
@@ -2012,7 +2012,7 @@ class ReportConfig
 		// 	$retval[] = ReportConfig::getObject($$value, $lab_config_id);
 		// }
 		// DbUtil::switchRestore($saved_db);
-		return $record;	
+		return $record;
 	}
 
 	public static function getById($lab_config_id, $report_id)
@@ -2025,23 +2025,23 @@ class ReportConfig
 		$record = query_associative_one($query_string);
 		$retval = ReportConfig::getObject($record, $lab_config_id);
 		DbUtil::switchRestore($saved_db);
-		return $retval;		
+		return $retval;
 	}
-	
+
 	public static function getByTestTypeId($lab_config_id, $test_type_id)
 	{
 		global $con;
 		$lab_config_id = mysql_real_escape_string($lab_config_id);
-		
+
 		$reflFunc = new ReflectionFunction('mysql_real_escape_string');
-		
+
 		$test_type_id = mysql_real_escape_string($test_type_id);
 		$saved_db = DbUtil::switchToLabConfig($lab_config_id);
 		$query_string = "SELECT * FROM report_config WHERE test_type_id=$test_type_id LIMIT 1";
 		$record = query_associative_one($query_string);
 		$retval = ReportConfig::getObject($record, $lab_config_id);
 		DbUtil::switchRestore($saved_db);
-		return $retval;		
+		return $retval;
 	}
 
 	public static function updatePfieldsToDb(
@@ -2059,14 +2059,14 @@ class ReportConfig
 		DbUtil::switchRestore($saved_db);
 
 	}
-	
+
 	public static function updateToDb(
-		$report_config, 
-		$margin_csv, 
-		$patient_main_field_map, 
-		$specimen_main_field_map, 
-		$test_main_field_map, 
-		$patient_custom_field_map, 
+		$report_config,
+		$margin_csv,
+		$patient_main_field_map,
+		$specimen_main_field_map,
+		$test_main_field_map,
+		$patient_custom_field_map,
 		$specimen_custom_field_map
 		//$labtitle_custom_field_map
 	)
@@ -2080,7 +2080,7 @@ class ReportConfig
 		$landscape_flag = 0;
 		if($report_config->landscape === true)
 			$landscape_flag = 1;
-		$query_string = 
+		$query_string =
 			"SELECT report_id FROM report_config WHERE report_id=$report_config->reportId LIMIT 1";
 		$record = query_associative_one($query_string);
 		$footer_designation=implode("#", array($report_config->footerText, $report_config->designation));
@@ -2091,7 +2091,7 @@ class ReportConfig
 			$record = query_associative_one($query_string);
 			$reportId = $record['reportId'];
 			$reportId += 1;
-			$query_string = 
+			$query_string =
 				"INSERT INTO report_config (".
 					"report_id, test_type_id, header, footer, title, landscape, margins, ".
 					"p_fields, s_fields, t_fields, p_custom_fields, s_custom_fields , row_items,show_border,show_result_border ".
@@ -2104,7 +2104,7 @@ class ReportConfig
 		else
 		{
 			# Update existing entry
-			$query_string = 
+			$query_string =
 				"UPDATE report_config SET ".
 				"header='$report_config->headerText', ".
 				"footer='$footer_designation', ".
@@ -2124,7 +2124,7 @@ class ReportConfig
 				"WHERE report_id=$report_config->reportId";
 			query_update($query_string);
 		}
-		
+
 		DbUtil::switchRestore($saved_db);
 	}
 }
@@ -2141,7 +2141,7 @@ class TestType
 	public $prevalenceThreshold;
 	public $targetTat;
     public $is_report_enabled;
-	
+
 	public static function getObject($record)
 	{
 		# Converts a test_type record in DB into a TestType object
@@ -2167,7 +2167,7 @@ class TestType
 		}
 		return $test_type;
 	}
-	
+
 	public function getName()
 	{
 		global $CATALOG_TRANSLATION;
@@ -2180,7 +2180,7 @@ class TestType
 			return $this->name;
 		}
 	}
-	
+
 	public function getDescription()
 	{
 		if(trim($this->description) == "" || $this->description == null)
@@ -2188,7 +2188,7 @@ class TestType
 		else
 			return trim($this->description);
 	}
-	
+
 	public function getClinicalData()
 	{
 		if(trim($this->clinical_data) == "" || $this->clinical_data == null)
@@ -2196,18 +2196,18 @@ class TestType
 		else
 			return trim($this->clinical_data);
 	}
-	
+
 	public static function getByCategory($cat_code)
 	{
 		# Returns all test types belonging to a partciular category (aka section)
 		if($cat_code == null || $cat_code == "")
 			return null;
 		$retval = array();
-		$query_string = 
+		$query_string =
 			"SELECT * FROM test_type ".
 			"WHERE test_category_id=$cat_code AND disabled=0";
 		//$saved_db = DbUtil::switchToLabConfigRevamp();
-		$saved_db = DbUtil::switchToLabConfig($_SESSION['lab_config_id']);	
+		$saved_db = DbUtil::switchToLabConfig($_SESSION['lab_config_id']);
 		$resultset = query_associative_all($query_string);
 		foreach($resultset as $record)
 		{
@@ -2216,14 +2216,14 @@ class TestType
 		DbUtil::switchRestore($saved_db);
 		return $retval;
 	}
-	
+
 	public static function getById($test_type_id)
 	{
 		# Returns test type record in DB
 		global $con;
 		$test_type_id = mysql_real_escape_string($test_type_id, $con);
 		//$saved_db = DbUtil::switchToLabConfigRevamp();
-		$saved_db = DbUtil::switchToLabConfig($_SESSION['lab_config_id']);	
+		$saved_db = DbUtil::switchToLabConfig($_SESSION['lab_config_id']);
 		$query_string =
 			"SELECT * FROM test_type WHERE test_type_id=$test_type_id LIMIT 1";
 		$record = query_associative_one($query_string);
@@ -2271,12 +2271,12 @@ return $retval;
             query_update($query_string);
         }
     }
-	
+
 	public function getMeasures()
 	{
 		# Returns list of measures included in a test type
 		$saved_db = DbUtil::switchToLabConfigRevamp();
-		$query_string = 
+		$query_string =
 			"SELECT measure_id FROM test_type_measure ".
 			"WHERE test_type_id=$this->testTypeId ";
                         //"ORDER BY ts";
@@ -2292,12 +2292,12 @@ return $retval;
 		DbUtil::switchRestore($saved_db);
 		return $retval;
 	}
-	
+
 	public function getMeasureIds()
 	{
 		# Returns list of measure IDs included in a test type
 		$saved_db = DbUtil::switchToLabConfigRevamp();
-		$query_string = 
+		$query_string =
 			"SELECT measure_id FROM test_type_measure ".
 			"WHERE test_type_id=$this->testTypeId ";
 		$resultset = query_associative_all($query_string);
@@ -2309,7 +2309,7 @@ return $retval;
 		DbUtil::switchRestore($saved_db);
 		return $retval;
 	}
-	
+
 	public static function deleteById($test_type_id)
 	{
 		# Deletes test type from database
@@ -2317,7 +2317,7 @@ return $retval;
 		global $con;
 		$test_type_id = mysql_real_escape_string($test_type_id, $con);
 		$saved_db = DbUtil::switchToLabConfigRevamp();
-		$query_string = 
+		$query_string =
 			"DELETE FROM lab_config_test_type WHERE test_type_id=$test_type_id";
 		query_blind($query_string);
 		# 2. Delete entries from specimen_test
@@ -2330,27 +2330,27 @@ return $retval;
 		query_blind($query_string);
 		DbUtil::switchRestore($saved_db);
 	}
-	
+
 	public function toHidePatientName($test_type_id) {
 		global $con;
 		$test_type_id = mysql_real_escape_string($test_type_id, $con);
-		$query_string = 
+		$query_string =
 			"SELECT hide_patient_name FROM test_type WHERE test_type_id=$test_type_id";
 		$record = query_associative_one($query_string);
 		$retval = $record['hide_patient_name'];
 		return $retval;
 	}
-	
+
 	public static function getNameById($id)
 	{
 		$query_string = "SELECT name FROM `test_type` WHERE `test_type_id` = $id";
-		
+
 		$saved_db = DbUtil::switchToLabConfig($_SESSION['lab_config_id']);
 
 		$retVal = query_associative_one($query_string);
 
 		DbUtil::switchRestore($saved_db);
-		
+
 		return $retVal['name'];
 	}
 }
@@ -2360,32 +2360,32 @@ class SpecimenType
 	public $specimenTypeId;
 	public $name;
 	public $description;
-	
+
 	public static function getObject($record)
 	{
 		if($record == null)
 			return null;
-			
+
 		$specimen_type = new SpecimenType();
-		
+
 		if(isset($record['specimen_type_id']))
 			$specimen_type->specimenTypeId = $record['specimen_type_id'];
 		else
 			$specimen_type->specimenTypeId = null;
-		
+
 		if(isset($record['name']))
 			$specimen_type->name = $record['name'];
 		else
 			$specimen_type->name = null;
-			
+
 		if(isset($record['description']))
 			$specimen_type->description = $record['description'];
 		else
 			$specimen_type->description = null;
-			
+
 		return $specimen_type;
 	}
-	
+
 	public function getName()
 	{
 		global $CATALOG_TRANSLATION;
@@ -2398,29 +2398,29 @@ class SpecimenType
 			return $this->name;
 		}
 	}
-	
+
 	public function getDescription()
 	{
 		if(trim($this->description) == "" || $this->description == null)
 			return "-";
-		else 
+		else
 			return trim($this->description);
 	}
-	
+
 	public static function getById($specimen_type_id)
 	{
 		# Returns a specimen type entry fetch by ID
 		global $con;
 		$specimen_type_id = mysql_real_escape_string($specimen_type_id, $con);
 		$saved_db = DbUtil::switchToLabConfigRevamp();
-		$query_string = 
+		$query_string =
 			"SELECT * FROM specimen_type ".
 			"WHERE specimen_type_id=$specimen_type_id";
 		$record = query_associative_one($query_string);
 		DbUtil::switchRestore($saved_db);
 		return SpecimenType::getObject($record);
 	}
-	
+
 	public static function deleteById($specimen_type_id)
 	{
 		# Deletes specimen type from database
@@ -2428,7 +2428,7 @@ class SpecimenType
 		global $con;
 		$specimen_type_id = mysql_real_escape_string($specimen_type_id, $con);
 		$saved_db = DbUtil::switchToLabConfigRevamp();
-		$query_string = 
+		$query_string =
 			"DELETE FROM lab_config_specimen_type WHERE specimen_type_id=$specimen_type_id";
 		query_blind($query_string);
 		# 2. Delete entries from specimen_test
@@ -2446,13 +2446,13 @@ class SpecimenType
 class Measure
 {
 	# For each test indicator in 'measure' table
-	
+
 	public $measureId;
 	public $name;
 	public $unit;
 	public $description;
 	public $range;
-	
+
 	public static $RANGE_ERROR = 0;
 	public static $RANGE_OPTIONS = 1;
 	public static $RANGE_NUMERIC = 2;
@@ -2461,10 +2461,10 @@ class Measure
 	//nc40
         public static $RANGE_FREETEXT = 5;
         //-nc40
-        
+
         # nc50
         public static $RANGE_SUBTYPE = 6;
-        
+
 	public static function getObject($record)
 	{
 		# Converts a measure record in DB into a Measure object
@@ -2478,7 +2478,7 @@ class Measure
 		$measure->range = $record['range'];
 		return $measure;
 	}
-	
+
 	public function getName()
 	{
 		global $CATALOG_TRANSLATION;
@@ -2501,10 +2501,10 @@ class Measure
                     else
                     */
 			return $this->name;
-                    
+
 		}
 	}
-	
+
 	public function getRangeType()
 	{
 		if(strpos($this->range, "_") !== false)
@@ -2518,7 +2518,7 @@ class Measure
 		else if(strpos($this->range, "*") !== false)
 		{
 			return Measure::$RANGE_MULTI;
-		}	
+		}
 		else if(strpos($this->range, "/") !== false)
 		{
 			return Measure::$RANGE_OPTIONS;
@@ -2529,13 +2529,13 @@ class Measure
                     return Measure::$RANGE_FREETEXT;
                 }
 		//-nc40
-                
-		else 
+
+		else
 		{
 			return Measure::$RANGE_ERROR;
 		}
 	}
-	
+
         #nc50
         public function checkIfSubmeasure()
         {
@@ -2548,7 +2548,7 @@ class Measure
                     return 0;
                 }
         }
-        
+
         #nc50
         public function truncateSubmeasureTag()
         {
@@ -2559,7 +2559,7 @@ class Measure
             $decName = substr($encName, $subm_end + 2);
             return $decName;
         }
-        
+
         # nc50
         public function getSubmeasureParent()
         {
@@ -2571,7 +2571,7 @@ class Measure
             $parent_int = intval($parent);
             return $parent_int;
         }
-        
+
         #nc50
         public function getSubmeasuresAsObj()
         {
@@ -2583,7 +2583,7 @@ class Measure
 		$saved_db = DbUtil::switchToLabConfig($lab_config_id);
 		$recordset = query_associative_all($query_string);
                 DbUtil::switchRestore($saved_db);
-                foreach( $recordset as $record ) 
+                foreach( $recordset as $record )
                 {
 				$measureName = $record['name'];
                                 $smID = intval($record['measure_id']);
@@ -2596,7 +2596,7 @@ class Measure
 		}
                 return $submeasureList;
         }
-        
+
         public function getSubmeasures()
         {
             $id = $this->measureId;
@@ -2607,7 +2607,7 @@ class Measure
 		$saved_db = DbUtil::switchToLabConfig($lab_config_id);
 		$recordset = query_associative_one($query_string);
                 DbUtil::switchRestore($saved_db);
-                foreach( $recordset as $record ) 
+                foreach( $recordset as $record )
                 {
 				$measureName = $record['name'];
                                 $smID = intval($record['measure_id']);
@@ -2618,11 +2618,11 @@ class Measure
 		}
                 return $submeasureList;
         }
-        
+
 	public function getRangeValues($patient=null)
 	{
 		# Returns range values in a list
-		
+
 		$range_type = $this->getRangeType();
 		$retval = array();
 		switch($range_type)
@@ -2632,7 +2632,7 @@ class Measure
 				$ref_range = null;
 				if($patient != null)
 				{	$ref_range = ReferenceRange::getByAgeAndSex($patient->getAgeNumber(), $patient->sex, $this->measureId, $_SESSION['lab_config_id']);
-				
+
 				}
 				if($ref_range == null)
 					# Fetch from default entry in 'measure' table
@@ -2641,13 +2641,13 @@ class Measure
 					$retval = array($ref_range->rangeLower, $ref_range->rangeUpper);
 				break;
 			case Measure::$RANGE_OPTIONS:
-			
+
 			{
 			$retval = explode("/", $this->range);
-				
+
 				foreach($retval as $key=>$value)
 				{
-				
+
 				$retval[$key]=str_replace("#","/",$value);
 				}
 			break;
@@ -2659,14 +2659,14 @@ class Measure
 				$retval[$key]=str_replace("#","_",$value);
 				}
 				break;
-                                
+
                         case Measure::$RANGE_FREETEXT:
 				$retval = "Free Text Measure Type";
 				break;
 		}
 		return $retval;
 	}
-	
+
 	public function getRangeString($patient=null)
 	{
 		# Returns range in string for printing or displaying
@@ -2698,16 +2698,16 @@ class Measure
 				$retval .= "  ".$this->unit;
 			$retval .= ")";
 		}
-		
+
 		return $range_parts;
-                
+
 	}
-	
+
 	public function getUnits()
 	{
 		return $this->unit;
 	}
-	
+
 	public static function getById($measure_id)
 	{
 		# Returns a test measure by ID
@@ -2719,25 +2719,25 @@ class Measure
 		$saved_db = DbUtil::switchToLabConfigRevamp();
 		$record = query_associative_one($query_string);
 		DbUtil::switchRestore($saved_db);
-		return Measure::getObject($record);		
+		return Measure::getObject($record);
 	}
-	
+
 	public function updateToDb()
 	{
 		# Updates an existing measure entry in DB
 		$saved_db = DbUtil::switchToLabConfigRevamp();
-		$query_string = 
+		$query_string =
 			"UPDATE measure SET name='$this->name', range='$this->range', unit='$this->unit' ".
 			"WHERE measure_id=$this->measureId";
 		query_blind($query_string);
 		DbUtil::switchRestore($saved_db);
 	}
-	
+
 	public function setInterpretation($inter)
 	{
 		# Updates an existing measure entry in DB
 		$saved_db = DbUtil::switchToLabConfigRevamp();
-		$query_string = 
+		$query_string =
 			"UPDATE measure SET description='$inter'".
 			"WHERE measure_id=$this->measureId";
 		query_blind($query_string);
@@ -2773,11 +2773,11 @@ class Measure
 						}else
 							{
 							//update
-						$query_string = 
+						$query_string =
 						"UPDATE numeric_interpretation SET range_u=$range_u_list[$count], range_l=$range_l_list[$count], age_u=$age_u_list[$count], age_l=$age_l_list[$count], gender='$gender_list[$count]' , description='$remarks_list[$count]' ".
 						"WHERE id=$id_list[$count]";
 						query_update($query_string);
-						
+
 						}
 				}else
 					{
@@ -2785,13 +2785,13 @@ class Measure
 			"VALUES($range_u_list[$count],$range_l_list[$count],$age_u_list[$count],$age_l_list[$count],'$gender_list[$count]','$remarks_list[$count]',$this->measureId)";
 			query_insert_one($query_string);
 				}
-		
+
 		$count++;
 		}
 	}
 	DbUtil::switchRestore($saved_db);
 	}
-	
+
 	public function getNumericInterpretation()
 	{
 	$saved_db = DbUtil::switchToLabConfigRevamp();
@@ -2812,7 +2812,7 @@ class Measure
 				$measure_id=$record['measure_id'];
 				$retval[] =array($range_l,$range_u,$age_l,$age_u,$gender,$description,$id,$measure_id);
 			}
-			
+
 		}else
 			{
 		//get interpretation ka loop
@@ -2820,18 +2820,18 @@ class Measure
 	DbUtil::switchRestore($saved_db);
 	return $retval;
 	}
-	
+
 	public function addToDb()
 	{
 		# Updates an existing measure entry in DB
 		$saved_db = DbUtil::switchToLabConfigRevamp();
-		$query_string = 
+		$query_string =
 			"INSERT INTO measure (`name`, `range`, unit) ".
 			"VALUES ('$this->name', '$this->range', '$this->unit')".
 		query_insert_one($query_string);
 		DbUtil::switchRestore($saved_db);
 	}
-	
+
 	public function getReferenceRanges($lab_config_id)
 	{
 		# Fetches reference ranges from database for this measure
@@ -2847,18 +2847,18 @@ class Measure
 			{
 				$retval[] = ReferenceRange::getObject($record);
 			}
-		}	
+		}
 			DbUtil::switchRestore($saved_db);
 			return $retval;
 	}
-	
+
 	public function getInterpretation()
-	{	
+	{
 		$retval= array();
 		$numeric_description=array();
 		if(trim($this->description) == "" || $this->description == null)
 			return $retval;
-		else 
+		else
 		{
 		$description=substr(($this->description),2);
 		if(strpos($description,"##")===false)
@@ -2866,10 +2866,10 @@ class Measure
 		else
 		$retval=explode("##",$description);
 		}
-		
+
 		return $retval;
 	}
-	
+
 	public function getDescription()
 	{
 		if(trim($this->description) == "" || $this->description == null)
@@ -2893,7 +2893,7 @@ class Patient
 	public $createdBy; # user ID who registered this patient
 	public $hashValue; # hash value for this patient (based on name, dob, sex)
 	public $regDate;
-	
+
 	public $specimenCount;
 	public static function getObject($record)
 	{
@@ -2910,7 +2910,7 @@ class Patient
 		$date_parts = explode(" ", date($record['ts']));
 		$date_parts_1=explode("-",$date_parts[0]);
 		$patient->regDate=$date_parts_1[2]."-".$date_parts_1[1]."-".$date_parts_1[0];
-		
+
 		$patient->specimenCount = 0;
 		$args = func_get_args();
 		if(func_num_args() ==1){
@@ -2918,7 +2918,7 @@ class Patient
 		} else {
 			$patient->specimenCount = $args[1];
 		}
-		
+
 		if(isset($record['partial_dob']))
 			$patient->partialDob = $record['partial_dob'];
 		else
@@ -2937,13 +2937,13 @@ class Patient
 			$patient->hashValue = null;
 		return $patient;
 	}
-	
+
 	public static function checkNameExists($name)
 	{
 		# Checks if the given patient name (or similar match) already exists
 		global $con;
 		$name = mysql_real_escape_string($name, $con);
-		$query_string = 
+		$query_string =
 			"SELECT COUNT(patient_id) AS val FROM patient WHERE name LIKE '%$name%'";
 		$resultset = query_associative_one($query_string);
 		if($resultset == null || $resultset['val'] == 0)
@@ -2951,7 +2951,7 @@ class Patient
 		else
 			return true;
 	}
-	
+
 	public function getName()
 	{
 		if(trim($this->name) == "")
@@ -2959,7 +2959,7 @@ class Patient
 		else
 			return $this->name;
 	}
-	
+
 	public function getAddlId()
 	{
 		if($this->addlId == "")
@@ -2975,7 +2975,7 @@ class Patient
 		else
 			return $this->regDate;
 	}
-	
+
 	public function getAssociatedTests() {
 		if( $this->patientId == "" )
 			return " - ";
@@ -2992,7 +2992,7 @@ class Patient
 			return $result;
 		}
 	}
-	
+
 	public function getAge()
 	{
 		# Returns patient age value
@@ -3003,7 +3003,7 @@ class Patient
 				# DoB present in patient record
 				return DateLib::dobToAge($this->dob);
 			}
-			else 
+			else
 			{	$age_value=-1*$this->age;
 				if($age_value>100){
 					$age_value=200-$age_value;
@@ -3038,7 +3038,7 @@ class Patient
 			return DateLib::dobToAge($approx_dob);
 		}
 	}
-	
+
 	public function getAgeNumber()
 	{
 		# Returns patient age value (numeric part alone)
@@ -3054,7 +3054,7 @@ class Patient
 					$this->age=200+$this->age;
 				else if($this->age<0)
 					$this->age=-1*$this->age;
-			
+
 				return $this->age;
 			}
 		}
@@ -3075,7 +3075,7 @@ class Patient
 			return DateLib::dobToAgeNumber($approx_dob);
 		}
 	}
-	
+
 	public function getDob()
 	{
 		# Returns patient dob value
@@ -3092,13 +3092,13 @@ class Patient
 			return DateLib::mysqlToString($this->dob);
 		}
 	}
-	
+
 	public static function getByAddDate($date)
 	{
 		# Returns all patient records added on that date
 		global $con;
 		$date = mysql_real_escape_string($date, $con);
-		$query_string = 
+		$query_string =
 			"SELECT * FROM patient ".
 			"WHERE ts LIKE '%$date%' ORDER BY patient_id";
 		$resultset = query_associative_all($query_string);
@@ -3107,11 +3107,11 @@ class Patient
 			$retval[] = Patient::getObject($record);
 		return $retval;
 	}
-	
+
 	public static function getByAddDateRange($date_from, $date_to)
 	{
 		# Returns all patient records added on that date range
-		$query_string = 
+		$query_string =
 			"SELECT * FROM patient ".
 			"WHERE UNIX_TIMESTAMP(ts) >= UNIX_TIMESTAMP('$date_from 00:00:00') ".
 			"AND UNIX_TIMESTAMP(ts) <= UNIX_TIMESTAMP('$date_to 23:59:59') ".
@@ -3122,7 +3122,7 @@ class Patient
 			$retval[] = Patient::getObject($record);
 		return $retval;
 	}
-	
+
 	public static function getByRegDateRange($date_from , $date_to)
 	{
 	$query_string =
@@ -3139,8 +3139,8 @@ class Patient
 				$record_p[]=Patient::getObject($record_each);
 				}
 			}
-		return $record_p;	
-	
+		return $record_p;
+
 	}
 
 	public static function getReportedByRegDateRange($date_from , $date_to, $lab_section)
@@ -3179,13 +3179,13 @@ class Patient
 			"SELECT DISTINCT patient_id FROM specimen , test ".
 			"WHERE date_collected BETWEEN '$date_from' AND '$date_to' ".
 			"AND result!='$emp' ".
-			"AND specimen.specimen_id=test.specimen_id ".$labsecwise_addon." AND patient_id 
+			"AND specimen.specimen_id=test.specimen_id ".$labsecwise_addon." AND patient_id
 						 NOT IN
 			(SELECT DISTINCT patient_id FROM specimen , test ".
 						"WHERE date_collected BETWEEN '$date_from' AND '$date_to' ".
 						"AND result='$emp' ".
 						"AND specimen.specimen_id=test.specimen_id)".$labsecwise_addon;
-			
+
 		}
 		//;
 		$resultset = query_associative_all($query_string);
@@ -3201,18 +3201,18 @@ class Patient
 			}
 		}
 		//$unreportedList = self::getUnReportedByRegDateRange($date_from, $date_to);
-		return $record_p;	
-	
+		return $record_p;
+
 	}
-	
-	
+
+
 	public static function getPatientsAndSpecimenCountByRegDateRange($date_from , $date_to)
 	{
 		$query_string =
-		"SELECT patient_id as patientId, count(*) as specimenCount FROM specimen ". 
+		"SELECT patient_id as patientId, count(*) as specimenCount FROM specimen ".
 		"WHERE date_collected BETWEEN '$date_from' AND '$date_to'".
  		"group by patientId order by SpecimenCount desc";
-		
+
 		$resultset = query_associative_all($query_string);
 		$retval = array();
 		$record_p=array();
@@ -3237,9 +3237,9 @@ class Patient
 		}
 		//$unreportedList = self::getUnReportedByRegDateRange($date_from, $date_to);
 		return $record_p;
-	
+
 	}
-	
+
 
 	public static function getUnReportedByRegDateRange($date_from , $date_to, $lab_section)
 	{
@@ -3287,19 +3287,19 @@ class Patient
 		return $record_p;
 	}
 
-	
+
 	public static function getById($patient_id)
 	{
 		# Returns patient record by ID
 		global $con;
 		$patient_id = mysql_real_escape_string($patient_id, $con);
 		$query_string = "SELECT * FROM patient WHERE patient_id=$patient_id";
-		$saved_db = DbUtil::switchToLabConfig($_SESSION['lab_config_id']);	
+		$saved_db = DbUtil::switchToLabConfig($_SESSION['lab_config_id']);
 		$record = query_associative_one($query_string);
 		DbUtil::switchRestore($saved_db);
 		return Patient::getObject($record);
 	}
-	
+
 	public function getSurrogateId()
 	{
 		if($this->surrogateId == null || trim($this->surrogateId) == "")
@@ -3307,7 +3307,7 @@ class Patient
 		else
 			return $this->surrogateId;
 	}
-	
+
 	public function getSpecimenCount()
 	{
 		if($this->specimenCount == null || trim($this->specimenCount) == "")
@@ -3315,7 +3315,7 @@ class Patient
 		else
 			return $this->specimenCount;
 	}
-	
+
 	public function getDailyNum()
 	{
 		# Returns daily number ("patient number")
@@ -3325,7 +3325,7 @@ class Patient
 			"WHERE s.patient_id=p.patient_id ".
 			"AND p.patient_id=$this->patientId ".
 			"ORDER BY s.date_collected DESC";
-		$record = query_associative_one($query_string);		
+		$record = query_associative_one($query_string);
 		$retval = "";
 		if($record == null || trim($record['daily_num']) == "")
 			$retval = "-";
@@ -3341,7 +3341,7 @@ class Patient
 		$sex_part = strtolower($this->sex);
 		$dob_part = "";
 		if($this->partialDob != null && trim($this->partialDob) != "")
-		{	
+		{
 			# Determine unix timestamp based on partial (approximate) date of birth
 			$approx_dob = "";
 			if(strpos($this->partialDob, "-") === false)
@@ -3369,30 +3369,30 @@ class Patient
 		$retval = sha1($hash_input);
 		return $retval;
 	}
-	
+
 	public function getHashValue()
 	{
 		$retval = $this->hashValue;
 		return $retval;
 	}
-	
+
 	public function getSex()
 	{
 	$sex=$this->sex;
-	
+
 	return $sex;
 	}
-	
+
 	public function setHashValue($hash_value)
 	{
 		if($hash_value == null || trim($hash_value) == "")
 			return;
-		$query_string = 
+		$query_string =
 			"UPDATE patient SET hash_value='$hash_value' ".
 			"WHERE patient_id=$this->patientId";
 		query_update($query_string);
 	}
-	
+
 	#updates patients ordered fields on reports
 	public static function updateReportOrder($p_fields, $o_fields)
 	{
@@ -3408,14 +3408,14 @@ class Patient
 		else
 		{
 			$query_string="update patient_report_fields_order set p_fields='$p_fields',o_fields='$o_fields'";
-			
+
 		}
-		
+
 		query_update($query_string);
-		
+
 		DbUtil::switchRestore($saved_db);
 	}
-	
+
 	public static function getReportfieldsOrder()
 	{
 		$query_string ="select * from patient_report_fields_order limit 1";
@@ -3445,16 +3445,16 @@ class Specimen
 	public $referredToName;
 	public $dailyNum;
     public $site_id;
-	
+
 	public $referredFromName;
-	
+
 	public static $STATUS_PENDING = 0;
 	public static $STATUS_DONE = 1;
 	public static $STATUS_REFERRED = 2;
 	public static $STATUS_TOVERIFY = 3;
 	public static $STATUS_REPORTED = 4;
 	public static $STATUS_RETURNED = 5;
-	
+
 	public static function getObject($record)
 	{
 		# Converts a specimen record in DB into a Specimen object
@@ -3502,7 +3502,7 @@ class Specimen
 			{
 			$specimen->doctor = $record['doctor'];
 			}
-			
+
 		else
 			$specimen->doctor = null;
 		if(isset($record['date_reported']))
@@ -3513,12 +3513,12 @@ class Specimen
 			$specimen->referredToName = $record['referred_to_name'];
 		else
 			$specimen->referredToName = null;
-		
+
 		if(isset($record['referred_from_name']))
 			$specimen->referredFromName = $record['referred_from_name'];
 		else
 			$specimen->referredFromName = null;
-		
+
 		if(isset($record['daily_num']))
 			$specimen->dailyNum = $record['daily_num'];
 		else
@@ -3532,7 +3532,7 @@ class Specimen
         }
 		return $specimen;
 	}
-	
+
 	public static function getById($specimen_id)
 	{
 		global $con;
@@ -3541,7 +3541,7 @@ class Specimen
 		$record = query_associative_one($query_string);
 		return Specimen::getObject($record);
 	}
-	
+
 	public function getComments()
 	{
 		if(trim($this->comments) == "" || $this->comments == null)
@@ -3549,7 +3549,7 @@ class Specimen
 		else
 			echo $this->comments;
 	}
-	
+
 	public function getAuxId()
 	{
 		if($this->auxId == "" || $this->auxId == null)
@@ -3557,7 +3557,7 @@ class Specimen
 		else
 			echo $this->auxId;
 	}
-	
+
 	public function getStatus()
 	{
 		switch($this->statusCodeId)
@@ -3579,7 +3579,7 @@ class Specimen
 				break;
 		}
 	}
-	
+
 	public function getReportTo()
 	{
 		if($this->reportTo == null)
@@ -3590,7 +3590,7 @@ class Specimen
 			return LangUtil::$generalTerms['DOCTOR'];
 		return trim($this->doctor);
 	}
-	
+
 	public function isReported()
 	{
 		if(($this->dateReported != null || trim($this->dateReported) != ""))
@@ -3598,7 +3598,7 @@ class Specimen
 		else
 			return false;
 	}
-	
+
 	public function getDateReported()
 	{
 		if($this->dateReported == null || $this->dateReported == "")
@@ -3609,21 +3609,21 @@ class Specimen
 			return DateLib::mysqlToString($date_parts[0])." ".$date_parts[1];
 		}
 	}
-	
+
 	public function setDateReported($date_reported)
 	{
 		# Sets value for date_reported
 		if($date_reported == null)
 			return;
-		$query_string = 
+		$query_string =
 			"UPDATE specimen SET date_reported='$date_reported' WHERE specimen_id=".$this->specimenId;
 		query_blind($query_string);
 	}
-	
+
 	public static function getUnreported()
 	{
 		# Returns all test results that have been entered but not reported
-		$query_string = 
+		$query_string =
 			"SELECT sp.* FROM specimen sp ".
 			"WHERE sp.report_to <> '' ".
 			"AND sp.date_reported IS NULL ".
@@ -3642,19 +3642,19 @@ class Specimen
 		}
 		return $retval;
 	}
-	
+
 	public static function markAsReported($specimen_id, $timestamp)
 	{
 		# Marks a given specimen as reported as sets 'date_reported'
 		global $con;
 		$specimen_id = mysql_real_escape_string($specimen_id, $con);
-		$query_string = 
+		$query_string =
 			"UPDATE specimen ".
 			"SET date_reported='$timestamp' ".
 			"WHERE specimen_id=$specimen_id";
 		query_blind($query_string);
 	}
-	
+
 	public function getTypeName()
 	{
 		$specimen_type = SpecimenType::getById($this->specimenTypeId);
@@ -3662,19 +3662,19 @@ class Specimen
 			return LangUtil::$generalTerms['NOTKNOWN'];
 		return $specimen_type->getName();
 	}
-	
+
 	public function getSessionNum()
 	{
 		if(trim($this->sessionNum) == "" || $this->sessionNum == null)
 			return " -  ";
-		else 
+		else
 			return trim($this->sessionNum);
 	}
-	
+
 	public function getTestNames()
 	{
 		$query_string = "SELECT test_type_id FROM test WHERE specimen_id=$this->specimenId";
-		$saved_db = DbUtil::switchToLabConfig($_SESSION['lab_config_id']);	
+		$saved_db = DbUtil::switchToLabConfig($_SESSION['lab_config_id']);
 		$resultset = query_associative_all($query_string);
 		DbUtil::switchRestore($saved_db);
 		$retval = "";
@@ -3692,7 +3692,7 @@ class Specimen
 		}
 		return $retval;
 	}
-	
+
 	public function getDailyNum()
 	{
 		if(trim($this->dailyNum) == "" || $this->dailyNum == 0)
@@ -3700,14 +3700,14 @@ class Specimen
 		$dnum_parts = explode("-", $this->dailyNum);
 		return $dnum_parts[1];
 	}
-	
+
 	public function getDailyNumFull()
 	{
 		if(trim($this->dailyNum) == "" || $this->dailyNum == 0)
 			return "-";
 		return $this->dailyNum;
 	}
-	
+
 	public function getDailyNumExpand()
 	{
 		if(trim($this->dailyNum) == "" || $this->dailyNum == 0)
@@ -3719,31 +3719,31 @@ class Specimen
 			return $this->dailyNum;
 		else
 			return $dnum_parts[1];
-			
+
 	}
-	
+
 	public function getReferredToName()
 	{
 		if($this->referredToName == null || trim($this->referredToName) == "")
 			return "-";
 		return trim($this->referredToName);
 	}
-	
+
 	public function getReferredFromName()
 	{
 		if($this->referredFromName == null || trim($this->referredFromName) == "")
 			return "-";
 		return trim($this->referredFromName);
 	}
-	
+
 	public function getDoctor()
 	{
 		if($this->doctor == "" || $this->doctor == null)
 			return "-";
 		else
 			return $this->doctor;
-			
-			
+
+
 	}
 
 	public static function getSpecimensByDateRange($specimen_type_id, $from, $to)
@@ -3777,62 +3777,62 @@ class Test
 	public $dateVerified;
 	public $timestamp;
 	public $ts;
-	
+
 	public static function getObject($record)
 	{
 		# Converts a test record in DB into a Test object
 		if($record == null)
 			return null;
 		$test = new Test();
-		
+
 		if(isset($record['test_id']))
 			$test->testId = $record['test_id'];
 		else
 			$test->testId = null;
-			
+
 		if(isset($record['test_type_id']))
 			$test->testTypeId = $record['test_type_id'];
 		else
 			$test->testTypeId = null;
-			
+
 		if(isset($record['specimen_id']))
 			$test->specimenId = $record['specimen_id'];
 		else
 			$test->specimenId = null;
-		
+
 		if(isset($record['result']))
 			$test->result = $record['result'];
 		else
 			$test->result = null;
-		
+
 		if(isset($record['comments']))
 			$test->comments = $record['comments'];
 		else
 			$test->comments = null;
-			
+
 		if(isset($record['user_id']))
 			$test->userId = $record['user_id'];
 		else
 			$test->userId = null;
-			
+
 		if(isset($record['verified_by']))
 			$test->verifiedBy = $record['verified_by'];
 		else
 			$test->verifiedBy = null;
-			
+
 		if(isset($record['date_verified']))
 			$test->dateVerified = $record['date_verified'];
 		else
 			$test->dateVerified = null;
-		
+
 		if(isset($record['ts']))
 			$test->timestamp = $record['ts'];
 		else
 			$test->timestamp = null;
-		
+
 		return $test;
 	}
-	
+
 	public static function getTestBySpecimenID($sid)
 	{
 		# Returns a test result entry by test_id field
@@ -3846,7 +3846,7 @@ class Test
 		$record = query_associative_one($query_string);
 		return Test::getObject($record);
 	}
-	
+
 	public static function getAllTestsBySpecimenId($id)
     {
         $query = "SELECT * FROM test WHERE specimen_id='$id'";
@@ -3859,7 +3859,7 @@ class Test
         }
         return $ret;
     }
-	
+
 	public static function getById($test_id)
 	{
 		# Returns a test result entry by test_id field
@@ -3873,7 +3873,7 @@ class Test
 		$record = query_associative_one($query_string);
 		return Test::getObject($record);
 	}
-	
+
 	public function isPending()
 	{
 		# Checks if test results are pending or not
@@ -3881,7 +3881,7 @@ class Test
 			return true;
 		return false;
 	}
-	
+
 	public function isVerified()
 	{
 		# Checks if test results have been verified by a second technician
@@ -3889,13 +3889,13 @@ class Test
 			return false;
 		return true;
 	}
-	
+
 	public function isReported()
 	{
 		# TODO:
 		return false;
 	}
-	
+
 	public function getEnteredBy()
 	{
 		# Returns username of the technician who entered results
@@ -3907,7 +3907,7 @@ class Test
 			return get_username_by_id($this->userId);
 		}
 	}
-	
+
 	public function getVerifiedBy()
 	{
 		# Returns username of the technician who verified results
@@ -3916,7 +3916,7 @@ class Test
 			return get_username_by_id($this->verifiedBy);
 		return LangUtil::$generalTerms['PENDING_VER'];
 	}
-	
+
 	public function getVerifierPosition()
 	{
 	# Returns username of the technician who verified results
@@ -3925,7 +3925,7 @@ class Test
 		return get_user_position_by_id($this->verifiedBy);
 	return "";
 	}
-	
+
 	public function setVerifiedBy($verified_by)
 	{
 		# Sets verified by flag for given test
@@ -3935,7 +3935,7 @@ class Test
 			"UPDATE test SET verified_by=$verified_by WHERE test_id=".$this->testId;
 		query_blind($query_string);
 	}
-	
+
 	public function addResult($hash_value)
 	{
 		# Enters results for this test
@@ -3943,7 +3943,7 @@ class Test
 		$curent_ts = "";
 		$current_ts = date("Y-m-d H:i:s");
 		$result_field = $this->result.$hash_value;
-		$query_string = 
+		$query_string =
 			"UPDATE `test` SET result='$result_field', ".
 			"comments='$this->comments', ".
 			"user_id=$this->userId, ".
@@ -3955,16 +3955,16 @@ class Test
 		if($specimen_id != "")
 			update_specimen_status($specimen_id);
 	}
-	
+
 	public function getResultWithoutHash()
 	{
 	    global $PATIENT_HASH_LENGTH;
 		if(trim($this->result) == "")
 			# Results not yet entered
 			return "";
-		
+
         #$retval = substr($this->result, 0, -1*$PATIENT_HASH_LENGTH);
-        
+
         if ($retval == '')
             $retval = substr($this->result, 0, -1);
         # nc44
@@ -4006,7 +4006,7 @@ class Test
         $retval = $testt;
 		return $retval;
 	}
-	
+
         public function getResultWithoutHash2()
 	{
 		global $PATIENT_HASH_LENGTH;
@@ -4016,7 +4016,7 @@ class Test
 		$retval = substr($this->result, 0, -1*$PATIENT_HASH_LENGTH);
 		return $retval;
 	}
-        
+
         public function getHashInResult()
 	{
 		global $PATIENT_HASH_LENGTH;
@@ -4032,20 +4032,20 @@ class Test
                 $submeasure_list = array();
                 $comb_measure_list = array();
                // print_r($measure_list);
-                
+
                 foreach($measure_list as $measure)
                 {
-                    
+
                     $submeasure_list = $measure->getSubmeasuresAsObj();
                     //echo "<br>".count($submeasure_list);
                     //print_r($submeasure_list);
                     $submeasure_count = count($submeasure_list);
-                    
+
                     if($measure->checkIfSubmeasure() == 1)
                     {
                         continue;
                     }
-                        
+
                     if($submeasure_count == 0)
                     {
                         array_push($comb_measure_list, $measure);
@@ -4054,7 +4054,7 @@ class Test
                     {
                         array_push($comb_measure_list, $measure);
                         foreach($submeasure_list as $submeasure)
-                           array_push($comb_measure_list, $submeasure); 
+                           array_push($comb_measure_list, $submeasure);
                     }
                 }
                 $measure_list = $comb_measure_list;
@@ -4063,19 +4063,19 @@ class Test
                         if(strpos($curr_measure->name, "\$sub") !== false)
                                                             {
                                                                 $decName = "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;".$curr_measure->truncateSubmeasureTag();
-                                                                
+
                                                             }
                                                             else
                                                             {
                                                                 $decName = $curr_measure->name;
                                                             }
-                                            
-                        
+
+
 			$retval .= "<br>".$decName."<br>";
 		}
 		return $retval;
-	}	
-	
+	}
+
 	public function decodeResult($show_range=false,$add_units=true) {
 
 		# Converts stored result value(s) for showing on front-end
@@ -4097,7 +4097,7 @@ class Test
             {
                 continue;
             }
-                        
+
             if($submeasure_count == 0)
             {
                 array_push($comb_measure_list, $measure);
@@ -4148,7 +4148,7 @@ class Test
                     //echo "$testto<br>$subb<br>";
                     $result_csv = $testt;
                     if(strpos($testt, ",") == 0)
-                            $result_csv = substr($testt, 1, strlen($testt)); 
+                            $result_csv = substr($testt, 1, strlen($testt));
                     $result_list = explode(",", $result_csv);
                     //echo "<br>";
                     //print_r($result_list);
@@ -4173,7 +4173,7 @@ class Test
 			if($curr_measure->getRangeType() != Measure::$RANGE_FREETEXT)
                         {
                             if(isset($result_list[$i]))
-                            {    
+                            {
                                 //echo "Num->".$i;
                                     # If matching result value exists (e.g. after a new measure was added to this test type)
                                     if(count($measure_list) == 1)
@@ -4210,14 +4210,14 @@ class Test
                                          if(strpos($curr_measure->name, "\$sub") !== false)
                                                             {
                                                                 $decName = "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;".$curr_measure->truncateSubmeasureTag();
-                                                                
+
                                                             }
                                                             else
                                                             {
                                                                 $decName = $curr_measure->name;
                                                             }
                                             $retval .= "<br>".$decName.":"."&nbsp;";
-                                        
+
                                             if($curr_measure->getRangeType() == Measure::$RANGE_AUTOCOMPLETE)
                                             {
                                                     $result_string = "";
@@ -4255,7 +4255,7 @@ class Test
                                             if(strpos($curr_measure->name, "\$sub") !== false)
                                                             {
                                                                 $decName = "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;".$curr_measure->truncateSubmeasureTag();
-                                                                
+
                                                             }
                                                             else
                                                             {
@@ -4273,14 +4273,14 @@ class Test
 
                             if(count($measure_list) == 1)
                             {
-                                $retval .= "<br>".$ft_result."&nbsp;";   
+                                $retval .= "<br>".$ft_result."&nbsp;";
                             }
                             else
                             {
                                 if(strpos($curr_measure->name, "\$sub") !== false)
                                                             {
                                                                 $decName = "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;".$curr_measure->truncateSubmeasureTag();
-                                                                
+
                                                             }
                                                             else
                                                             {
@@ -4297,13 +4297,13 @@ class Test
                                                 $retval .= "<br>";
                                         }
                             $j++;
-                            
+
                         }$c++;
 		}//end
 		//$retval = str_replace("_",",",$retval); # Replace all underscores with a comma
 		return $retval;
 	}
-	
+
         public function decodeResultWithoutMeasures($show_range=false) {
             # Converts stored result value(s) for showing on front-end
 		# Get measure, unit pairs for this test
@@ -4313,20 +4313,20 @@ class Test
                 $submeasure_list = array();
                 $comb_measure_list = array();
                // print_r($measure_list);
-                
+
                 foreach($measure_list as $measure)
                 {
-                    
+
                     $submeasure_list = $measure->getSubmeasuresAsObj();
                     //echo "<br>".count($submeasure_list);
                     //print_r($submeasure_list);
                     $submeasure_count = count($submeasure_list);
-                    
+
                     if($measure->checkIfSubmeasure() == 1)
                     {
                         continue;
                     }
-                        
+
                     if($submeasure_count == 0)
                     {
                         array_push($comb_measure_list, $measure);
@@ -4335,7 +4335,7 @@ class Test
                     {
                         array_push($comb_measure_list, $measure);
                         foreach($submeasure_list as $submeasure)
-                           array_push($comb_measure_list, $submeasure); 
+                           array_push($comb_measure_list, $submeasure);
                     }
                 }
                 $measure_list = $comb_measure_list;
@@ -4377,7 +4377,7 @@ class Test
                     //echo "$testto<br>$subb<br>";
                     $result_csv = $testt;
                     if(strpos($testt, ",") == 0)
-                            $result_csv = substr($testt, 1, strlen($testt)); 
+                            $result_csv = substr($testt, 1, strlen($testt));
                     $result_list = explode(",", $result_csv);
                     //echo "<br>";
                     //print_r($result_list);
@@ -4402,7 +4402,7 @@ class Test
 			if($curr_measure->getRangeType() != Measure::$RANGE_FREETEXT)
                         {
                             if(isset($result_list[$i]))
-                            {    
+                            {
                                 //echo "Num->".$i;
                                     # If matching result value exists (e.g. after a new measure was added to this test type)
                                     if(count($measure_list) == 1)
@@ -4434,8 +4434,8 @@ class Test
                                     else
                                     {
                                             # Print measure name with each result value
-                                         
-                                        
+
+
                                             if($curr_measure->getRangeType() == Measure::$RANGE_AUTOCOMPLETE)
                                             {
                                                     $result_string = "";
@@ -4467,7 +4467,7 @@ class Test
                                     # Matching result value not found: Show "-"
                                     if(count($measure_list) == 1)
                                     {
-                                            
+
                                     }
                                     $retval .= " - <br>";
                             }
@@ -4479,11 +4479,11 @@ class Test
 
                             if(count($measure_list) == 1)
                             {
-                                $retval .= "<br>".$ft_result."&nbsp;";   
+                                $retval .= "<br>".$ft_result."&nbsp;";
                             }
                             else
                             {
-                                 $retval .= "<br>".$ft_result."&nbsp;"; 
+                                 $retval .= "<br>".$ft_result."&nbsp;";
                             }
                             if($show_range === true)
                                         {
@@ -4494,13 +4494,13 @@ class Test
                                                 $retval .= "<br>";
                                         }
                             $j++;
-                            
+
                         }$c++;
 		}//end
 		//$retval = str_replace("_",",",$retval); # Replace all underscores with a comma
 		return $retval;
         }
-        
+
         /*
 	public function decodeResultWithoutMeasures($show_range=false) {
 		# Converts stored result value(s) for showing on front-end
@@ -4513,7 +4513,7 @@ class Test
 			# Pretty print
 			$curr_measure = $measure_list[$i];
 			if(isset($result_list[$i]))
-			{    
+			{
 				# If matching result value exists (e.g. after a new measure was added to this test type)
 				if(count($measure_list) == 1)
 				{
@@ -4593,7 +4593,7 @@ class Test
 		return $retval;
 	}
 	*/
-        
+
 	public function getComments()
 	{
 		if(trim($this->comments) == "" || $this->comments == null)
@@ -4601,7 +4601,7 @@ class Test
 		else
 			return $this->comments;
 	}
-	
+
 	public static function getByAddDate($date, $test_type_id)
 	{
 		# Returns all test records added on that day
@@ -4619,8 +4619,8 @@ class Test
 			$retval[] = Test::getObject($record);
 		return $retval;
 	}
-        
-	
+
+
 	public function verifyAndUpdate($hash_value)
 	{
 		# Updates changes to DB after verified/corrected result values are submitted
@@ -4636,19 +4636,19 @@ class Test
 		$new_result_value = $this->result.$hash_value;
 		$query_verify = "";
 		if	(
-				$existing_entry->result == $new_result_value && 
+				$existing_entry->result == $new_result_value &&
 				$existing_entry->comments == $this->comments
 			)
 		{
 			# No changes or corrections after verification
-			$query_verify = 
+			$query_verify =
 				"UPDATE test ".
 				"SET verified_by=$this->verifiedBy, ".
 				"date_verified='$this->dateVerified' ".
 				"WHERE test_id=$test_id";
 		}
 		else
-		{	
+		{
 			# Update with corrections and mark as verified
 			$query_verify =
 				"UPDATE test ".
@@ -4661,7 +4661,7 @@ class Test
 		query_blind($query_verify);
 
 	}
-	
+
 	public function getDateVerified()
 	{
 		if($this->dateVerified == null || $this->dateVerified == "")
@@ -4672,7 +4672,7 @@ class Test
 			return DateLib::mysqlToString($date_parts[0])." ".$date_parts[1];
 		}
 	}
-	
+
 	public function getStatus()
 	{
 		if($this->isPending())
@@ -4693,7 +4693,7 @@ class Test
 		$retval = $resultset['date_collected'];
 		return $retval;
 	}
-	
+
 	/* public function getTestBySpecimenIdAndLabSection()
 	{
 		$query_string =
@@ -4704,7 +4704,7 @@ class Test
 		$retval = $resultset['date_collected'];
 		return $retval;
 	} */
-	
+
 	public static function convertArrayOfIdsToObjects($testIds)
 	{
 		$test_objs = array();
@@ -4714,12 +4714,12 @@ class Test
 		}
 		return $test_objs;
 	}
-	
+
 	// Returns the name associated with the test type this is an instance of.
 	public function getTestName()
 	{
 		$id = $this->testTypeId;
-		
+
 		return TestType::getNameById($id);
 	}
 }
@@ -4736,19 +4736,19 @@ class CustomField
 	public static $FIELD_OPTIONS = 3;
 	public static $FIELD_NUMERIC = 4;
 	public static $FIELD_MULTISELECT = 5;
-	
+
 	public static function getObject($record)
 	{
 		# Converts a custom field record in DB into a CustomField object
 		if($record == null)
 			return null;
 		$custom_field = new CustomField();
-		
+
 		if(isset($record['id']))
 			$custom_field->id = $record['id'];
 		else
 			$custom_field->id = null;
-			
+
 		if(isset($record['field_name']))
 		{
 			$name=$record['field_name'];
@@ -4761,20 +4761,20 @@ class CustomField
 		}
 			else
 			$custom_field->fieldName = null;
-			
+
 		if(isset($record['field_options']))
 			$custom_field->fieldOptions = $record['field_options'];
 		else
 			$custom_field->fieldOptions = null;
-			
+
 		if(isset($record['field_type_id']))
 			$custom_field->fieldTypeId = $record['field_type_id'];
 		else
 			$custom_field->fieldTypeId = null;
-			
+
 		return $custom_field;
 	}
-	
+
 	public static function addNew($new_entry, $lab_config_id, $tabletype)
 	{
 		global $con;
@@ -4792,14 +4792,14 @@ class CustomField
 			$table_name = "labtitle_custom_field";
 		else
 			return;
-		$query_string = 
+		$query_string =
 			"INSERT INTO $table_name (field_name, field_options, field_type_id) ".
 			"VALUES ('$new_entry->fieldName', '$new_entry->fieldOptions', $new_entry->fieldTypeId)";
 		$saved_db = DbUtil::switchToLabConfig($lab_config_id);
 		query_insert_one($query_string);
 		DbUtil::switchRestore($saved_db);
 	}
-	
+
 	public function setId($field_id, $lab_config_id, $tabletype)
 	{
 		global $con;
@@ -4825,7 +4825,7 @@ class CustomField
 		$saved_db = DbUtil::switchToLabConfig($lab_config_id);
 		$record = query_associative_one($query_string);
 		DbUtil::switchRestore($saved_db);
-	
+
 	}
 	public static function getById($field_id, $lab_config_id, $tabletype)
 	{
@@ -4850,7 +4850,7 @@ class CustomField
 		DbUtil::switchRestore($saved_db);
 		return CustomField::getObject($record);
 	}
-	
+
 	public static function deleteById($updated_entry, $lab_config_id, $tabletype)
 	{
 		global $con;
@@ -4864,18 +4864,18 @@ class CustomField
 			$table_name = "patient_custom_field";
 		else if($tabletype == 3)
 			$table_name = "labtitle_custom_field";
-		else 
+		else
 			return;
-			
-		$query_string = 
+
+		$query_string =
 			"DELETE FROM $table_name ".
 			"WHERE id=$updated_entry->id ";
-		
+
 		$saved_db = DbUtil::switchToLabConfig($lab_config_id);
 		query_blind($query_string);
 		DbUtil::switchRestore($saved_db);
-			
-	
+
+
 	}
 	public static function updateById($updated_entry, $lab_config_id, $tabletype ,$offset=0)
 	{
@@ -4894,7 +4894,7 @@ class CustomField
 			$table_name = "patient_custom_field";
 		else if($tabletype == 3)
 			$table_name = "labtitle_custom_field";
-		else 
+		else
 			return;
 			if($offset==$updated_entry->id)
 			$new_id=intval($updated_entry->id)*13;
@@ -4906,8 +4906,8 @@ class CustomField
 			$new_id=intval($updated_entry->id)/13;
 			else
 			$new_id=$updated_entry->id;
-			
-		$query_string = 
+
+		$query_string =
 			"UPDATE $table_name ".
 			"SET field_name='$updated_entry->fieldName', ".
 			"id='$new_id', ".
@@ -4918,7 +4918,7 @@ class CustomField
 		query_blind($query_string);
 		DbUtil::switchRestore($saved_db);
 	}
-	
+
 	public function getFieldTypeName()
 	{
 		# Returns a string describing field type of this custom field
@@ -4936,7 +4936,7 @@ class CustomField
 				return LangUtil::$generalTerms['MULTISELECT'];
 		}
 	}
-	
+
 	public function getFieldOptions()
 	{
 		# Returns list of option values for this custom field
@@ -4950,7 +4950,7 @@ class CustomField
 			return $retval;
 		}
 	}
-	
+
 	public function getFieldRange()
 	{
 		# Returns range bound values for this custom field
@@ -4964,8 +4964,8 @@ class CustomField
 			return $retval;
 		}
 	}
-	
-	
+
+
 }
 
 class SpecimenCustomData
@@ -4973,33 +4973,33 @@ class SpecimenCustomData
 	public $fieldId;
 	public $specimenId;
 	public $fieldValue;
-	
+
 	public static function getObject($record)
 	{
 		# Converts a specimen_custom_data record in DB into a SpecimenCustomData object
 		if($record == null)
 			return null;
 		$custom_data = new SpecimenCustomData();
-		
+
 		if(isset($record['field_id']))
 			$custom_data->fieldId = $record['field_id'];
 		else
 			$custom_data->fieldId = null;
-			
+
 		if(isset($record['specimen_id']))
 			$custom_data->specimenId = $record['specimen_id'];
 		else
 			$custom_data->specimenId = null;
-			
+
 		if(isset($record['field_value']))
 			$custom_data->fieldValue = $record['field_value'];
 		else
 			$custom_data->fieldValue = null;
-		
+
 		return $custom_data;
 	}
-	
-	
+
+
 	public function getFieldValueString($lab_config_id, $tabletype)
 	{
 		global $con;
@@ -5067,32 +5067,32 @@ class PatientCustomData
 	public $fieldId;
 	public $patientId;
 	public $fieldValue;
-	
+
 	public static function getObject($record)
 	{
 		# Converts a patient_custom_data record in DB into a PatientCustomData object
 		if($record == null)
 			return null;
 		$custom_data = new PatientCustomData();
-		
+
 		if(isset($record['field_id']))
 			$custom_data->fieldId = $record['field_id'];
 		else
 			$custom_data->fieldId = null;
-			
+
 		if(isset($record['patient_id']))
 			$custom_data->patientId = $record['patient_id'];
 		else
 			$custom_data->patientId = null;
-			
+
 		if(isset($record['field_value']))
 			$custom_data->fieldValue = $record['field_value'];
 		else
 			$custom_data->fieldValue = null;
-		
+
 		return $custom_data;
 	}
-	
+
 	public function getFieldValueString($lab_config_id, $tabletype)
 	{
 		global $con;
@@ -5127,7 +5127,7 @@ class Report
 	public $groupByGender;
 	public $groupByAge;
 	public $ageSlots;
-	
+
 	public static function getObject($record)
 	{
 		# Converts a `report` table record to Report object
@@ -5166,12 +5166,12 @@ class Report
 			$report->ageSlots = null;
 		return $report;
 	}
-	
+
 	public function addToDb()
 	{
 		# Adds a new report configuration to DB
 		$saved_db = DbUtil::switchToGlobal();
-		$query_string = 
+		$query_string =
 			"INSERT INTO report (name, group_by_gender, group_by_age, age_slots) ".
 			"VALUES ('$this->name', $this->groupByGender, $this->groupByAge, '$this->ageSlots')";
 		query_insert_one($query_string);
@@ -5179,7 +5179,7 @@ class Report
 		DbUtil::switchRestore($saved_db);
 		return $new_report_id;
 	}
-	
+
 	public static function getById($report_id)
 	{
 		global $con;
@@ -5191,7 +5191,7 @@ class Report
 		DbUtil::switchRestore($saved_db);
 		return Report::getObject($record);
 	}
-	
+
 	public static function getAllFromDb()
 	{
 		# Returns all report types stored in DB
@@ -5217,7 +5217,7 @@ class DiseaseReport
 	public $groupByAge;
 	public $ageGroups;
 	public $measureGroups;
-	
+
 	public static function getObject($record)
 	{
 		if($record == null)
@@ -5234,7 +5234,7 @@ class DiseaseReport
 			$retval->measureGroups = $record['measure_groups'];
 		return $retval;
 	}
-	
+
 	public function addToDb()
 	{
 		$disease_report = $this;
@@ -5247,7 +5247,7 @@ class DiseaseReport
 			"AND measure_id=$this->measureId";
 		query_blind($query_string);
 		# Add updated entry
-		$query_string = 
+		$query_string =
 			"INSERT INTO report_disease( ".
 				"lab_config_id, ".
 				"test_type_id, ".
@@ -5269,7 +5269,7 @@ class DiseaseReport
 		query_insert_one($query_string);
 		//DbUtil::switchRestore($saved_db);
 	}
-	
+
 	public static function getByKeys($lab_config_id, $test_type_id, $measure_id)
 	{
 		global $con;
@@ -5288,7 +5288,7 @@ class DiseaseReport
 		DbUtil::switchRestore($saved_db);
 		return $retval;
 	}
-	
+
 	public function getAgeGroupAsList()
 	{
 		# Returns the age_group field as a PHP list
@@ -5303,7 +5303,7 @@ class DiseaseReport
 		}
 		return $retval;
 	}
-	
+
 	public function getMeasureGroupAsList()
 	{
 		# Returns the measure_group field as a PHP list
@@ -5324,38 +5324,38 @@ class CustomWorksheet
 {
 	public $id;
 	public $name;
-	
+
 	public $headerText;
 	public $footerText;
 	public $titleText;
 	public $margins;
-	
+
 	public $idFields;
 	public static $OFFSET_PID = 0;
 	public static $OFFSET_DNUM = 1;
 	public static $OFFSET_ADDLID = 2;
-	
+
 	public $patientFields;
 	public $specimenFields;
 	public $testFields;
 	public $patientCustomFields;
 	public $specimenCustomFields;
 	public $userFields;
-	
+
 	public $testTypes;
 	public $columnWidths;
 	public $landscape;
-	
+
 	public static $DEFAULT_WIDTH = 10; # in %age
 	public static $DEFAULT_MARGINS = array(2, 2, 2, 2);
-	
+
 	public static function getObject($record)
 	{
 		if($record == null)
 			return null;
-		
+
 		$worksheet = new CustomWorksheet();
-		
+
 		if(isset($record['id']))
 			$worksheet->id = $record['id'];
 		else
@@ -5376,27 +5376,27 @@ class CustomWorksheet
 			$worksheet->titleText = $record['title'];
 		else
 			$worksheet->titleText = "";
-			
+
 		$worksheet->landscape = false;
 		if(isset($record['landscape']) && $record['landscape'] == 1)
 			$worksheet->landscape = true;
-		
+
 		$margins_csv = $record['margins'];
 		$worksheet->margins = explode(",", $margins_csv);
-		
+
 		$id_fields_csv = $record['id_fields'];
 		if($id_fields_csv == null || trim($id_fields_csv) == "")
 		{
 			$id_fields_csv = "0,0,0";
 		}
 		$worksheet->idFields = explode(",", $id_fields_csv);
-		
+
 		$patient_custom_csv = $record['p_custom'];
 		$worksheet->patientCustomFields = explode(",", $patient_custom_csv);
-		
+
 		$specimen_custom_csv = $record['s_custom'];
 		$worksheet->specimenCustomFields = explode(",", $specimen_custom_csv);
-	
+
 		$query_string =
 			"SELECT test_type_id, measure_id, width FROM worksheet_custom_test WHERE worksheet_id=$worksheet->id ORDER BY test_type_id";
 		$resultset = query_associative_all($query_string);
@@ -5420,9 +5420,9 @@ class CustomWorksheet
 				$worksheet->columnWidths[$test_type_id] = array();
 			$worksheet->columnWidths[$test_type_id][$measure_id] = $width;
 		}
-		
+
 		# Populate list of user-defined fields
-		$query_string = 
+		$query_string =
 			"SELECT name,width,field_id FROM worksheet_custom_userfield WHERE worksheet_id=$worksheet->id ORDER BY name";
 		$resultset = query_associative_all($query_string);
 		$worksheet->userFields = array();
@@ -5434,15 +5434,15 @@ class CustomWorksheet
 			$field_entry = array($field_id, $field_name, $field_width);
 			$worksheet->userFields[] = $field_entry;
 		}
-		
+
 		# TODO:
 		# Populate patient main field maps
 		# Populate specimen main field maps
 		# Populate test main field maps
-		
+
 		return $worksheet;
 	}
-	
+
 	public static function getById($worksheet_id, $lab_config)
 	{
 		global $con;
@@ -5450,14 +5450,14 @@ class CustomWorksheet
 		if($worksheet_id == null || $lab_config == null)
 			return null;
 		$saved_db = DbUtil::switchToLabConfig($lab_config->id);
-		$query_string = 
+		$query_string =
 			"SELECT * FROM worksheet_custom WHERE id=$worksheet_id";
 		$record = query_associative_one($query_string);
 		$retval = CustomWorksheet::getObject($record);
 		DbUtil::switchRestore($saved_db);
 		return $retval;
 	}
-	
+
 	public static function addToDb($worksheet, $lab_config)
 	{
 		if($worksheet == null || $lab_config == null)
@@ -5467,7 +5467,7 @@ class CustomWorksheet
 		$saved_db = DbUtil::switchToLabConfig($lab_config->id);
 		$margins_csv = implode(",", $worksheet->margins);
 		$id_fields_csv = implode(",", $worksheet->idFields);
-		$query_string = 
+		$query_string =
 			"INSERT INTO worksheet_custom (name, header, footer, title, margins, id_fields, p_fields, s_fields, t_fields, p_custom, s_custom) ".
 			"VALUES ('$worksheet->name', '$worksheet->headerText', '$worksheet->footerText', '$worksheet->titleText', '$margins_csv', '$id_fields_csv', '', '', '', '', '')";
 		query_insert_one($query_string);
@@ -5480,17 +5480,17 @@ class CustomWorksheet
 			{
 				$measure_id = $key2;
 				$width = $value2;
-				$query_string = 
+				$query_string =
 					"INSERT INTO worksheet_custom_test (worksheet_id, test_type_id, measure_id, width) ".
 					"VALUES ($worksheet_id, $test_type_id, $measure_id, '$width')";
-				query_insert_one($query_string);				
+				query_insert_one($query_string);
 			}
 		}
 		foreach($worksheet->userFields as $field_entry)
 		{
 			$field_name = $field_entry[1];
 			$field_width = $field_entry[2];
-			$query_string = 
+			$query_string =
 				"INSERT INTO worksheet_custom_userfield (worksheet_id, name, width) ".
 				"VALUES ($worksheet_id, '$field_name', $field_width) ";
 			query_insert_one($query_string);
@@ -5499,8 +5499,8 @@ class CustomWorksheet
 		DbUtil::switchRestore($saved_db);
 		return $worksheet_id;
 	}
-	
-	
+
+
 	public static function updateToDb($worksheet, $lab_config)
 	{
 		if($worksheet == null || $lab_config == null)
@@ -5510,7 +5510,7 @@ class CustomWorksheet
 		$saved_db = DbUtil::switchToLabConfig($lab_config->id);
 		$margins_csv = implode(",", $worksheet->margins);
 		$id_fields_csv = implode(",", $worksheet->idFields);
-		$query_string = 
+		$query_string =
 			"UPDATE worksheet_custom SET ".
 			"name='$worksheet->name', ".
 			"header='$worksheet->headerText', ".
@@ -5532,7 +5532,7 @@ class CustomWorksheet
 			{
 				$measure_id = $key2;
 				$width = $value2;
-				$query_string = 
+				$query_string =
 					"INSERT INTO worksheet_custom_test (worksheet_id, test_type_id, measure_id, width) ".
 					"VALUES ($worksheet->id, $test_type_id, $measure_id, '$width')";
 				query_insert_one($query_string);
@@ -5546,7 +5546,7 @@ class CustomWorksheet
 			if($field_id == 0)
 			{
 				# New user field
-				$query_string = 
+				$query_string =
 					"INSERT INTO worksheet_custom_userfield (worksheet_id, name, width) ".
 					"VALUES ($worksheet->id, '$field_name', $field_width) ";
 				query_insert_one($query_string);
@@ -5554,7 +5554,7 @@ class CustomWorksheet
 			else
 			{
 				# Existing user field to update
-				$query_string = 
+				$query_string =
 					"UPDATE worksheet_custom_userfield ".
 					"SET name='$field_name', width=$field_width ".
 					"WHERE field_id=$field_id";
@@ -5574,7 +5574,7 @@ class ReferenceRange
 	public $sex;
 	public $rangeLower;
 	public $rangeUpper;
-	
+
 	public static function getObject($record)
 	{
 		if($record == null)
@@ -5612,18 +5612,18 @@ class ReferenceRange
 			$reference_range->rangeUpper = null;
 		return $reference_range;
 	}
-	
+
 	public function addToDb($lab_config_id)
 	{
 		# Adds this entry to database
 		$saved_db = DbUtil::switchToLabConfig($lab_config_id);
-		$query_string = 
+		$query_string =
 			"INSERT INTO reference_range (measure_id, age_min, age_max, sex, range_lower, range_upper) ".
 			"VALUES ($this->measureId, '$this->ageMin', '$this->ageMax', '$this->sex', '$this->rangeLower', '$this->rangeUpper')";
 		query_insert_one($query_string);
 		DbUtil::switchRestore($saved_db);
 	}
-	
+
 	public static function deleteByMeasureId($measure_id, $lab_config_id)
 	{
 		# Deletes all entries for the given measure
@@ -5637,7 +5637,7 @@ class ReferenceRange
 		query_delete($query_string);
 		DbUtil::switchRestore($saved_db);
 	}
-	
+
 	public static function getByAgeAndSex($age, $sex, $measure_id, $lab_config_id)
 	{
 		# Fetches the reference range based on supplied age and sex values
@@ -5680,8 +5680,8 @@ class DbUtil
 {
 	public static function switchToGlobal()
 	{
-		
-		# Saves currently selected DB and switches to 
+
+		# Saves currently selected DB and switches to
 		# global/metadata DB instance
 		global $DEBUG;
 		if($DEBUG)
@@ -5696,7 +5696,7 @@ class DbUtil
 	}
 
 	public static function switchToCountry($countryName) {
-		# Saves currently selected DB and switches to 
+		# Saves currently selected DB and switches to
 		# country specific DB instance
 		global $DEBUG;
 		if($DEBUG) {
@@ -5708,7 +5708,7 @@ class DbUtil
 		db_change($dbName);
 		return $saved_db_name;
 	}
-	
+
 	public static function switchToLabConfig($lab_config_id)
 	{
 		# Saves currently selected DB and switches to
@@ -5731,7 +5731,7 @@ class DbUtil
 		db_change($db_name);
 		return $saved_db_name;
 	}
-	
+
 	public static function switchToLabConfigRevamp($lab_config_id=null)
 	{
 		$saved_db_name = db_get_current();
@@ -5745,7 +5745,7 @@ class DbUtil
 		db_change($db_name);
 		return $saved_db_name;
 	}
-	
+
 	public static function switchRestore($db_name)
 	{
 		# Reverts back to saved DB instance
@@ -5771,7 +5771,7 @@ class SessionUtil
 		}
 		return $saved_session;
 	}
-	
+
 	public static function restore($saved_session)
 	{
 		foreach($saved_session as $key=>$value)
@@ -5779,7 +5779,7 @@ class SessionUtil
 			$_SESSION[$key] = $value;
 		}
 	}
-	
+
 	public static function includeIfMissing($include_path, $test_string)
 	{
 		# Includes a php file if found to be not included already
@@ -5804,13 +5804,13 @@ class UILog
 {
     // Name of the file where the message logs will be appended.
 	private $LOGFILENAME;
-	
+
     // Define the separator for the fields. Default is comma (,).
 	private $SEPARATOR;
-        
+
    // hHeaders
 	private $HEADERS;
-        
+
         public $datetime;
         public $id;
         public $info;
@@ -5821,7 +5821,7 @@ class UILog
         public $tag1;
         public $tag2;
         public $tag3;
-        
+
     function UILog($logfilename = '../../local/UILog.csv', $separator = ',') {
                 global $VERSION;
                 $vers = $VERSION;
@@ -5830,8 +5830,8 @@ class UILog
 		$this->LOGFILENAME = $logfilename;
 		$this->SEPARATOR = $separator;
 		$this->HEADERS =
-			'DATETIME' . $this->SEPARATOR . 
-                        'IDENTIFIER' . $this->SEPARATOR . 
+			'DATETIME' . $this->SEPARATOR .
+                        'IDENTIFIER' . $this->SEPARATOR .
 			'INFO' . $this->SEPARATOR .
                         'FILE' . $this->SEPARATOR .
                         'USER' . $this->SEPARATOR .
@@ -5841,7 +5841,7 @@ class UILog
                         'TAG2' . $this->SEPARATOR .
 			'TAG3';
 	}
-        
+
     public function writeUILog()
     {
         global $VERSION;
@@ -5850,27 +5850,27 @@ class UILog
         $this->lab = $_SESSION['lab_config_id'];
         $this->version = $VERSION;
 
-        
-                
-        if (!file_exists($this->LOGFILENAME)) 
+
+
+        if (!file_exists($this->LOGFILENAME))
         {
 		$headers = $this->HEADERS .  "\n";
 	}
-        
+
         $fd = fopen($this->LOGFILENAME, "a");
-        
-        if (@$headers) 
+
+        if (@$headers)
         {
 		fwrite($fd, $headers);
 	}
-        
+
         //$entry = array($datetime,$errorlevel,$tag,$value,$line,$file);
         $entry = array($this->datetime, $this->id, $this->info, $this->file, $this->user, $this->lab, $this->version, $this->tag1, $this->tag2, $this->tag3);
         fputcsv($fd, $entry, $this->SEPARATOR);
 
         fclose($fd);
     }
-    
+
     public function readUILog($vers, $mode = 0, $filename = "")
     {
         $row = -1;
@@ -5886,7 +5886,7 @@ class UILog
         }
         if (($handle = fopen($logfilename, "r")) !== FALSE)
         {
-            while (($data = fgetcsv($handle, ",")) !== FALSE) 
+            while (($data = fgetcsv($handle, ",")) !== FALSE)
             {
                 $row++;
                 if($row == 0)
@@ -5898,7 +5898,7 @@ class UILog
         }
         return $csvdata;
     }
-    
+
     public function getLogsByID($id, $datefrom = NULL, $dateto = NULL)
     {
         $csvdata = apc_fetch('csvdata');
@@ -5923,25 +5923,25 @@ class UserStats
 {
     #Specimen table ts reflect date of specimen/test registration and test table ts reflects date of resut entry
     #Specimen table user_id reflects user who registered the specime/test and test table user_id reflects the user who enetered results
-    
+
     public function getAdminUser($lab_config_id)
     {
         $saved_db = DbUtil::switchToGlobal();
-        $query_string = 
+        $query_string =
                             "SELECT admin_user_id FROM lab_config ".
                             "WHERE lab_config_id = $lab_config_id";
-                        
+
 	$resultset = query_associative_one($query_string);
         //print_r($resultset);
-        $retval = $resultset['admin_user_id'];	
+        $retval = $resultset['admin_user_id'];
 	DbUtil::switchRestore($saved_db);
 	return $retval;
     }
-    
+
     public function getAllUsers($lab_config_id)
     {
         $saved_db = DbUtil::switchToGlobal();
-        $query_string = 
+        $query_string =
 			"SELECT user_id FROM user ".
 			"WHERE lab_config_id = $lab_config_id ".
                         "AND user_id <> ".
@@ -5949,7 +5949,7 @@ class UserStats
                             "SELECT admin_user_id FROM lab_config ".
                             "WHERE lab_config_id = $lab_config_id".
                         " ) ";
-	
+
 	$retval = array();
 	$resultset = query_associative_all($query_string);
         //print_r($resultset);
@@ -5961,109 +5961,109 @@ class UserStats
 	DbUtil::switchRestore($saved_db);
 	return $retval;
     }
-    
+
     public function getTestStats($user_id, $lab_config_id, $date_from, $date_to)
     {
         $saved_db = DbUtil::switchToLabConfig($lab_config_id);
-        $date_from_parts = explode("-", $date_from);		
+        $date_from_parts = explode("-", $date_from);
         $date_to_parts = explode("-", $date_to);
         $date_from_ts = mktime(0, 0, 0, $date_from_parts[1], $date_from_parts[2], $date_from_parts[0]);
         $date_from_ts = date( 'Y-m-d H:i:s', $date_from_ts );
         $date_to_ts=mktime(0, 0, 0, $date_to_parts[1], $date_to_parts[2], $date_to_parts[0]);
         $date_to_ts = date( 'Y-m-d H:i:s', $date_to_ts );
 
-        $query_string = 
+        $query_string =
 				"SELECT COUNT(*) as count_val FROM test ".
 				"WHERE specimen_id IN ( ".
                                 "SELECT specimen_id from specimen ".
                                 "WHERE ts BETWEEN '$date_from_ts' AND '$date_to_ts' ".
 				"AND user_id = $user_id)";
-	
+
 	$resultset = query_associative_one($query_string);
 	$retval = $resultset['count_val'];
         DbUtil::switchRestore($saved_db);
         return $retval;
     }
-    
+
     public function getPatientsStats($user_id, $lab_config_id, $date_from, $date_to)
     {
         $saved_db = DbUtil::switchToLabConfig($lab_config_id);
-        $date_from_parts = explode("-", $date_from);		
+        $date_from_parts = explode("-", $date_from);
         $date_to_parts = explode("-", $date_to);
         $date_from_ts = mktime(0, 0, 0, $date_from_parts[1], $date_from_parts[2], $date_from_parts[0]);
         $date_from_ts = date( 'Y-m-d H:i:s', $date_from_ts );
         $date_to_ts=mktime(0, 0, 0, $date_to_parts[1], $date_to_parts[2], $date_to_parts[0]);
         $date_to_ts = date( 'Y-m-d H:i:s', $date_to_ts );
 
-        $query_string = 
+        $query_string =
 				"SELECT COUNT(*) as count_val FROM patient ".
 				"WHERE ts BETWEEN '$date_from_ts' AND '$date_to_ts' ".
 				"AND created_by = $user_id";
-	
+
 	$resultset = query_associative_one($query_string);
 	$retval = $resultset['count_val'];
         DbUtil::switchRestore($saved_db);
         return $retval;
     }
-    
+
     public function getSpecimenStats($user_id, $lab_config_id, $date_from, $date_to)
     {
         $saved_db = DbUtil::switchToLabConfig($lab_config_id);
-        $date_from_parts = explode("-", $date_from);		
+        $date_from_parts = explode("-", $date_from);
         $date_to_parts = explode("-", $date_to);
         $date_from_ts = mktime(0, 0, 0, $date_from_parts[1], $date_from_parts[2], $date_from_parts[0]);
         $date_from_ts = date( 'Y-m-d H:i:s', $date_from_ts );
         $date_to_ts=mktime(0, 0, 0, $date_to_parts[1], $date_to_parts[2], $date_to_parts[0]);
         $date_to_ts = date( 'Y-m-d H:i:s', $date_to_ts );
 
-        $query_string = 
+        $query_string =
 				"SELECT COUNT(*) as count_val FROM specimen ".
 				"WHERE ts BETWEEN '$date_from_ts' AND '$date_to_ts' ".
 				"AND user_id = $user_id";
-	
+
 	$resultset = query_associative_one($query_string);
 	$retval = $resultset['count_val'];
         DbUtil::switchRestore($saved_db);
         return $retval;
     }
-    
+
     public function getResultStats($user_id, $lab_config_id, $date_from, $date_to)
     {
         $saved_db = DbUtil::switchToLabConfig($lab_config_id);
-        $date_from_parts = explode("-", $date_from);		
+        $date_from_parts = explode("-", $date_from);
         $date_to_parts = explode("-", $date_to);
         $date_from_ts = mktime(0, 0, 0, $date_from_parts[1], $date_from_parts[2], $date_from_parts[0]);
         $date_from_ts = date( 'Y-m-d H:i:s', $date_from_ts );
         $date_to_ts=mktime(0, 0, 0, $date_to_parts[1], $date_to_parts[2], $date_to_parts[0]);
         $date_to_ts = date( 'Y-m-d H:i:s', $date_to_ts );
 
-        $query_string = 
+        $query_string =
 				"SELECT COUNT(*) as count_val FROM test ".
 				"WHERE ts BETWEEN '$date_from_ts' AND '$date_to_ts' ".
 				"AND user_id = $user_id ".
                                 "AND result <> ''";
-	
+
 	$resultset = query_associative_one($query_string);
 	$retval = $resultset['count_val'];
         DbUtil::switchRestore($saved_db);
-        return $retval;      
+        return $retval;
     }
-    
+
     public function getPatientRegLog($user_id, $lab_config_id, $date_from, $date_to)
     {
         $saved_db = DbUtil::switchToLabConfig($lab_config_id);
-        $date_from_parts = explode("-", $date_from);		
+        $date_from_parts = explode("-", $date_from);
         $date_to_parts = explode("-", $date_to);
         $date_from_ts = mktime(0, 0, 0, $date_from_parts[1], $date_from_parts[2], $date_from_parts[0]);
         $date_from_ts = date( 'Y-m-d H:i:s', $date_from_ts );
         $date_to_ts=mktime(0, 0, 0, $date_to_parts[1], $date_to_parts[2], $date_to_parts[0]);
         $date_to_ts = date( 'Y-m-d H:i:s', $date_to_ts );
 
-        $query_string = 
+        $query_string =
 				"SELECT * FROM patient ".
 				"WHERE ts BETWEEN '$date_from_ts' AND '$date_to_ts' ".
 				"AND created_by = $user_id";
-	
+
 	$resultset = query_associative_all($query_string);
 	$patient_list = array();
 	if(count($resultset) > 0)
@@ -6076,22 +6076,22 @@ class UserStats
         DbUtil::switchRestore($saved_db);
         return $patient_list;
     }
-    
+
     public function getSpecimenRegLog($user_id, $lab_config_id, $date_from, $date_to)
     {
         $saved_db = DbUtil::switchToLabConfig($lab_config_id);
-        $date_from_parts = explode("-", $date_from);		
+        $date_from_parts = explode("-", $date_from);
         $date_to_parts = explode("-", $date_to);
         $date_from_ts = mktime(0, 0, 0, $date_from_parts[1], $date_from_parts[2], $date_from_parts[0]);
         $date_from_ts = date( 'Y-m-d H:i:s', $date_from_ts );
         $date_to_ts=mktime(0, 0, 0, $date_to_parts[1], $date_to_parts[2], $date_to_parts[0]);
         $date_to_ts = date( 'Y-m-d H:i:s', $date_to_ts );
 
-        $query_string = 
+        $query_string =
 				"SELECT * FROM specimen ".
 				"WHERE ts BETWEEN '$date_from_ts' AND '$date_to_ts' ".
 				"AND user_id = $user_id";
-	
+
 	$resultset = query_associative_all($query_string);
 	$test_list = array();
 	if(count($resultset) > 0)
@@ -6104,22 +6104,22 @@ class UserStats
         DbUtil::switchRestore($saved_db);
         return $test_list;
     }
-    
+
     public function getTestRegLog($user_id, $lab_config_id, $date_from, $date_to)
     {
         $saved_db = DbUtil::switchToLabConfig($lab_config_id);
-        $date_from_parts = explode("-", $date_from);		
+        $date_from_parts = explode("-", $date_from);
         $date_to_parts = explode("-", $date_to);
         $date_from_ts = mktime(0, 0, 0, $date_from_parts[1], $date_from_parts[2], $date_from_parts[0]);
         $date_from_ts = date( 'Y-m-d H:i:s', $date_from_ts );
         $date_to_ts=mktime(0, 0, 0, $date_to_parts[1], $date_to_parts[2], $date_to_parts[0]);
         $date_to_ts = date( 'Y-m-d H:i:s', $date_to_ts );
 
-        $query_string = 
+        $query_string =
 				"SELECT * FROM test ".
 				"WHERE ts BETWEEN '$date_from_ts' AND '$date_to_ts' ".
 				"AND user_id = $user_id";
-	
+
 	$resultset = query_associative_all($query_string);
 	$test_list = array();
 	if(count($resultset) > 0)
@@ -6132,22 +6132,22 @@ class UserStats
         DbUtil::switchRestore($saved_db);
         return $test_list;
     }
-    
+
     public function getResultEntryLog($user_id, $lab_config_id, $date_from, $date_to)
     {
         $saved_db = DbUtil::switchToLabConfig($lab_config_id);
-        $date_from_parts = explode("-", $date_from);		
+        $date_from_parts = explode("-", $date_from);
         $date_to_parts = explode("-", $date_to);
         $date_from_ts = mktime(0, 0, 0, $date_from_parts[1], $date_from_parts[2], $date_from_parts[0]);
         $date_from_ts = date( 'Y-m-d H:i:s', $date_from_ts );
         $date_to_ts=mktime(0, 0, 0, $date_to_parts[1], $date_to_parts[2], $date_to_parts[0]);
         $date_to_ts = date( 'Y-m-d H:i:s', $date_to_ts );
 
-        $query_string = 
+        $query_string =
 				"SELECT * FROM test ".
 				"WHERE ts BETWEEN '$date_from_ts' AND '$date_to_ts' ".
 				"AND user_id = $user_id";
-	
+
 	$resultset = query_associative_all($query_string);
 	$test_list = array();
 	if(count($resultset) > 0)
@@ -6166,17 +6166,17 @@ class Bill
 {
 	#Used to combine payments into a logical grouping, and provide a quick method for users to see if a patient has
 	#been billed for a particular test or set of tests.
-	
+
 	private $id;
 	private $patientId;
 	private $paidInFull;
-	
+
 	function Bill($patientId)
 	{
 		$this->paidInFull = FALSE;
 		$this->patientId = $patientId;
 	}
-	
+
 	public function create($lab_config_id)
 	{
 		$patientId = $this->patientId;
@@ -6190,18 +6190,18 @@ class Bill
 		}
 
 		$query_string = "INSERT INTO `bills` (`patient_id`, `paid_in_full`)	VALUES ($patientId, $paidInFull)";
-							
+
 		$saved_db = DbUtil::switchToLabConfig($lab_config_id);
-		
+
 		query_insert_one($query_string);
-		
+
 		$this->id = get_last_insert_id();
-		
+
 		DbUtil::switchRestore($saved_db);
-		
+
 		return 1;
 	}
-	
+
 	public function save($lab_config_id)
 	{
 		$id = $this->id;
@@ -6211,46 +6211,46 @@ class Bill
 		$query_string = "UPDATE `bills` SET `patient_id` = $patientId,
 											`paid_in_full` = $paidInfull
 						WHERE `id` = $id";
-							
+
 		$saved_db = DbUtil::switchToLabConfig($lab_config_id);
-		
+
 		query_update($query_string);
-		
+
 		DbUtil::switchRestore($saved_db);
-		
+
 		return 1;
 	}
-	
+
 	public static function loadFromId($billId, $lab_config_id)
 	{
 		$id = $billId;
-		
+
 		$query_string = "SELECT * FROM `bills` WHERE `id` = $id";
-		
+
 		$saved_db = DbUtil::switchToLabConfig($lab_config_id);
-		
+
 		$retVal = query_associative_one($query_string);
-		
+
 		DbUtil::switchRestore($saved_db);
-		
+
 		$bill = new Bill($retVal['patient_id']);
-		
+
 		$bill->id = $id;
 		$bill->paidInFull = $retVal['paidInFull'];
-		
+
 		return $bill;
 	}
-	
+
 	public function getId()
 	{
 		return $this->id;
 	}
-	
+
 	public function getPatientId()
 	{
 		return $this->patientId;
 	}
-	
+
 	public static function createBillForTests($tests, $lab_config_id)
 	{
 		# Create a new bill and associate all of the desired tests with it.
@@ -6265,18 +6265,18 @@ class Bill
 			$association = new BillsTestsAssociationObject($bill->id, $test->testId);
 			$association->create($lab_config_id);
 		}
-		
+
 		return $bill;
 	}
-	
+
 	public static function hasTestBeenBilled($testId, $lab_config_id)
 	{
 		$query_string = "SELECT COUNT(*) FROM `bills_test_association` WHERE `test_id` = $testId";
-		
+
 		$saved_db = DbUtil::switchToLabConfig($lab_config_id);
-		
+
 		$retVal = query_associative_one($query_string);
-		
+
 		DbUtil::switchRestore($saved_db);
 
 		if ($retVal["COUNT(*)"] > 0)
@@ -6285,7 +6285,7 @@ class Bill
 		}
 		return FALSE;
 	}
-	
+
 	public function hasBillBeenFullyPaid($lab_config_id)
 	{
 		if ($this->paidInFull) # If this flag has been toggled, there's no reason to make another DB query.
@@ -6294,16 +6294,16 @@ class Bill
 		}
 		# Return true if there are enough payments associated with this bill to fully cover its cost.
 		$bill_amount = $this->amount;
-		
+
 		$payments_total = 0.0;
-		
+
 		$payments = Payment::loadAllPaymentsForBill($this->id, $lab_config_id);
-		
+
 		foreach($payments as $payment)
 		{
 			$payments_total += $payment->amount;
 		}
-		
+
 		if ($payments_total == $bill_amount)
 		{
 			$bill->paidInFull = TRUE;
@@ -6321,19 +6321,19 @@ class Bill
 			return TRUE;
 		}
 	}
-	
+
 	public function getAllAssociationsForBill($lab_config_id)
 	{
 		$id = $this->id;
-		
+
 		$query_string = "SELECT id FROM `bills_test_association` WHERE `bill_id` = $id";
-		
+
 		$saved_db = DbUtil::switchToLabConfig($lab_config_id);
-		
+
 		$retVal = query_associative_all($query_string);
-		
+
 		DbUtil::switchRestore($saved_db);
-		
+
 		$associations = array();
 		foreach($retVal as $entry)
 		{
@@ -6353,11 +6353,11 @@ class Bill
 		}
 		return $runningTotal;
 	}
-	
+
 	public function getFormattedTotal($lab_config_id)
 	{
 		$cost = $this->getBillTotal($lab_config_id);
-		
+
 		return format_number_to_money($cost);
 	}
 }
@@ -6366,18 +6366,18 @@ class BillsTestsAssociationObject
 {
 	# Used to associate tests with a bill.  Also provides a place to apply discounts to a test,
 	#  since we don't want to modify the existing test table structure.
-	
+
 	// Constants for discount assignments.
 	const NONE = 1000;
 	const PERCENT = 1001;
 	const FLAT = 1002;
-	
+
 	private $id;
 	private $billId;
 	private $testId;
 	private $discountType;
 	private $discount;
-	
+
 	function BillsTestsAssociationObject($billId, $testId)
 	{
 		$this->billId = $billId;
@@ -6385,28 +6385,28 @@ class BillsTestsAssociationObject
 		$this->discountType = self::NONE;
 		$this->discount = 0.00;
 	}
-	
+
 	function create($lab_config_id)
 	{
 		$billId = $this->billId;
 		$testId = $this->testId;
 		$discountType = $this->discountType;
 		$discountAmount = $this->discount;
-		
+
 		$query_string = "INSERT INTO `bills_test_association` (bill_id, test_id, discount_type, discount_amount)
 							VALUES ($billId, $testId, $discountType, $discountAmount)";
-							
+
 		$saved_db = DbUtil::switchToLabConfig($lab_config_id);
-		
+
 		query_insert_one($query_string);
-		
+
 		$this->id = get_last_insert_id();
-		
+
 		DbUtil::switchRestore($saved_db);
-		
+
 		return 1;
 	}
-	
+
 	function save($lab_config_id)
 	{
 		$id = $this->id;
@@ -6414,7 +6414,7 @@ class BillsTestsAssociationObject
 		$testId = $this->testId;
 		$discountType = $this->discountType;
 		$discountAmount = $this->discount;
-		
+
 		$query_string = "UPDATE `bills_test_association` SET `bill_id` = $billId,
 															 `test_id` = $testId,
 															 `discount_type` = $discountType,
@@ -6422,39 +6422,39 @@ class BillsTestsAssociationObject
 						WHERE `id` = $id";
 
 		$saved_db = DbUtil::switchToLabConfig($lab_config_id);
-		
+
 		query_update($query_string);
-		
+
 		DbUtil::switchRestore($saved_db);
-		
+
 		return 1;
 	}
-	
+
 	function loadFromId($id, $lab_config_id)
 	{
-		
+
 		$query_string = "SELECT * FROM `bills_test_association` WHERE `id` = $id";
-		
+
 		$saved_db = DbUtil::switchToLabConfig($lab_config_id);
 
 		$retVal = query_associative_one($query_string);
 
 		DbUtil::switchRestore($saved_db);
-		
+
 		$association = new BillsTestsAssociationObject($retVal['bill_id'], $retVal['test_id']);
 
 		$association->id = $id;
 		$association->discountType = $retVal['discount_type'];
 		$association->discount = $retVal['discount_amount'];
-		
+
 		return $association;
 	}
-	
+
 	public function getId()
 	{
 		return $this->id;
 	}
-	
+
 	public function getDiscountedTotal()
 	{
 		switch($this->discountType)
@@ -6475,7 +6475,7 @@ class BillsTestsAssociationObject
 		$cost = (floor($unformatted_cost * 100)) / 100;
 		return $unformatted_cost;
 	}
-	
+
 	public function getCostOfTest()
 	{
 		$test = Test::getById($this->testId);
@@ -6483,31 +6483,31 @@ class BillsTestsAssociationObject
 		$cost = $cost['amount'];
 		return floatVal($cost);
 	}
-	
+
 	public function getTestId()
 	{
 		return $this->testId;
 	}
-	
+
 	public function getTest()
 	{
 		$id = $this->testId;
-		
+
 		$test = Test::loadById($id);
-		
+
 		return $test;
 	}
-	
+
 	public function getBillId()
 	{
 		return $this->billId;
 	}
-	
+
 	public function getDiscountAmount()
 	{
 		return $this->discount;
 	}
-	
+
 	public function isFlatDiscount()
 	{
 		if ($this->discountType == self::FLAT)
@@ -6540,7 +6540,7 @@ class BillsTestsAssociationObject
 			return FALSE;
 		}
 	}
-	
+
 	public function setDiscountType($discount_type)
 	{
 		if ($discount_type < 100 or $discount_type > 1002)
@@ -6551,7 +6551,7 @@ class BillsTestsAssociationObject
 
 		return 1;
 	}
-	
+
 	public function setDiscountAmount($amount)
 	{
 		if (!is_numeric($amount))
@@ -6559,10 +6559,10 @@ class BillsTestsAssociationObject
 			# Passed in something that was not a number.
 			return 0;
 		}
-		
+
 		#Ensure that whatever we got is in numeric form.
 		$amount = floatval($amount);
-		
+
 		if ($amount < 0)
 		{
 			# Passed in a negative value, which we aren't going to allow.
@@ -6595,29 +6595,29 @@ class BillsTestsAssociationObject
 		$this->discount = $amount;
 		return 1;
 	}
-	
+
 	public function loadByTestId($testId, $lab_config_id)
 	{
 		$query_string = "SELECT id FROM `bills_test_association` WHERE `test_id` = $testId";
-		
+
 		$saved_db = DbUtil::switchToLabConfig($lab_config_id);
 
 		$retVal = query_associative_one($query_string);
 
 		DbUtil::switchRestore($saved_db);
-		
+
 		$association = self::loadFromId($retVal['id'], $lab_config_id);
-		
+
 		return $association;
 	}
-	
+
 	// Return the name for the test this object references.
 	public function getTestName()
 	{
 		$id = $this->testId;
 
 		$query_string = "SELECT name FROM test_type WHERE test_type_id = (SELECT test_type_id FROM test WHERE test_id = $id)";
-		
+
 		$saved_db = DbUtil::switchToLabConfig($_SESSION['lab_config_id']);
 
 		$retVal = query_associative_one($query_string);
@@ -6626,14 +6626,14 @@ class BillsTestsAssociationObject
 
 		return $retVal['name'];
 	}
-	
+
 	// Return the date for the test this object references.
 	public function getTestDate()
 	{
 		$id = $this->testId;
 
 		$query_string = "SELECT ts FROM test WHERE test_id = $id";
-		
+
 		$saved_db = DbUtil::switchToLabConfig($_SESSION['lab_config_id']);
 
 		$retVal = query_associative_one($query_string);
@@ -6641,15 +6641,15 @@ class BillsTestsAssociationObject
 		DbUtil::switchRestore($saved_db);
 
 		$date = $retVal['ts'];
-		
+
 		return date("Y-m-d", strtotime($date));
 	}
-	
+
 	// Return the cost for the test this object references, formatted accordingly.
 	public function getFormattedTestCost()
 	{
 		$cost = $this->getDiscountedTotal();
-		
+
 		return format_number_to_money($cost);
 	}
 }
@@ -6657,17 +6657,17 @@ class BillsTestsAssociationObject
 class Payment
 {
 	#Records the payment of a bill
-	
+
 	public $id;
 	public $amount;
 	public $billId;
-	
+
 	function Payment($amount, $billId)
 	{
 		$this->amount = $amount;
 		$this->billId = $billId;
 	}
-	
+
 	public function create($lab_config_id)
 	{
 		$amount = $this->amount;
@@ -6675,18 +6675,18 @@ class Payment
 
 		$query_string = "INSERT INTO `payments` (`amount`, `bill_id`)
 							VALUES ($amount, $billId)";
-							
+
 		$saved_db = DbUtil::switchToLabConfig($lab_config_id);
-		
+
 		query_insert_one($query_string);
-		
+
 		$this->id = get_last_insert_id();
-		
+
 		DbUtil::switchRestore($saved_db);
-		
+
 		return 1;
 	}
-	
+
 	public function save($lab_config_id)
 	{
 		$id = $this->id;
@@ -6696,49 +6696,49 @@ class Payment
 		$query_string = "UPDATE `payments` SET `amount` = $amount,
 											   `bill_id` = $billId
 						WHERE `id` = $id";
-							
+
 		$saved_db = DbUtil::switchToLabConfig($lab_config_id);
-		
+
 		query_update($query_string);
-		
+
 		DbUtil::switchRestore($saved_db);
-		
+
 		return 1;
 	}
-	
+
 	public static function loadFromId($id, $lab_config_id)
 	{
 		$query_string = "SELECT * FROM `payments` WHERE `id` = $id";
-		
+
 		$saved_db = DbUtil::switchToLabConfig($lab_config_id);
-		
+
 		$retVal = query_associative_one($query_string);
-		
+
 		DbUtil::switchRestore($saved_db);
-		
+
 		$payment = new Payment($retVal['patient_id']);
-		
+
 		$payment->id = $id;
 		$payment->amount = $retVal['amount'];
 		$payment->billId = $retVal['bill_id'];
-		
+
 		return $payment;
 	}
-	
+
 	public static function loadAllPaymentsForBill($bill, $lab_config_id)
 	{
 		$billId = $bill->id;
-		
+
 		$query_string = "SELECT id FROM `payments` WHERE `bill_id` = $billId";
-		
+
 		$saved_db = DbUtil::switchToLabConfig($lab_config_id);
-		
+
 		$retVal = query_associative_all($query_string);
-		
+
 		DbUtil::switchRestore($saved_db);
-		
+
 		$payments = array();
-		
+
 		if (count($retVal != 0))
 		{
 			foreach ($retVal as $val)
@@ -6751,13 +6751,13 @@ class Payment
 			return 0;
 		}
 	}
-	
+
 	public static function createNewPaymentForBill($bill, $amount, $lab_config_id)
 	{
 		$payment = new Payment($amount, $bill->id);
-		
+
 		$payment->create($lab_config_id);
-		
+
 		return $payment;
 	}
 }
@@ -6780,7 +6780,7 @@ function check_user_password($username, $password)
 	$username = mysql_real_escape_string($username, $con);
 	$saved_db = DbUtil::switchToGlobal();
 	$password = encrypt_password($password);
-	$query_string = 
+	$query_string =
 		"SELECT * FROM user ".
 		"WHERE username='$username' ".
 		"AND password='$password' LIMIT 1";
@@ -6817,13 +6817,13 @@ function change_user_password_oneTime($username, $password)
 	"SET password='$password' ".
 	"WHERE username='$username'";
 	query_blind($query_string);
-	
+
 	//insert into blis_129.misc (vr_id, v1, v2) values ("username", "admin", "Password Reset Complete");
-	$query_string_misc = 
+	$query_string_misc =
 	"INSERT INTO MISC ".
 	"(username, action) values ('$username', 'password reset completed')";
 	query_blind($query_string_misc);
-	
+
 	DbUtil::switchRestore($saved_db);
 }
 
@@ -6838,12 +6838,12 @@ function password_reset_need_confirm()
 	DbUtil::switchRestore($saved_db);
 	if($record['resetCount'] == 0)
 		return true;
-	return false; 
+	return false;
 	//return $record;
 }
 
 function password_reset_flush($reset_before_date){
-	global $con; 
+	global $con;
 	$saved_db = DbUtil::switchToGlobal();
 	$query_string = "delete from misc where ts<'$reset_before_date' && action='password reset completed'";
 	query_blind($query_string);
@@ -6874,17 +6874,17 @@ function add_user($user)
 		if($user->level == 17) {
 			$user->rwoptions = LabConfig::getDoctorUserOptions();
 		}
-		$query_string = 
+		$query_string =
 			"INSERT INTO user(username, password, actualname, level, created_by, lab_config_id, email, phone, lang_id, rwoptions) ".
 			"VALUES ('$user->username', '$password', '$user->actualName', $user->level, $user->createdBy, '$user->labConfigId', '$user->email', '$user->phone', '$user->langId','$user->rwoptions')";
-		
+
 		query_insert_one($query_string);
 		DbUtil::switchRestore($saved_db);
 
 		$saved_db = DbUtil::switchToGlobal();
 		$query_string = "SELECT user_id FROM user WHERE username='$user->username' LIMIT 1";
 		$record = query_associative_one($query_string);
-		$query_string = 
+		$query_string =
 			"INSERT INTO user_config(user_id, level, parameter, value, created_by, created_on, modified_by, modified_on) ".
 			"VALUES ('".$record['user_id']."',$user->level, 'rwoptions', '$rwoptions', $user->createdBy, curdate(), $user->createdBy, curdate())";
 		query_insert_one($query_string);
@@ -6895,7 +6895,7 @@ add_lab_config_access($record['user_id'],$user->labConfigId);
 //AS 08/29/2018 END
 		DbUtil::switchRestore($saved_db);
 		return true;
-	}	
+	}
 	return false;
 }
 function fetch_user_log($patientId,$logType){
@@ -6912,17 +6912,17 @@ function add_user_type($user_type, $defaultdisplay, $rwoption)
 	$saved_db = DbUtil::switchToGlobal();
 	$password = encrypt_password($user->password);
 	$query_string = "SELECT count(1) as count from user_type where lower(name) = lower('$user_type')";
-	
+
 	$retVal = query_associative_one($query_string);
 
 	if($retVal['count'] == 0){
-		$query_string = 
+		$query_string =
 		"INSERT INTO user_type(name, defaultdisplay, created_by) ".
 		"VALUES ('$user_type',$defaultdisplay,'".$_SESSION['user_id']."')";
-	
+
 		query_insert_one($query_string);
 
-		$query_string = "SELECT level from user_type where name = '$user_type'";	
+		$query_string = "SELECT level from user_type where name = '$user_type'";
 		$retVal = query_associative_one($query_string);
 
 		$query_string = "insert into user_type_config(level, parameter, value, created_by, modified_by) values ('".$retVal['level']."','rwoptions', '$rwoption', '".$_SESSION['user_id']."', '".$_SESSION['user_id']."')";
@@ -6940,9 +6940,9 @@ function get_user_type_options($user_type)
 	# Adds a new user account
 	$saved_db = DbUtil::switchToGlobal();
 	$password = encrypt_password($user->password);
-	$query_string = "SELECT value from user_type_config where level = $user_type and parameter ='rwoptions'";	
+	$query_string = "SELECT value from user_type_config where level = $user_type and parameter ='rwoptions'";
 	$retVal = query_associative_one($query_string);
-	
+
 	DbUtil::switchRestore($saved_db);
 
 	return $retVal['value'];
@@ -6953,9 +6953,9 @@ function get_level_name_db($user_level)
 {
 	$saved_db = DbUtil::switchToGlobal();
 	$password = encrypt_password($user->password);
-	$query_string = "SELECT name FROM user_type where level = $user_level";	
+	$query_string = "SELECT name FROM user_type where level = $user_level";
 	$retVal = query_associative_one($query_string);
-	
+
 	DbUtil::switchRestore($saved_db);
 
 	return $retVal['name'];
@@ -6986,13 +6986,13 @@ function delete_specimen_by_specimen_id($specimen_list){
 			remove_specimens($lab_config_id, $specimen->specimenId, $remarks, $category);
 		}
 	}
-	
+
 }
 
  function delete_specimen_by_specimen_id_api($specimen_list, $lab_config_id, $remarks = "Typo"){
 	global $con;
 	$saved_db = DbUtil::switchToLabConfig($lab_config_id);
-	
+
  	if(sizeof($specimen_list)>0){
 		foreach($specimen_list as $specimen){
 			//echo "in delete_specimen_by_specimen_id_api : ".$specimen->specimenId;
@@ -7000,7 +7000,7 @@ function delete_specimen_by_specimen_id($specimen_list){
 			delete_tests_by_test_id($testsList);
 			/* $query_string = "DELETE FROM specimen WHERE specimen_id=$specimen->specimenId";
 			query_blind($query_string); */
-			
+
 			$category = "specimen";
 			remove_specimens($lab_config_id, $specimen->specimenId, $remarks, $category);
 		}
@@ -7014,11 +7014,11 @@ function delete_test_by_test_id_api($test_list, $lab_config_id){
 	$saved_db = DbUtil::switchToLabConfig($lab_config_id);
 
 	if(sizeof($test_list)>0){
-		
+
 		foreach($test_list as $test){
 /* 			$query_string = "DELETE FROM test WHERE test_id=$test->testId";
 			query_blind($query_string);
- */		
+ */
 			$remarks = "Typo";
 			$category = "test";
 			remove_specimens($lab_config_id, $test->testId, $remarks, $category);
@@ -7035,15 +7035,15 @@ function delete_patient($patient_id, $lab_config_id)
 	$isSuccess = 1;
 	global $con;
 	$saved_db = DbUtil::switchToLabConfig($lab_config_id);
-	
+
 	if(sizeof($retval)>0){
-		// Collect Specimen Related to patients 
+		// Collect Specimen Related to patients
 		// Delete the above collected specimen from the above specimen table
 		// Collect the tests related to the above specimen
 		// Delete the above collected tests from the appropriate table
 		//$isSuccess = 0;
 		delete_specimen_by_specimen_id($retval);
-	}  
+	}
 		# Remove patient record
 	//$query_string = "DELETE FROM patient WHERE patient_id=$patient_id";
 	//query_blind($query_string);
@@ -7059,7 +7059,7 @@ function update_user_profile($updated_entry)
 	# Updates user profile information
 	$saved_db = DbUtil::switchToGlobal();
 	$user_id = $updated_entry->userId;
-	$query_string = 
+	$query_string =
 		"UPDATE user ".
 		"SET email='$updated_entry->email', ".
 		"phone='$updated_entry->phone', ".
@@ -7075,14 +7075,14 @@ function update_user_level($updated_entry)
 	# Changes user access level
 	$saved_db = DbUtil::switchToGlobal();
 	$user_id = $updated_entry->userId;
-	$query_string = 
+	$query_string =
 		"UPDATE user ".
 		"SET level=$updated_entry->level ".
 		"WHERE user_id=$updated_entry->userId";
 	query_blind($query_string);
 	DbUtil::switchRestore($saved_db);
 	$saved_db = DbUtil::switchToGlobal();
-	$query_string = 
+	$query_string =
 		"UPDATE user_config ".
 		"SET level=$updated_entry->level ".
 		"WHERE user_id=$user_id";
@@ -7094,7 +7094,7 @@ function update_admin_user($updated_entry)
 {
 	# Updates lab admin account
 	$saved_db = DbUtil::switchToGlobal();
-	$query_string = 
+	$query_string =
 		"UPDATE user ".
 		"SET actualname='$updated_entry->actualName', ".
 		"phone='$updated_entry->phone', ".
@@ -7117,7 +7117,7 @@ function update_lab_user($updated_entry)
 	// 	$updated_entry->rwoption = LabConfig::getDoctorUserOptions();
 	// }
 	$user = get_user_by_id($updated_entry->userId);
-	$query_string = 
+	$query_string =
 		"UPDATE user ".
 		"SET actualname='$updated_entry->actualName', ".
 		"phone='$updated_entry->phone', ".
@@ -7136,7 +7136,7 @@ query_blind($query_string);
 	# Updates user_config
 	$saved_db = DbUtil::switchToGlobal();
 	$query_string =
-		"UPDATE user_config 
+		"UPDATE user_config
 		SET level=".$updated_entry->level.", ".
 		"value='".$updated_entry->rwoption."' ".
 		" WHERE user_id=".$updated_entry->userId." and parameter = 'rwoptions'";
@@ -7164,18 +7164,18 @@ function update_lab_user_type($updated_entry, $rwoption)
 {
 	# Updates lab user (non-admin) account
 	$saved_db = DbUtil::switchToGlobal();
-	$query_string = 
+	$query_string =
 		"UPDATE user_type ".
 		"SET defaultdisplay=$updated_entry->defaultdisplay ".
 		"WHERE level=$updated_entry->level";
 	query_blind($query_string);
 
-	$query_string = 
+	$query_string =
 		"UPDATE user_type_config ".
 		"SET value='$rwoption' ".
 		"WHERE level=$updated_entry->level and parameter='rwoptions'";
 	query_blind($query_string);
-	
+
 	DbUtil::switchRestore($saved_db);
 }
 
@@ -7183,19 +7183,19 @@ function update_lab_RWOptions($config)
 {
 	# Updates lab user (non-admin) account
 	$saved_db = DbUtil::switchToGlobal();
-	$query_string = 
+	$query_string =
 	"UPDATE user ".
 	"SET rwoptions='$config'".
 	"WHERE level=17 and lab_config_id = ".$_SESSION['lab_config_id']."";
-	query_blind($query_string);	
+	query_blind($query_string);
 	DbUtil::switchRestore($saved_db);
 
 	$saved_db = DbUtil::switchToGlobal();
-	$query_string = 
+	$query_string =
 	"UPDATE user_config ".
 	"SET value='$config'".
 	"WHERE level=17 and lab_config_id = ".$_SESSION['lab_config_id']." and parameter = 'rwoptions'";
-	query_blind($query_string);	
+	query_blind($query_string);
 	DbUtil::switchRestore($saved_db);
 
 }
@@ -7204,7 +7204,7 @@ function delete_lab_config_access_by_id($user_id)
 	global $con;
 	$saved_db = DbUtil::switchToGlobal();
 	# Remove entries from lab_config_access
-	$query_string = 
+	$query_string =
 		"DELETE FROM lab_config_access ".
 		"WHERE user_id=$user_id";
 	query_blind($query_string);
@@ -7217,7 +7217,7 @@ function delete_user_by_id($user_id)
 	$user_id = mysql_real_escape_string($user_id, $con);
 	$saved_db = DbUtil::switchToGlobal();
 	# Remove entries from lab_config_access
-	$query_string = 
+	$query_string =
 		"DELETE FROM lab_config_access ".
 		"WHERE user_id=$user_id";
 	query_blind($query_string);
@@ -7241,12 +7241,12 @@ function delete_user_type($user_type)
 	//$user_id = mysql_real_escape_string($user_id, $con);
 	$saved_db = DbUtil::switchToGlobal();
 	# Remove entries from lab_config_access
-	$query_string = 
+	$query_string =
 		"DELETE FROM user_type ".
 		"WHERE level=$user_type";
 	query_blind($query_string);
 
-	$query_string = 
+	$query_string =
 	"DELETE FROM user_type_config ".
 	"WHERE level=$user_type";
 	query_blind($query_string);
@@ -7262,7 +7262,7 @@ function get_user_by_id($user_id)
 	$user_id = mysql_real_escape_string($user_id, $con);
 	# Fetches user record by primary key
 	$saved_db = DbUtil::switchToGlobal();
-	$query_string = "SELECT  a.user_id, a.username, a.password,a.actualname, a.email, a.created_by, a.ts, a.lab_config_id, a.level, a.phone, a.lang_id, b.value as rwoptions 
+	$query_string = "SELECT  a.user_id, a.username, a.password,a.actualname, a.email, a.created_by, a.ts, a.lab_config_id, a.level, a.phone, a.lang_id, b.value as rwoptions
 	FROM user a, user_config b  WHERE a.user_id = b.user_id and b.parameter = 'rwoptions' and a.user_id=$user_id LIMIT 1";
 	$record = query_associative_one($query_string);
 	DbUtil::switchRestore($saved_db);
@@ -7307,13 +7307,13 @@ function get_user_position_by_id($user_id)
 	DbUtil::switchRestore($saved_db);
 	if($record == null)
 		return LangUtil::$generalTerms['NOTKNOWN'];
-	
+
 	$user_level = $record['level'];
-	
-	
+
+
 	global $LIS_TECH_RO, $LIS_TECH_RW, $LIS_ADMIN, $LIS_SUPERADMIN, $LIS_VERIFIER, $LIS_COUNTRYDIR, $LIS_CLERK,$LIS_PHYSICIAN;
 	global $LIS_001, $LIS_010, $LIS_011, $LIS_100, $LIS_101, $LIS_110, $LIS_111, $LIS_TECH_SHOWPNAME;
-	
+
 	switch($user_level){
 		case $LIS_VERIFIER:
 			return "Verifier";
@@ -7337,14 +7337,14 @@ function get_user_position_by_id($user_id)
 			return "";
 			break;
 	}
-	
-	
-	
-	
-	
+
+
+
+
+
 	return $record['level'];
-	
-	
+
+
 }
 
 function get_user_by_name($username)
@@ -7354,7 +7354,7 @@ function get_user_by_name($username)
 	# Fetches user record by username
 	$saved_db = DbUtil::switchToGlobal();
 	#$query_string = "SELECT * FROM user WHERE username='$username' LIMIT 1";
-	$query_string = "SELECT  a.user_id, a.username, a.password,a.actualname, a.email, a.created_by, a.ts, a.lab_config_id, a.level, a.phone, a.lang_id, b.value as rwoptions 
+	$query_string = "SELECT  a.user_id, a.username, a.password,a.actualname, a.email, a.created_by, a.ts, a.lab_config_id, a.level, a.phone, a.lang_id, b.value as rwoptions
 	FROM user a, user_config b  WHERE a.user_id = b.user_id and b.parameter = 'rwoptions' and a.username='$username' LIMIT 1";
 	$record = query_associative_one($query_string);
 	if ($record == null){
@@ -7379,16 +7379,16 @@ function get_admin_users()
 	if($_SESSION['user_level'] == $LIS_SUPERADMIN)
 	{
 		# Return all admin accounts
-		#$query_string = 
+		#$query_string =
 		#	"SELECT * FROM user ".
 		#	"WHERE level=$LIS_ADMIN ORDER BY username";
-		$query_string = "SELECT  a.user_id, a.username, a.password,a.actualname, a.email, a.created_by, a.ts, a.lab_config_id, a.level, a.phone, a.lang_id, b.value as rwoptions 
+		$query_string = "SELECT  a.user_id, a.username, a.password,a.actualname, a.email, a.created_by, a.ts, a.lab_config_id, a.level, a.phone, a.lang_id, b.value as rwoptions
 		FROM user a, user_config b  WHERE a.user_id = b.user_id and b.parameter = 'rwoptions' and a.username='$LIS_ADMIN' ORDER BY username";
 	}
 	else if($_SESSION['user_level'] == $LIS_COUNTRYDIR)
 	{
 		# Return all admin accounts from that country alone
-		$query_string = 
+		$query_string =
 			"SELECT u.* FROM user u ".
 			"WHERE u.level=$LIS_ADMIN ".
 			"AND (u.user_id IN ( ".
@@ -7427,34 +7427,14 @@ function get_admin_user_list($user_id)
 	$saved_db = DbUtil::switchToGlobal();
 	$user = get_user_by_id($user_id);
 	$retval = array();
-	if(true)//is_super_admin($user))
-	{
-		# Super-admin level user: Return all admin accounts
-		#$query_string = 
-		#	"SELECT * FROM user ".
-		#	"WHERE level=$LIS_ADMIN";
-		$query_string = "SELECT  a.user_id, a.username, a.password,a.actualname, a.email, a.created_by, a.ts, a.lab_config_id, a.level, a.phone, a.lang_id, b.value as rwoptions 
-		FROM user a, user_config b  WHERE a.user_id = b.user_id and b.parameter = 'rwoptions' and a.username='$LIS_ADMIN'";
-	}
-	else if(is_country_dir($user))
-	{
-		# Country dir: Return all admin accounts in that country alone
-		$query_string = 
-			"SELECT u.* FROM user u ".
-			"WHERE u.level=$LIS_ADMIN ".
-			"AND u.user_id IN ( ".
-			"SELECT lc.admin_user_id FROM lab_config lc, lab_config_access lca ".
-			"WHERE lc.lab_config_id=lca.lab_config_id ".
-			"AND lca.user_id=".$_SESSION['user_id']." ) ".
-			"ORDER BY u.username";
-	}
-	else
-	{
-		# Only admin level user: Return single option
-		#$query_string = "SELECT * FROM user WHERE user_id=$user_id";
-		$query_string = "SELECT  a.user_id, a.username, a.password,a.actualname, a.email, a.created_by, a.ts, a.lab_config_id, a.level, a.phone, a.lang_id, b.value as rwoptions 
-		FROM user a, user_config b  WHERE a.user_id = b.user_id and b.parameter = 'rwoptions' and a.user_id='$user_id' ";
-	}
+
+    # Super-admin level user: Return all admin accounts
+    #$query_string =
+    #	"SELECT * FROM user ".
+    #	"WHERE level=$LIS_ADMIN";
+    $query_string = "SELECT  a.user_id, a.username, a.password,a.actualname, a.email, a.created_by, a.ts, a.lab_config_id, a.level, a.phone, a.lang_id, b.value as rwoptions
+    FROM user a, user_config b  WHERE a.user_id = b.user_id and b.parameter = 'rwoptions' and a.username='$LIS_ADMIN'";
+
 	$resultset = query_associative_all($query_string);
 	foreach($resultset as $record)
 	{
@@ -7484,23 +7464,23 @@ function add_patient($patient, $importOn = false)
 	$created_by = db_escape($patient->createdBy);
 	$hash_value = $patient->generateHashValue();
 	$query_string = "";
-	
+
 	/* Ensure that no other entry has been added prior to this function being called. If yes, update patientId */
 	if($importOn == false) { // Do not check during importing of patient since no conflicts are going to arise
 		$maxPid = bcadd(get_max_patient_id(), 1);
 		if( $maxPid != $pid )
 			$pid = $maxPid;
 	}
-	
+
 	if($dob == "" && $partial_dob == "")
 	{
-		$query_string = 
+		$query_string =
 			"INSERT INTO `patient`(`patient_id`, `addl_id`, `name`, `age`, `sex`, `surr_id`, `created_by`, `hash_value` ,`ts`) ".
 			"VALUES ($pid, '$addl_id', '$name', $age, '$sex', '$surr_id', $created_by, '$hash_value', '$receipt_date')";
 	}
 	else if($partial_dob != "")
 	{
-		$query_string = 
+		$query_string =
 			"INSERT INTO `patient`(`patient_id`, `addl_id`, `name`, `age`, `sex`, `partial_dob`, `surr_id`, `created_by`, `hash_value`,`ts`) ".
 			"VALUES ($pid, '$addl_id', '$name', $age, '$sex', '$partial_dob', '$surr_id', $created_by, '$hash_value', '$receipt_date')";
 	}
@@ -7510,7 +7490,7 @@ function add_patient($patient, $importOn = false)
 			"INSERT INTO `patient`(`patient_id`, `addl_id`, `name`, `dob`, `age`, `sex`, `surr_id`, `created_by`, `hash_value`, `ts`) ".
 			"VALUES ($pid, '$addl_id', '$name', '$dob', $age, '$sex', '$surr_id', $created_by, '$hash_value', '$receipt_date')";
 	}
-	
+
 	print $query_string;
 	query_insert_one($query_string);
 	return true;
@@ -7535,13 +7515,13 @@ function check_spacemen_byname($specimen_name)
 	# Checks if Specimen already exists in DB, and returns true/false accordingly
 	global $con;
 	$specimen_name = mysql_real_escape_string($specimen_name, $con);
-	$query_string = "SELECT specimen_type_id FROM specimen_type WHERE name='$specimen_name' LIMIT 1";	
+	$query_string = "SELECT specimen_type_id FROM specimen_type WHERE name='$specimen_name' LIMIT 1";
 	$retval = query_associative_one($query_string);
 	if($retval == null)
 		return false;
 	else
 		return true;
-	
+
 }
 
 function check_testType_byname($test_type)
@@ -7549,13 +7529,13 @@ function check_testType_byname($test_type)
 	# Checks if Specimen already exists in DB, and returns true/false accordingly
 	global $con;
 	$test_type = mysql_real_escape_string($test_type, $con);
-	$query_string = "SELECT test_type_id FROM test_type WHERE name='$test_type' LIMIT 1";	
+	$query_string = "SELECT test_type_id FROM test_type WHERE name='$test_type' LIMIT 1";
 	$retval = query_associative_one($query_string);
 	if($retval == null)
 		return false;
 	else
 		return true;
-	
+
 }
 function check_patient_surr_id($surr_id)
 {
@@ -7563,7 +7543,7 @@ function check_patient_surr_id($surr_id)
 	# Called from ajax/patient_check_surr_id.php
 	global $con;
 	$surr_id = mysql_real_escape_string($surr_id, $con);
-	$query_string = "SELECT surr_id FROM patient WHERE surr_id='$surr_id' LIMIT 1";	
+	$query_string = "SELECT surr_id FROM patient WHERE surr_id='$surr_id' LIMIT 1";
 	$retval = query_associative_one($query_string);
 	if($retval == null)
 		return false;
@@ -7581,9 +7561,9 @@ $resultset = query_associative_one($query_string);
 $patient_list = array();
 	if(count($resultset) > 0)
 	{
-		
+
 		$id= $resultset['patient_id'];
-		
+
 			$patient_list[] = Patient::getById($id);
 			//print_r($patient_list);
 		}
@@ -7619,11 +7599,11 @@ function search_patients_by_id($q, $labsection = 0)
 			"p.surr_id ='$q' and p.patient_id = s.patient_id and s.specimen_id in ".
 			"(select specimen_id from specimen where specimen_type_id in (select specimen_type_id from specimen_test where test_type_id in ".
 			"(select test_type_id as lab_section from test_type where test_category_id = '$labsection'))) ORDER BY p.ts DESC";
-		
-		}	
+
+		}
 	} else {
 	if($labsection == 0){
-		$query_string = 
+		$query_string =
 		"SELECT * FROM patient ".
 		"WHERE surr_id='$q' AND patient.patient_id NOT IN (select r_id from removal_record where category='patient' AND removal_record.status=1)".
 		"ORDER BY ts DESC";
@@ -7633,7 +7613,7 @@ function search_patients_by_id($q, $labsection = 0)
 		"p.surr_id ='$q' AND p.patient_id NOT IN (select r_id from removal_record where category='patient' AND removal_record.status=1) and p.patient_id = s.patient_id and s.specimen_id in ".
 		"(select specimen_id from specimen where specimen_type_id in (select specimen_type_id from specimen_test where test_type_id in ".
 		"(select test_type_id as lab_section from test_type where test_category_id = '$labsection'))) ORDER BY p.ts DESC";
-		
+
 	}
 	}
 	//;
@@ -7644,7 +7624,7 @@ function search_patients_by_id($q, $labsection = 0)
 		foreach($resultset as $record)
 		{
 			$patient_list[] = Patient::getObject($record);
-			
+
 		}
 	}
 	return $patient_list;
@@ -7656,10 +7636,10 @@ function search_patients_by_id_dyn($q, $cap, $counter, $labsection = 0)
 	global $con;
         $offset = $cap * ($counter - 1);
 	$q = mysql_real_escape_string($q, $con);
-	
-	
+
+
 	if($labsection == 0){
-		$query_string = 
+		$query_string =
 		"SELECT * FROM patient ".
 		"WHERE surr_id='$q' ORDER BY ts DESC LIMIT $offset,$cap";
 	} else {
@@ -7668,9 +7648,9 @@ function search_patients_by_id_dyn($q, $cap, $counter, $labsection = 0)
 		"p.surr_id ='$q' and p.patient_id = s.patient_id and s.specimen_id in ".
 		"(select specimen_id from specimen where specimen_type_id in (select specimen_type_id from specimen_test where test_type_id in ".
 		"(select test_type_id as lab_section from test_type where test_category_id = '$labsection'))) ORDER BY p.ts DESC LIMIT $offset,$cap";
-	
+
 	}
-	
+
 	$resultset = query_associative_all($query_string);
 	$patient_list = array();
 	if(count($resultset) > 0)
@@ -7678,7 +7658,7 @@ function search_patients_by_id_dyn($q, $cap, $counter, $labsection = 0)
 		foreach($resultset as $record)
 		{
 			$patient_list[] = Patient::getObject($record);
-			
+
 		}
 	}
 	return $patient_list;
@@ -7689,7 +7669,7 @@ function search_patients_by_id_count($q, $labsection = 0)
 	# Searches for patients with similar name
 	global $con;
 	$q = mysql_real_escape_string($q, $con);
-	
+
 	if(is_admin_check(get_user_by_id($_SESSION['user_id']))){
 		if($labsection == 0){
 			$query_string =
@@ -7702,9 +7682,9 @@ function search_patients_by_id_count($q, $labsection = 0)
 					"(select specimen_id from specimen where specimen_type_id in ".
 					"(select specimen_type_id from specimen_test where test_type_id in ".
 					"(select test_type_id as lab_section from test_type where test_category_id = $labsection)))";
-		}	
+		}
 	} else {
-		
+
 		if($labsection == 0){
 			$query_string =
 			"SELECT count(*) as val FROM patient ".
@@ -7718,13 +7698,13 @@ function search_patients_by_id_count($q, $labsection = 0)
 					"(select specimen_type_id from specimen_test where test_type_id in ".
 					"(select test_type_id as lab_section from test_type where test_category_id = $labsection)))";
 		}
-		
-		
+
+
 	}
-	
-	
-	
-	$saved_db = DbUtil::switchToLabConfig($_SESSION['lab_config_id']);	
+
+
+
+	$saved_db = DbUtil::switchToLabConfig($_SESSION['lab_config_id']);
 	$resultset = query_associative_one($query_string);
 	DbUtil::switchRestore($saved_db);
 	return $resultset['val'];
@@ -7737,13 +7717,13 @@ function search_patients_by_name($q, $labsection = 0,$c="")
 	$q = mysql_real_escape_string($q, $con);
 	if(empty($c))
 		$q.='%';
-    else	
+    else
 		$q=str_replace('[pq]',$q,$c);
 
 	if(is_admin_check(get_user_by_id($_SESSION['user_id']))){
-	
+
 	if($labsection == 0){
-		$query_string = 
+		$query_string =
 		"SELECT * FROM patient ".
 		"WHERE name LIKE '$q' ORDER BY name ASC";
 	} else {
@@ -7752,7 +7732,7 @@ function search_patients_by_name($q, $labsection = 0,$c="")
 		"p.name LIKE '$q' and p.patient_id = s.patient_id and s.specimen_id in ".
 		"(select specimen_id from specimen where specimen_type_id in (select specimen_type_id from specimen_test where test_type_id in ".
 		"(select test_type_id as lab_section from test_type where test_category_id = '$labsection'))) ORDER BY p.name ASC";
-	
+
 	}
 	} else {
 		if($labsection == 0){
@@ -7765,9 +7745,9 @@ function search_patients_by_name($q, $labsection = 0,$c="")
 			"p.name LIKE '$q'  AND p.patient_id NOT IN (select r_id from removal_record where category='patient' AND removal_record.status=1) and p.patient_id = s.patient_id and s.specimen_id in ".
 			"(select specimen_id from specimen where specimen_type_id in (select specimen_type_id from specimen_test where test_type_id in ".
 			"(select test_type_id as lab_section from test_type where test_category_id = '$labsection'))) ORDER BY p.name ASC";
-		
+
 		}
-	}			
+	}
 	$resultset = query_associative_all($query_string);
 	$patient_list = array();
 	if(count($resultset) > 0)
@@ -7775,10 +7755,10 @@ function search_patients_by_name($q, $labsection = 0,$c="")
 		foreach($resultset as $record)
 		{
 			$patient_list[] = Patient::getObject($record);
-			
+
 		}
 	}
-	
+
 	return $patient_list;
 }
 
@@ -7790,14 +7770,14 @@ function search_patients_by_name_dyn($q, $cap, $counter, $c="", $labsection = 0)
 	$q = mysql_real_escape_string($q, $con);
 	if(empty($c))
 		$q.='%';
-    else	
+    else
 		$q=str_replace('[pq]',$q,$c);
 	//echo "[]".$labsection;
 	$user = get_user_by_id($_SESSION['user_id']);
-	
+
 	if(! is_admin_check($user)){
 	if($labsection == 0){
-		$query_string = 
+		$query_string =
 		"SELECT * FROM patient  ".
 		"WHERE name LIKE '$q' AND patient.patient_id NOT IN (select r_id from removal_record where category='patient' AND removal_record.status=1) ORDER BY name ASC LIMIT $offset,$cap";
 	} else {
@@ -7822,7 +7802,7 @@ function search_patients_by_name_dyn($q, $cap, $counter, $c="", $labsection = 0)
 			//;
 		}
 	}
-	//;	
+	//;
 	$resultset = query_associative_all($query_string);
 	$patient_list = array();
 	if(count($resultset) > 0)
@@ -7830,7 +7810,7 @@ function search_patients_by_name_dyn($q, $cap, $counter, $c="", $labsection = 0)
 		foreach($resultset as $record)
 		{
 			$patient_list[] = Patient::getObject($record);
-			
+
 		}
 	}
 	return $patient_list;
@@ -7843,9 +7823,9 @@ function search_patients_by_name_count($q, $labsection = 0,$c="")
 	$q = mysql_real_escape_string($q, $con);
 	if(empty($c))
 		$q.='%';
-    else	
+    else
 		$q=str_replace('[pq]',$q,$c);
-		
+
 	if(! is_admin_check(get_user_by_id($_SESSION['user_id']))){
 		if($labsection == 0){
 			$query_string =
@@ -7870,10 +7850,10 @@ function search_patients_by_name_count($q, $labsection = 0,$c="")
 			"p.name LIKE '$q' and p.patient_id = s.patient_id and s.specimen_id in ".
 			"(select specimen_id from specimen where specimen_type_id in (select specimen_type_id from specimen_test where test_type_id in ".
 			"(select test_type_id as lab_section from test_type where test_category_id = '$labsection')))";
-			
+
 		}
 	}
-	$saved_db = DbUtil::switchToLabConfig($_SESSION['lab_config_id']);	
+	$saved_db = DbUtil::switchToLabConfig($_SESSION['lab_config_id']);
 	$resultset = query_associative_one($query_string);
 	DbUtil::switchRestore($saved_db);
 	//$res = implode(",",$resultset);
@@ -7886,11 +7866,11 @@ function search_patients_by_addlid($q, $labsection = 0)
 	global $con;
 	$q = mysql_real_escape_string($q, $con);
 	# Searches for patients with similar addl ID
-	
+
 	if(is_admin_check(get_user_by_id($_SESSION['user_id']))){
-		
+
 	if($labsection == 0){
-		$query_string = 
+		$query_string =
 		"SELECT * FROM patient ".
 		"WHERE addl_id LIKE '%$q%'";
 	} else {
@@ -7899,7 +7879,7 @@ function search_patients_by_addlid($q, $labsection = 0)
 		"p.addl_id LIKE '%$q%' and p.patient_id = s.patient_id and s.specimen_id in ".
 		"(select specimen_id from specimen where specimen_type_id in (select specimen_type_id from specimen_test where test_type_id in ".
 		"(select test_type_id as lab_section from test_type where test_category_id = '$labsection')))";
-	
+
 	}
 	} else {
 		if($labsection == 0){
@@ -7912,8 +7892,8 @@ function search_patients_by_addlid($q, $labsection = 0)
 			"p.addl_id LIKE '%$q%'  AND p.patient_id NOT IN (select r_id from removal_record where category='patient' AND removal_record.status=1) and p.patient_id = s.patient_id and s.specimen_id in ".
 			"(select specimen_id from specimen where specimen_type_id in (select specimen_type_id from specimen_test where test_type_id in ".
 			"(select test_type_id as lab_section from test_type where test_category_id = '$labsection')))";
-		
-		}	
+
+		}
 	}
 	//;
 	$resultset = query_associative_all($query_string);
@@ -7923,7 +7903,7 @@ function search_patients_by_addlid($q, $labsection = 0)
 		foreach($resultset as $record)
 		{
 			$patient_list[] = Patient::getObject($record);
-			
+
 		}
 	}
 	return $patient_list;
@@ -7935,11 +7915,11 @@ function search_patients_by_addlid_dyn($q, $cap, $counter, $labsection = 0)
 	global $con;
         $offset = $cap * ($counter - 1);
 	$q = mysql_real_escape_string($q, $con);
-	
+
 	if(is_admin_check(get_user_by_id($_SESSION['user_id']))){
-	
+
 	if($labsection == 0){
-		$query_string = 
+		$query_string =
 		"SELECT * FROM patient ".
 		"WHERE addl_id LIKE '%$q%' ORDER BY addl_id ASC LIMIT $offset,$cap";
 	} else {
@@ -7948,7 +7928,7 @@ function search_patients_by_addlid_dyn($q, $cap, $counter, $labsection = 0)
 		"p.addl_id LIKE '%$q%' and p.patient_id = s.patient_id and s.specimen_id in ".
 		"(select specimen_id from specimen where specimen_type_id in (select specimen_type_id from specimen_test where test_type_id in ".
 		"(select test_type_id as lab_section from test_type where test_category_id = '$labsection'))) ORDER BY p.addl_id ASC LIMIT $offset,$cap";
-	
+
 	}
 	} else{
 		if($labsection == 0){
@@ -7961,7 +7941,7 @@ function search_patients_by_addlid_dyn($q, $cap, $counter, $labsection = 0)
 			"p.addl_id LIKE '%$q%' AND p.patient_id NOT IN (select r_id from removal_record where category='patient' AND removal_record.status=1) and p.patient_id = s.patient_id and s.specimen_id in ".
 			"(select specimen_id from specimen where specimen_type_id in (select specimen_type_id from specimen_test where test_type_id in ".
 			"(select test_type_id as lab_section from test_type where test_category_id = '$labsection'))) ORDER BY p.addl_id ASC LIMIT $offset,$cap";
-		
+
 		}
 	}
 	//;
@@ -7972,7 +7952,7 @@ function search_patients_by_addlid_dyn($q, $cap, $counter, $labsection = 0)
 		foreach($resultset as $record)
 		{
 			$patient_list[] = Patient::getObject($record);
-				
+
 		}
 	}
 	return $patient_list;
@@ -7983,11 +7963,11 @@ function search_patients_by_addlid_count($q, $labsection = 0)
 	# Searches for patients with similar name
 	global $con;
 	$q = mysql_real_escape_string($q, $con);
-	
+
 	if(is_admin_check(get_user_by_id($_SESSION['user_id']))){
-	
+
 	if($labsection == 0){
-		$query_string = 
+		$query_string =
 		"SELECT count(*) as val FROM patient ".
 		"WHERE addl_id LIKE '%$q%'";
 	}
@@ -8012,10 +7992,10 @@ function search_patients_by_addlid_count($q, $labsection = 0)
 					"(select specimen_id from specimen where specimen_type_id in ".
 					"(select specimen_type_id from specimen_test where test_type_id in ".
 					"(select test_type_id as lab_section from test_type where test_category_id = $labsection)))";
-		}	
+		}
 	}
 	//;
-	$saved_db = DbUtil::switchToLabConfig($_SESSION['lab_config_id']);	
+	$saved_db = DbUtil::switchToLabConfig($_SESSION['lab_config_id']);
 	$resultset = query_associative_one($query_string);
 	DbUtil::switchRestore($saved_db);
 	return $resultset['val'];
@@ -8050,7 +8030,7 @@ function search_patients_by_dailynum($q, $labsection = 0)
 					"(select specimen_type_id from specimen_test where test_type_id in ".
 					"(select test_type_id as lab_section from test_type where test_category_id = $labsection)))".
 					"  ORDER BY date_collected DESC LIMIT 20";
-		}	
+		}
 	}
 	$resultset = query_associative_all($query_string);
 	$patient_list = array();
@@ -8059,7 +8039,7 @@ function search_patients_by_dailynum($q, $labsection = 0)
 		foreach($resultset as $record)
 		{
 			$patient_list[] = Patient::getById($record['patient_id']);
-			
+
 		}
 	}
 	return $patient_list;
@@ -8071,10 +8051,10 @@ function search_patients_by_dailynum_dyn($q, $cap, $counter, $labsection = 0)
 	global $con;
         $offset = $cap * ($counter - 1);
 	$q = mysql_real_escape_string($q, $con);
-	
+
 	if(is_admin_check(get_user_by_id($_SESSION['user_id']))){
 	if($labsection == 0){
-		$query_string = 
+		$query_string =
 		"SELECT DISTINCT patient_id FROM specimen WHERE daily_num LIKE '%".$q."' ORDER BY date_collected DESC LIMIT $offset,$cap";
 	} else {
 		$query_string = "select distinct patient_id from specimen ".
@@ -8084,7 +8064,7 @@ function search_patients_by_dailynum_dyn($q, $cap, $counter, $labsection = 0)
 				"(select specimen_type_id from specimen_test where test_type_id in ".
 				"(select test_type_id as lab_section from test_type where test_category_id = $labsection)))".
 				"  ORDER BY date_collected DESC LIMIT $offset,$cap";
-	
+
 	}
 	} else {
 		if($labsection == 0){
@@ -8098,7 +8078,7 @@ function search_patients_by_dailynum_dyn($q, $cap, $counter, $labsection = 0)
 					"(select specimen_type_id from specimen_test where test_type_id in ".
 					"(select test_type_id as lab_section from test_type where test_category_id = $labsection)))".
 					"  ORDER BY date_collected DESC LIMIT $offset,$cap";
-		
+
 		}
 	}
 	$resultset = query_associative_all($query_string);
@@ -8108,7 +8088,7 @@ function search_patients_by_dailynum_dyn($q, $cap, $counter, $labsection = 0)
 		foreach($resultset as $record)
 		{
 			$patient_list[] = Patient::getById($record['patient_id']);
-			
+
 		}
 	}
 	return $patient_list;
@@ -8119,10 +8099,10 @@ function search_patients_by_dailynum_count($q, $labsection = 0)
 	# Searches for patients with similar name
 	global $con;
 	$q = mysql_real_escape_string($q, $con);
-	
+
 	if(is_admin_check(get_user_by_id($_SESSION['user_id']))){
 	if($labsection == 0){
-		$query_string = 
+		$query_string =
 		"SELECT count(DISTINCT patient_id) as val FROM specimen WHERE daily_num LIKE '%$q'";
 	} else {
 		$query_string = "select count(distinct specimen.patient_id) as val from specimen ".
@@ -8142,11 +8122,11 @@ function search_patients_by_dailynum_count($q, $labsection = 0)
 				"(select specimen_id from specimen where specimen_type_id in ".
 				"(select specimen_type_id from specimen_test where test_type_id in ".
 				"(select test_type_id as lab_section from test_type where test_category_id = $labsection)))";
-		}	
+		}
 	}
-	
-	
-	$saved_db = DbUtil::switchToLabConfig($_SESSION['lab_config_id']);	
+
+
+	$saved_db = DbUtil::switchToLabConfig($_SESSION['lab_config_id']);
 	$resultset = query_associative_one($query_string);
 	DbUtil::switchRestore($saved_db);
 	return $resultset['val'];
@@ -8157,7 +8137,7 @@ function search_specimens_by_id($q)
 	global $con;
 	$q = mysql_real_escape_string($q, $con);
 	# Searches for specimens with similar ID
-	$query_string = 
+	$query_string =
 		"SELECT * FROM specimen ".
 		"WHERE specimen_id LIKE '%$q%'";
 	$resultset = query_associative_all($query_string);
@@ -8177,7 +8157,7 @@ function search_specimens_by_addlid($q)
 	global $con;
 	$q = mysql_real_escape_string($q, $con);
 	# Searches for specimens with similar addl ID
-	$query_string = 
+	$query_string =
 		"SELECT * FROM specimen ".
 		"WHERE aux_id LIKE '%$q%'";
 	$resultset = query_associative_all($query_string);
@@ -8197,7 +8177,7 @@ function search_specimens_by_patient_id($patient_id)
 	global $con;
 	$patient_id = mysql_real_escape_string($patient_id, $con);
 	# Searches for specimens by patient ID
-	$query_string = 
+	$query_string =
 		"SELECT sp.* FROM specimen sp, patient p ".
 		"WHERE sp.patient_id=p.patient_id ".
 		"AND p.patient_id = '".$patient_id."'";// OR p.patient_id LIKE '%".$patient_id."%'";
@@ -8218,7 +8198,7 @@ function search_specimens_by_patient_name($patient_name)
 	# Searches for specimens by patient name
 	global $con;
 	$patient_name = mysql_real_escape_string($patient_name, $con);
-	$query_string = 
+	$query_string =
 		"SELECT sp.* FROM specimen sp, patient p ".
 		"WHERE sp.patient_id=p.patient_id ".
 		"AND p.name LIKE '%$patient_name%' ";
@@ -8300,7 +8280,7 @@ function get_patients_by_name_or_id($search_term)
 	$search_term = mysql_real_escape_string($search_term, $con);
 	# Searches for patients with similar PID or Name
 	# Called from patient_fetch.php
-	$query_string = 
+	$query_string =
 		"SELECT * FROM patient ".
 		"WHERE patient_id LIKE '%$search_term%' ".
 		"OR name LIKE '%$search_term%'";
@@ -8328,7 +8308,7 @@ $pid = $modified_record->patientId;
 		$modified_record->name = $current_record->name;
 	if(trim($modified_record->age) == "" || is_nan($modified_record->age))
 		$modified_record->age=0;
-	$query_string = 
+	$query_string =
 		"UPDATE patient SET ".
 		"name='$modified_record->name', ".
 		"surr_id='$modified_record->surrogateId', ".
@@ -8366,7 +8346,7 @@ $pid = $modified_record->patientId;
 	fwrite($fh, $query_string);
 fclose($fh);
 	query_blind($query_string);
-	# Addition of custom fields: done from calling function/page	
+	# Addition of custom fields: done from calling function/page
 	return true;
 }
 
@@ -8403,7 +8383,7 @@ function get_pending_tests_by_type_date($test_type_id, $date_from,$date_to)
 		"AND ts >= '$date_from_array[0]-$date_from_array[1]-$date_from_array[2] 00:00:00' ".
 		"AND ts <='$date_to_array[0]-$date_to_array[1]-$date_to_array[2] 23:59:59'".
 		"AND result=''";
-		
+
 	$resultset = query_associative_all($query_string);
 	$retval = array();
 	foreach($resultset as $record)
@@ -8419,7 +8399,7 @@ function get_tests_by_specimen_id($specimen_id)
 	$specimen_id = mysql_real_escape_string($specimen_id, $con);
 	# Returns list of tests scheduled for this given specimen
 	$query_string = "SELECT * FROM test WHERE specimen_id=$specimen_id";
-	$saved_db = DbUtil::switchToLabConfig($_SESSION['lab_config_id']);	
+	$saved_db = DbUtil::switchToLabConfig($_SESSION['lab_config_id']);
 	$resultset = query_associative_all($query_string);
 	DbUtil::switchRestore($saved_db);
 	$retval = array();
@@ -8441,7 +8421,7 @@ function get_completed_tests_by_type($test_type_id, $date_from="", $date_to="")
 	{
 		if($test_type_id == 0)
 		{
-			$query_string = 
+			$query_string =
 				"SELECT UNIX_TIMESTAMP(t.ts) as ts, t.specimen_id, UNIX_TIMESTAMP(s.date_collected) as date_collected ".
 				"FROM test t, specimen s ".
 				"WHERE t.result <> '' ".
@@ -8449,7 +8429,7 @@ function get_completed_tests_by_type($test_type_id, $date_from="", $date_to="")
 		}
 		else
 		{
-			$query_string = 
+			$query_string =
 				"SELECT UNIX_TIMESTAMP(t.ts) as ts, t.specimen_id, UNIX_TIMESTAMP(s.date_collected) as date_collected ".
 				"FROM test t, specimen s ".
 				"WHERE s.test_type_id=$test_type_id ".
@@ -8461,7 +8441,7 @@ function get_completed_tests_by_type($test_type_id, $date_from="", $date_to="")
 	{
 		if($test_type_id == 0)
 		{
-			$query_string = 
+			$query_string =
 				"SELECT UNIX_TIMESTAMP(t.ts) as ts, t.specimen_id, UNIX_TIMESTAMP(s.date_collected) as date_collected ".
 				"FROM test t, specimen s ".
 				"WHERE t.result <> '' ".
@@ -8470,7 +8450,7 @@ function get_completed_tests_by_type($test_type_id, $date_from="", $date_to="")
 		}
 		else
 		{
-			$query_string = 
+			$query_string =
 				"SELECT UNIX_TIMESTAMP(t.ts) as ts, t.specimen_id, UNIX_TIMESTAMP(s.date_collected) as date_collected ".
 				"FROM test t, specimen s ".
 				"WHERE t.test_type_id=$test_type_id ".
@@ -8495,7 +8475,7 @@ function get_pendingtat_tests_by_type($test_type_id, $date_from="", $date_to="")
 	{
 		if($test_type_id == 0)
 		{
-			$query_string = 
+			$query_string =
 				"SELECT UNIX_TIMESTAMP(t.ts) as ts, t.specimen_id, UNIX_TIMESTAMP(s.date_collected) as date_collected ".
 				"FROM test t, specimen s ".
 				"WHERE t.result = '' ".
@@ -8503,7 +8483,7 @@ function get_pendingtat_tests_by_type($test_type_id, $date_from="", $date_to="")
 		}
 		else
 		{
-			$query_string = 
+			$query_string =
 				"SELECT UNIX_TIMESTAMP(t.ts) as ts, t.specimen_id, UNIX_TIMESTAMP(s.date_collected) as date_collected ".
 				"FROM test t, specimen s ".
 				"WHERE s.test_type_id=$test_type_id ".
@@ -8515,7 +8495,7 @@ function get_pendingtat_tests_by_type($test_type_id, $date_from="", $date_to="")
 	{
 		if($test_type_id == 0)
 		{
-			$query_string = 
+			$query_string =
 				"SELECT UNIX_TIMESTAMP(t.ts) as ts, t.specimen_id, UNIX_TIMESTAMP(s.date_collected) as date_collected ".
 				"FROM test t, specimen s ".
 				"WHERE t.result = '' ".
@@ -8524,7 +8504,7 @@ function get_pendingtat_tests_by_type($test_type_id, $date_from="", $date_to="")
 		}
 		else
 		{
-			$query_string = 
+			$query_string =
 				"SELECT UNIX_TIMESTAMP(t.ts) as ts, t.specimen_id, UNIX_TIMESTAMP(s.date_collected) as date_collected ".
 				"FROM test t, specimen s ".
 				"WHERE t.test_type_id=$test_type_id ".
@@ -8544,23 +8524,23 @@ function get_specimens_by_patient_id($patient_id, $labsection =0)
 	$patient_id = mysql_real_escape_string($patient_id, $con);
 	# Returns list of specimens registered for the given patient
 	if($labsection == 0){
-		$query_string = 
+		$query_string =
 		"SELECT * FROM specimen WHERE patient_id=$patient_id ORDER BY date_collected DESC";
 	} else {
-		$query_string = 
+		$query_string =
 		"SELECT DISTINCT s.* from specimen s, test t, test_type tt ".
 		"WHERE patient_id=$patient_id ".
 		"AND s.specimen_id=t.specimen_id AND t.test_type_id=tt.test_type_id AND tt.test_category_id=$labsection ".
 		"ORDER BY s.date_collected DESC";
 	}
 		//;
-	$saved_db = DbUtil::switchToLabConfig($_SESSION['lab_config_id']);	
+	$saved_db = DbUtil::switchToLabConfig($_SESSION['lab_config_id']);
 	$resultset = query_associative_all($query_string);
 	DbUtil::switchRestore($saved_db);
 	$retval = array();
 	foreach($resultset as $record)
 	{
-		
+
 		$retval[] = Specimen::getObject($record);
 	}
 	//echo $retval[0]->specimenId;
@@ -8570,7 +8550,7 @@ function get_specimens_by_patient_id($patient_id, $labsection =0)
 function add_specimen($specimen)
 {
 	# Adds a new specimen record in DB
-	$query_string = 
+	$query_string =
 		"INSERT INTO `specimen` ( specimen_id, patient_id, specimen_type_id, date_collected, date_recvd, user_id, status_code_id, referred_to, comments, aux_id, ".
 		"session_num, time_collected, report_to, doctor, referred_to_name, referred_from_name, daily_num, site_id) VALUES ( $specimen->specimenId, $specimen->patientId, $specimen->specimenTypeId, ".
 		"'$specimen->dateCollected', '$specimen->dateRecvd', $specimen->userId, $specimen->statusCodeId, $specimen->referredTo, '$specimen->comments', ".
@@ -8599,7 +8579,7 @@ function add_test($test, $testId=null)
 	# Adds a new test record in DB
 	if( $testId == null)
 		$testId = bcadd(get_max_test_id(),1);
-	$query_string = 
+	$query_string =
 		"INSERT INTO `test` ( test_id, specimen_id, test_type_id, result, comments, verified_by, user_id ) ".
 		"VALUES ( $testId, $test->specimenId, $test->testTypeId, '$test->result', '$test->comments', 0, $test->userId )";
 	query_insert_one($query_string);
@@ -8609,21 +8589,21 @@ function add_test($test, $testId=null)
 function add_test_random($test)
 {
 	# Adds a new test record in DB
-	$query_string = 
+	$query_string =
 		"INSERT INTO test (
-			test_type_id, 
-			specimen_id, 
-			result, 
+			test_type_id,
+			specimen_id,
+			result,
 			comments,
 			verified_by,
 			user_id,
-			ts ) 
+			ts )
 		VALUES (
-			$test->testTypeId,  
-			$test->specimenId, 
-			'$test->result', 
-			'$test->comments', 
-			0, 
+			$test->testTypeId,
+			$test->specimenId,
+			'$test->result',
+			'$test->comments',
+			0,
 			$test->userId,
 			'$test->ts' )";
 	query_insert_one($query_string);
@@ -8636,7 +8616,7 @@ function get_test_entry($specimen_id, $test_type_id)
 	$specimen_id = mysql_real_escape_string($specimen_id, $con);
 	$test_type_id = mysql_real_escape_string($test_type_id, $con);
 	# Returns the test_id primary key
-	$query_string = 
+	$query_string =
 		"SELECT * FROM test ".
 		"WHERE specimen_id=$specimen_id ".
 		"AND test_type_id=$test_type_id LIMIT 1";
@@ -8654,17 +8634,17 @@ function add_test_result($test_id, $result_entry, $comments="", $specimen_id="",
 	else
 		$current_ts = $ts;
 		//$current_ts = date("Y-m-d H:i:s" , $ts);
-	
+
 	# Append patient hash value to result field
 	$result_field = $result_entry.$hash_value;
 	# Add entry to DB
-	$query_string = 
+	$query_string =
 		"UPDATE `test` SET result='$result_field', ".
 		"comments='$comments', ".
 		"user_id=$user_id, ".
 		"ts='$current_ts' ".
 		"WHERE test_id=$test_id ";
-	
+
 	query_blind($query_string);
 	# If specimen ID was passed, update its status
 	if($specimen_id != "")
@@ -8697,7 +8677,7 @@ function set_specimen_status($specimen_id, $status_code)
 	$specimen_id = mysql_real_escape_string($specimen_id, $con);
 	# Sets specimen status to specified status code
 	# TODO: Link this to customized status codes in 'status_code' table
-	$query_string = 
+	$query_string =
 		"UPDATE `specimen` SET status_code_id=$status_code ".
 		"WHERE specimen_id=$specimen_id";
 	query_blind($query_string);
@@ -8709,7 +8689,7 @@ function get_specimen_status($specimen_id)
 	$specimen_id = mysql_real_escape_string($specimen_id, $con);
 	# Returns status of the given specimen
 	# TODO: Link this to customized status codes in 'status_code' table
-	$query_string = 
+	$query_string =
 		"SELECT status_code_id FROM specimen ".
 		"WHERE specimen_id=$specimen_id LIMIT 1";
 	$record = query_associative_one($query_string);
@@ -8721,10 +8701,10 @@ function get_specimen_by_id($specimen_id)
 	global $con;
 	$specimen_id = mysql_real_escape_string($specimen_id, $con);
 	# Fetches a specimen record by specimen id
-	$query_string = 
+	$query_string =
 		"SELECT * FROM specimen WHERE specimen_id=$specimen_id LIMIT 1";
 	//;
-	$saved_db = DbUtil::switchToLabConfig($_SESSION['lab_config_id']);	
+	$saved_db = DbUtil::switchToLabConfig($_SESSION['lab_config_id']);
 	$record = query_associative_one($query_string);
 	DbUtil::switchRestore($saved_db);
 	return Specimen::getObject($record);
@@ -8734,7 +8714,7 @@ function get_specimen_by_id_api($specimen_id, $lab_config_id)
 {
 	global $con;
 	$saved_db = DbUtil::switchToLabConfigRevamp($lab_config_id);
-	
+
 	$specimen_id = mysql_real_escape_string($specimen_id, $con);
 	# Fetches a specimen record by specimen id
 	$query_string =
@@ -8763,7 +8743,7 @@ function get_specimens_by_session($session_num)
 	global $con;
 	$session_num = mysql_real_escape_string($session_num, $con);
 	# Returns all specimens registered in this session
-	$query_string = 
+	$query_string =
 		"SELECT * FROM specimen ".
 		"WHERE session_num='$session_num'";
 	$resultset = query_associative_all($query_string);
@@ -8785,14 +8765,14 @@ function checkAndAddAdmin($adminName, $labConfigId, $dev=0) {
 	$labConfigId = mysql_real_escape_string($labConfigId, $con);
 	$saved_db = DbUtil::switchToGlobal();
 	if($dev == 0)
-		$query_check = "SELECT  a.user_id, a.username, a.password,a.actualname, a.email, a.created_by, a.ts, a.lab_config_id, a.level, a.phone, a.lang_id, b.value as rwoptions 
+		$query_check = "SELECT  a.user_id, a.username, a.password,a.actualname, a.email, a.created_by, a.ts, a.lab_config_id, a.level, a.phone, a.lang_id, b.value as rwoptions
 					FROM user a, user_config b  WHERE a.user_id = b.user_id and b.parameter = 'rwoptions' and a.username like '$adminName'";
 	else if($dev == 1)
 		$query_check = "SELECT  a.user_id, a.username, a.password,a.actualname, a.email, a.created_by, a.ts, a.lab_config_id, a.level, a.phone, a.lang_id
 					FROM user a WHERE a.lab_config_id = $labConfigId";
 
 	$record = query_associative_one($query_check);
-	
+
 	if($record) {
 		DbUtil::switchRestore($saved_db);
 		return $record['user_id'];
@@ -8807,7 +8787,7 @@ function checkAndAddAdmin($adminName, $labConfigId, $dev=0) {
 		query_insert_one($query_insert);
 		DbUtil::switchRestore($saved_db);
 		return $newAdminUserId;
-	}	
+	}
 }
 
 /* Checks if the lab admin user is added to user_config table or not and then adds it if it doesn't exist*/
@@ -8818,7 +8798,7 @@ function checkAndAddUserConfig($lab_admin_id){
 
 	$query_check = "SELECT user_id from user_config where user_id=$lab_admin_id";
 	$record = query_associative_one($query_check);
-	
+
 	if(!$record) {
 		#this branch is taken when developers import a backup into their application from a country director's interface
 		#query to insert into user_config
@@ -8826,7 +8806,7 @@ function checkAndAddUserConfig($lab_admin_id){
 						"VALUES ($lab_admin_id, 2, 'rwoptions', '2,3,4,6,7', $userId, CURDATE(), $userId, CURDATE()) ";
 		query_insert_one($query_insert);
 	}
-	
+
 	DbUtil::switchRestore($saved_db);
 	return;
 }
@@ -8839,29 +8819,29 @@ function add_lab_config($lab_config, $dev=0)
 	$record = query_associative_one($query_check);
 
 	if($dev == 0){
-		#This branch is taken when a new lab is created by a country director 
+		#This branch is taken when a new lab is created by a country director
 		# Adds a new lab configuration to DB
-		$query_add_lab_config = 
+		$query_add_lab_config =
 			"INSERT INTO lab_config(name, location, admin_user_id, id_mode, lab_config_id, country) ".
 			"VALUES ('$lab_config->name', '$lab_config->location', $lab_config->adminUserId, $lab_config->idMode, '$lab_config->id', '$lab_config->country')";
 		query_insert_one($query_add_lab_config);
 	}
 	else if($dev == 1  && is_null($record)){
-		# This branch is taken when an entry for lab in the config param doesn't exist in revamp db 
+		# This branch is taken when an entry for lab in the config param doesn't exist in revamp db
 		# (for devs importing lab backups using country director's interface)
-		$query_add_lab_config = 
+		$query_add_lab_config =
 			"INSERT INTO lab_config(admin_user_id, lab_config_id) ".
 			"VALUES ($lab_config->adminUserId, $lab_config->id)";
 		query_insert_one($query_add_lab_config);
 	}
 	else if($dev == 1 && (intval($record['admin_user_id']) != intval($lab_config->adminUserId))){
-		# This branch is taken when a lab backup is imported by developers in country director's interface, 
-		# and when an entry exists with an admin userid which is not the same as the one in lab config object param 
+		# This branch is taken when a lab backup is imported by developers in country director's interface,
+		# and when an entry exists with an admin userid which is not the same as the one in lab config object param
 		#Update the admin user id for the lab config in the object param passed
-		$query_update_lab_config = 
+		$query_update_lab_config =
 			"UPDATE lab_config ".
 			"SET admin_user_id = $lab_config->adminUserId WHERE lab_config_id = $lab_config->id";
-		query_update($query_update_lab_config);	
+		query_update($query_update_lab_config);
 	}
 
 	DbUtil::switchRestore($saved_db);
@@ -8873,7 +8853,7 @@ function add_lab_config_with_id($lab_config)
 	# Adds a new lab configuration to DB, when ID already known
 	$lab_config_id = $lab_config->id;
 	$saved_db = DbUtil::switchToLabConfigRevamp($lab_config_id);
-	$query_add_lab_config = 
+	$query_add_lab_config =
 		"INSERT INTO lab_config(lab_config_id, name, location, admin_user_id, id_mode) ".
 		"VALUES ($lab_config->id, '$lab_config->name', '$lab_config->location', $lab_config->adminUserId, $lab_config->idMode)";
 	query_insert_one($query_add_lab_config);
@@ -8894,7 +8874,7 @@ function add_lab_config_with_id($lab_config)
 function enable_new_test($lab_config_id, $test_type_id)
 {
     $saved_db = DbUtil::switchToLabConfigRevamp();
-    $query_ins= 
+    $query_ins=
 					"INSERT INTO lab_config_test_type(lab_config_id, test_type_id) ".
 					"VALUES ($lab_config_id, $test_type_id)";
     query_blind($query_ins);
@@ -8905,7 +8885,7 @@ function update_lab_config($updated_entry, $updated_specimen_list=null, $updated
 {
 	# Updates a lab configuration record
 	$saved_db = DbUtil::switchToGlobal();
-	$query_string = 
+	$query_string =
 		"UPDATE lab_config ".
 		"SET name='$updated_entry->name', ".
 		"location='$updated_entry->location', ".
@@ -8930,7 +8910,7 @@ function update_lab_config($updated_entry, $updated_specimen_list=null, $updated
 			else
 			{
 				# Add specimen type entry in mapping table
-				$query_ins= 
+				$query_ins=
 					"INSERT INTO lab_config_specimen_type(lab_config_id, specimen_type_id) ".
 					"VALUES ($updated_entry->id, $specimen_type_id)";
 				query_blind($query_ins);
@@ -8947,11 +8927,11 @@ function update_lab_config($updated_entry, $updated_specimen_list=null, $updated
 			else
 			{
 				# Remove specimen type entry from mapping table
-				$query_del = 
+				$query_del =
 					"DELETE FROM lab_config_specimen_type ".
 					"WHERE lab_config_id=$updated_entry->id ".
 					"AND specimen_type_id=$specimen_type_id";
-				query_blind($query_del);	
+				query_blind($query_del);
 			}
 		}
 	}
@@ -8970,7 +8950,7 @@ function update_lab_config($updated_entry, $updated_specimen_list=null, $updated
 			else
 			{
 				# Add test type entry in mapping table
-				$query_ins= 
+				$query_ins=
 					"INSERT INTO lab_config_test_type(lab_config_id, test_type_id) ".
 					"VALUES ($updated_entry->id, $test_type_id)";
 				query_blind($query_ins);
@@ -8987,7 +8967,7 @@ function update_lab_config($updated_entry, $updated_specimen_list=null, $updated
 			else
 			{
 				# Remove test type entry from mapping table
-				$query_del = 
+				$query_del =
 					"DELETE FROM lab_config_test_type ".
 					"WHERE lab_config_id=$updated_entry->id ".
 					"AND test_type_id=$test_type_id";
@@ -8996,11 +8976,11 @@ function update_lab_config($updated_entry, $updated_specimen_list=null, $updated
 				if($test_type_id != 0)
 				{
 					$saved_db2 = DbUtil::switchToLabConfig($updated_entry->id);
-					$query_del2 = 
+					$query_del2 =
 						"DELETE FROM report_config WHERE test_type_id=$test_type_id";
 					query_delete($query_del2);
 					DbUtil::switchRestore($saved_db2);
-				}				
+				}
 			}
 		}
 	}
@@ -9012,7 +8992,7 @@ function update_lab_config($updated_entry, $updated_specimen_list=null, $updated
 function update_stocks_details($name,$lot_number,$expiry_date,$manu,$quant,$supplier,$entry_id, $cost)
 {
 $saved_db = DbUtil::switchToLabConfigRevamp();
-$query_string = 
+$query_string =
 				"UPDATE stock_details SET name='$name',lot_number='$lot_number',expiry_date='$expiry_date',manufacturer='$manu',supplier='$supplier',current_quantity='$quant' , cost_per_unit='$cost' WHERE entry_id=$entry_id";
 				query_update($query_string);
 				DbUtil::switchRestore($saved_db);
@@ -9031,7 +9011,7 @@ $resultset = query_associative_all($query_string);
 		{
 		//echo $record['name'];
 		$retval[]=$record['name'];
-		}		
+		}
 	}
 				DbUtil::switchRestore($saved_db);
 return $retval;
@@ -9062,7 +9042,7 @@ function get_stock_details($entry_id)
 
 function add_new_stock($name,$lot_number,$expiry_date,$manufacture,$supplier,$quantity_supplied,$unit , $cost_per_unit,$ts) {
 	# Adds a new stock or update the quantity of the stock
-	
+
 	$saved_db = DbUtil::switchToLabConfigRevamp();
         # Find the entry_id (primary key)
 	/*$query_string = "SELECT MAX(entry_id) as'entry_id'FROM stock_details";
@@ -9071,16 +9051,16 @@ function add_new_stock($name,$lot_number,$expiry_date,$manufacture,$supplier,$qu
 	$entry_id=0;
 	else
 	$entry_id=$record['entry_id'];
-        
+
         $current_ts = date("Y-m-d H:i:s" , $ts[$i]);
-        
-        $query_string = 
+
+        $query_string =
                 "INSERT INTO stock_details(name,lot_number,expiry_date, manufacturer, quantity_ordered,quantity_supplied,current_quantity,supplier,unit,entry_id,cost_per_unit,date_of_reception, date_of_supply) ".
                 "VALUES ('$name[$i]','$lot_number[$i]','$expiry_date[$i]', '$manufacture[$i]', '$quantity_supplied[$i]' ,'$quantity_supplied[$i]','$current_quantity','$supplier[$i]','$unit[$i]','$current_entry_id','$cost_per_unit[$i]', '$current_ts','$current_ts')";
         query_insert_one($query_string);**/
-        
+
 	$length= count($name);
-	
+
 	# Find the entry_id (primary key)
 	$query_string = "SELECT MAX(entry_id) as'entry_id'FROM stock_details";
 	$record = query_associative_one($query_string);
@@ -9088,7 +9068,7 @@ function add_new_stock($name,$lot_number,$expiry_date,$manufacture,$supplier,$qu
 	$entry_id=0;
 	else
 	$entry_id=$record['entry_id'];
-	
+
 	for($i=0;$i<$length;$i++) {
 		$current_entry_id=$entry_id+1+$i;
 		if($name[$i]!="")
@@ -9103,15 +9083,15 @@ function add_new_stock($name,$lot_number,$expiry_date,$manufacture,$supplier,$qu
 					$query_string = "UPDATE stock_details SET current_quantity=$current_quantity WHERE name= '$name[$i]'";
 					query_update($query_string);
 				}
-		
+
 			}
-			
+
 			# If same lot number then no need to add another entry into stock_details table
 			$query_string="SELECT quantity_ordered, quantity_supplied, unit FROM stock_details WHERE name='$name[$i]' AND lot_number='$lot_number[$i]' AND manufacturer='$manufacture[$i]' AND supplier='$supplier[$i]' AND cost_per_unit=$cost_per_unit[$i] LIMIT 1";
 			$resultset = query_associative_all($query_string);
 			$current_ts = date("Y-m-d H:i:s" , $ts[$i]);
 			if($resultset==null) {
-				$query_string = 
+				$query_string =
 					"INSERT INTO stock_details(name,lot_number,expiry_date, manufacturer, quantity_ordered,quantity_supplied,current_quantity,supplier,unit,entry_id,cost_per_unit,date_of_reception, date_of_supply) ".
 					"VALUES ('$name[$i]','$lot_number[$i]','$expiry_date[$i]', '$manufacture[$i]', '$quantity_supplied[$i]' ,'$quantity_supplied[$i]','$current_quantity','$supplier[$i]','$unit[$i]','$current_entry_id','$cost_per_unit[$i]', '$current_ts','$current_ts')";
 				query_insert_one($query_string);
@@ -9157,7 +9137,7 @@ function get_stock_count()
 function get_stock_out_details()
 {
 $saved_db = DbUtil::switchToLabConfigRevamp();
-$query_string = 
+$query_string =
 		"SELECT name,current_quantity,new_balance,date_of_use,lot_number,user_name FROM stock_content";
 		$resultset = query_associative_all($query_string);
 		$retval = array();
@@ -9175,12 +9155,12 @@ $query_string =
 		{
 		$current_quantity=$quantity;
 		$quantity=$quantity."(new stock)";
-		
+
 		}
-		$retval[]= array($name,$lot_number,$quantity,$date_of_entry,$user,$current_quantity);	
+		$retval[]= array($name,$lot_number,$quantity,$date_of_entry,$user,$current_quantity);
 		}
 		}
-		
+
 		return $retval;
 DbUtil::switchRestore($saved_db);
 }
@@ -9190,7 +9170,7 @@ function get_current_inventory_byName($date_to,$date_from, $name)
 	$saved_db = DbUtil::switchToLabConfigRevamp();
 	global $con;
 	$name = mysql_real_escape_string($name, $con);
-	$query_string = 
+	$query_string =
 		"SELECT name,new_balance,date_of_use, lot_number FROM stock_content WHERE date_of_use<='$date_to' AND date_of_use >= '$date_from' AND name='$name' ";
 		$resultset = query_associative_all($query_string);
 	$retval = array();
@@ -9200,7 +9180,7 @@ function get_current_inventory_byName($date_to,$date_from, $name)
 			$quantity=$record['new_balance'];
 			$date_of_entry=$record['date_of_use'];
 			$lot_number=$record['lot_number'];
-		$retval[]= array( $name,$quantity,$date_of_entry, $lot_number);	
+		$retval[]= array( $name,$quantity,$date_of_entry, $lot_number);
 		}
 	}
 	return $retval;
@@ -9210,7 +9190,7 @@ function get_current_inventory_byName($date_to,$date_from, $name)
 
 function get_current_inventory($date_to,$date_from) {
 	$saved_db = DbUtil::switchToLabConfigRevamp();
-	$query_string = 
+	$query_string =
 		"SELECT name,new_balance,date_of_use, lot_number FROM stock_content WHERE date_of_use<='$date_to' AND date_of_use >= '$date_from' ";
 		$resultset = query_associative_all($query_string);
 		$retval = array();
@@ -9221,10 +9201,10 @@ function get_current_inventory($date_to,$date_from) {
 		$quantity=$record['new_balance'];
 		$date_of_entry=$record['date_of_use'];
 		$lot_number=$record['lot_number'];
-		$retval[]= array( $name,$quantity,$date_of_entry, $lot_number);	
+		$retval[]= array( $name,$quantity,$date_of_entry, $lot_number);
 		}
 		}
-		
+
 		return $retval;
 DbUtil::switchRestore($saved_db);
 
@@ -9234,7 +9214,7 @@ DbUtil::switchRestore($saved_db);
 function get_stocks()
 {
 	$saved_db = DbUtil::switchToLabConfigRevamp();
-	$query_string = 
+	$query_string =
 		"SELECT name,lot_number, manufacturer,current_quantity,expiry_date,supplier,unit,entry_id ,cost_per_unit, date_of_reception FROM stock_details ORDER BY name ASC, manufacturer ASC, lot_number ASC, date_of_reception DESC";
 	$resultset = query_associative_all($query_string);
 	$retval = array();
@@ -9250,17 +9230,17 @@ function get_stocks()
 			$entry_id=$record['entry_id'];
 			$cost=$record['cost_per_unit'];
 			$date_of_reception = $record['date_of_reception'];
-			$retval[]= array($name, $lot_number,$manufacture,$quantity,$expiry_date,$supplier,$unit,$entry_id ,$cost, $receive_date);	
+			$retval[]= array($name, $lot_number,$manufacture,$quantity,$expiry_date,$supplier,$unit,$entry_id ,$cost, $receive_date);
 		}
 	}
-	DbUtil::switchRestore($saved_db);		
+	DbUtil::switchRestore($saved_db);
 	return $retval;
 }
 
 function get_entry_ids()
 {
 	$saved_db = DbUtil::switchToLabConfigRevamp();
-	$query_string = 
+	$query_string =
 		"SELECT entry_id  FROM stock_details ORDER BY entry_id ";
 	$resultset = query_associative_all($query_string);
 	$retval = array();
@@ -9283,10 +9263,10 @@ function update_stocks($name, $lot_number, $quant, $receiver, $remarks, $ts)
 	$remarks = mysql_real_escape_string($remarks, $con);
 	$saved_db = DbUtil::switchToLabConfigRevamp();
 	$current_ts = date("Y-m-d H:i:s" , $ts);
-	$query_string = 
+	$query_string =
 		"SELECT current_quantity, quantity_supplied, quantity_used, used, user_name, receiver, remarks FROM stock_details WHERE name='$name' and lot_number='$lot_number'";
 	$record = query_associative_one($query_string);
-	
+
 	if($record!=null) {
 		$current_quantity=(int)$record['current_quantity'];
 		$quantity_supplied=$record['quantity_supplied'];
@@ -9295,47 +9275,47 @@ function update_stocks($name, $lot_number, $quant, $receiver, $remarks, $ts)
 		$username=$record['user_name'];
 		$receiver_old=$record['receiver'];
 		$remarks_old=$record['remarks'];
-				
+
 		$quantity_supplied_integer=(int)$quantity_supplied;
 		$quantity_used_integer=(int)$quantity_used;
 		$quant_integer=(int)$quant;
-		
+
 		$quant_finally_used=$quant_integer+$quantity_used_integer;
 		$new_current_quant=$current_quantity-$quant_integer;
 		$user_name=get_username_by_id($_SESSION['user_id']);
-		
+
 		#Checking to see if first entry or not and then appending or creating
-		if($use=="") 
-			$use_new=$current_ts.":".$quantity_integer;	
+		if($use=="")
+			$use_new=$current_ts.":".$quantity_integer;
 		else
 			$use_new=$use.",".$current_ts.":".$quantity_integer;
-			
+
 		if($receiver=="")
 			$receiver_new=$receiver;
 		else
 			$receiver_new=$receiver_old.",".$receiver;
-			
+
 		if($remarks=="")
 			$remarks_new=$remarks;
 		else
 			$remarks_new=$remarks_old.",".$remarks;
-			
-		#Checking to see that the quantity is present in DB	
-		if($quant_finally_used<=$quantity_supplied_integer) { 
+
+		#Checking to see that the quantity is present in DB
+		if($quant_finally_used<=$quantity_supplied_integer) {
 			$quant_final=$current_quantity-$quant_integer;
-			//$query_string = 
+			//$query_string =
 				// "INSERT INTO stock_content(name, current_quantity,lot_number, receiver ,remarks ,new_balance ,date_of_use,user_name) ".
 				// "VALUES ('$name', '$quant_final' ,'$lot_number','$receiver', '$remarks','$new_current_quant','$current_ts' , '$user_name')";
 			//query_insert_one($query_string);
-			
-			$query_string = 
+
+			$query_string =
 				"UPDATE stock_details SET current_quantity=$quant_final WHERE name= '$name'";
 			query_update($query_string);
-			$query_string = 
+			$query_string =
 				"UPDATE stock_details SET quantity_used=$quant_finally_used, used='$use_new', receiver='$receiver_new', remarks='$remarks_new' ".
 				"WHERE name= '$name' and lot_number='$lot_number'";
 			query_update($query_string);
-	
+
 			DbUtil::switchRestore($saved_db);
 			return 1;
 		}
@@ -9343,19 +9323,19 @@ function update_stocks($name, $lot_number, $quant, $receiver, $remarks, $ts)
 			DbUtil::switchRestore($saved_db);
 			return -1;
 		}
-		
+
 	}
 }
 
 /////////////////////////////////
 // This is add currency module //
-///////////////////////////////// 
+/////////////////////////////////
 function add_currency_lab_config($lab_config_id, $new_currency)
 {
 	global $con;
 	$lab_config_id = mysql_real_escape_string($lab_config_id, $con);
 	$saved_db = DbUtil::switchToLabConfig($lab_config_id);
-	$query_string = 
+	$query_string =
 			"select count(*) as currencyCount from currency_conversion where currencyb='$new_currency' limit 1";
 	$record = query_associative_one($query_string);
 	$retval = $record['currencyCount'];
@@ -9368,7 +9348,7 @@ function add_currency_lab_config($lab_config_id, $new_currency)
 		$record = query_associative_one($query_string);
 		$retval = $record['currencyCount'];
 		if($retval > 0){
-		$query_string = "insert into currency_conversion (currencya, currencyb, exchangerate, updatedts) 
+		$query_string = "insert into currency_conversion (currencya, currencyb, exchangerate, updatedts)
 		values ('$new_currency','$new_currency', 1, '$date_updated')";
 		query_insert_one($query_string);
 		} else {
@@ -9383,7 +9363,7 @@ function add_currency_lab_config($lab_config_id, $new_currency)
 
 /////////////////////////////////
 // This is add currency rate module //
-///////////////////////////////// 
+/////////////////////////////////
 
 function add_currency_rate_lab_config($lab_config_id, $default_currency, $new_currency, $exchange_rate)
 {
@@ -9446,7 +9426,7 @@ function delete_lab_config($lab_config_id)
 		"WHERE lab_config_id=$lab_config->id";
 	query_blind($query_string);
 	# Delete technician accounts
-	$query_string = 
+	$query_string =
 		"DELETE FROM user ".
 		"WHERE lab_config_id=$lab_config->id";
 	query_blind($query_string);
@@ -9455,7 +9435,7 @@ function delete_lab_config($lab_config_id)
 		"DELETE FROM report_disease WHERE lab_config_id=$lab_config->id";
 	query_blind($query_string);
 	# Delete entry from lab_config
-	$query_string = 
+	$query_string =
 		"DELETE FROM lab_config ".
 		"WHERE lab_config_id=$lab_config->id";
 	query_blind($query_string);
@@ -9492,8 +9472,8 @@ function blis_db_update($lab_config_id, $db_name, $ufile)
 	{
 		query_blind($sql_command.";");
 	}
-	
-	
+
+
 }
 
 
@@ -9533,7 +9513,7 @@ function set_lab_config_db_name($lab_config_id, $db_name)
 	$lab_config_id = mysql_real_escape_string($lab_config_id, $con);
 	# Sets database instance name for lab configuration
 	$saved_db = DbUtil::switchToGlobal();
-	$query_string = 
+	$query_string =
 		"UPDATE lab_config ".
 		"SET db_name='$db_name' ".
 		"WHERE lab_config_id='$lab_config_id' ";
@@ -9559,7 +9539,7 @@ function get_lab_config_id_admin($user_id)
 $query_string = "SELECT lab_config_id FROM lab_config WHERE admin_user_id='$user_id'";
 $record = query_associative_one($query_string);
 		$id = $record['lab_config_id'];
-		
+
 return $id;
 }
 
@@ -9574,7 +9554,7 @@ function get_lab_config_id($user_id)
 if($id==0)
 $id=get_lab_config_id_admin($user_id);
 //echo "second:".$id;
-	DbUtil::switchRestore($saved_db);	
+	DbUtil::switchRestore($saved_db);
 	return $id;
 }
 
@@ -9598,7 +9578,7 @@ function get_lab_configs_imported()
 		DbUtil::switchRestore($saved_db);
 		return $retval;
 	}
-        
+
 	foreach($resultset as $record)
 	{
 		$retval[] = LabConfig::getById($record['lab_config_id']);
@@ -9653,7 +9633,7 @@ function get_lab_configs($admin_user_id = "")
 	else if(is_country_dir($user))
 	{
 		# Country director: Fetch lab configs from lab_config_access table
-		$query_configs = 
+		$query_configs =
 			"SELECT * from lab_config lc ".
 			"WHERE lc.lab_config_id IN ( ".
 			"SELECT lca.lab_config_id from lab_config_access lca ".
@@ -9664,7 +9644,7 @@ function get_lab_configs($admin_user_id = "")
 	{
 		# Fetch all lab configs
 
-		$query_configs = 
+		$query_configs =
 			"SELECT * FROM lab_config ".
 			"WHERE admin_user_id=$admin_user_id ".
 			"OR lab_config_id IN ( ".
@@ -9720,7 +9700,7 @@ function get_lab_config_num_specimens_pending($lab_config_id, $specimen_type_id=
 	if($specimen_type_id != "")
 	{
 		# Narrow down to specimen type
-		$query_string = 
+		$query_string =
 			"SELECT COUNT(DISTINCT t.specimen_id) AS val ".
 			"FROM test t, specimen sp ".
 			"WHERE t.result='' ".
@@ -9730,7 +9710,7 @@ function get_lab_config_num_specimens_pending($lab_config_id, $specimen_type_id=
 	else
 	{
 		# Count for all specimen types
-		$query_string = 
+		$query_string =
 			"SELECT COUNT(DISTINCT specimen_id) AS val FROM test ".
 			"WHERE result=''";
 	}
@@ -9750,7 +9730,7 @@ function get_lab_config_num_tests_pending($lab_config_id, $test_type_id="")
 	if($test_type_id != "")
 	{
 		# Narrow down to test type
-		$query_string = 
+		$query_string =
 			"SELECT COUNT(*) AS val FROM test ".
 			"WHERE result='' ".
 			"AND test_type_id=$test_type_id";
@@ -9758,7 +9738,7 @@ function get_lab_config_num_tests_pending($lab_config_id, $test_type_id="")
 	else
 	{
 		# Count for all test types
-		$query_string = 
+		$query_string =
 			"SELECT COUNT(*) AS val FROM test ".
 			"WHERE result=''";
 	}
@@ -9969,7 +9949,7 @@ function get_test_types_by_site($lab_config_id="")
 	else
 		$query_string = "SELECT * FROM test_type ORDER BY name";
 		/*
-		$query_string = 
+		$query_string =
 			"SELECT tt.* FROM test_type tt, lab_config_test_type lctt ".
 			"WHERE tt.test_type_id=lctt.test_type_id ".
 			"AND lctt.lab_config_id=$lab_config_id ORDER BY tt.name";
@@ -9992,7 +9972,7 @@ function get_test_types_by_site_category($lab_config_id, $cat_code)
 	# configured for a particular site
 	$saved_db = DbUtil::switchToLabConfigRevamp($lab_config_id);
 	$retval = array();
-	$query_string = 
+	$query_string =
 		"SELECT tt.* FROM test_type tt, lab_config_test_type lctt ".
 		"WHERE tt.test_type_id=lctt.test_type_id ".
 		"AND lctt.lab_config_id=$lab_config_id ORDER BY tt.name";
@@ -10018,7 +9998,7 @@ function get_test_types_by_site_map($lab_config_id)
 	global $CATALOG_TRANSLATION;
 	$saved_db = DbUtil::switchToLabConfigRevamp($lab_config_id);
 	$retval = array();
-	$query_string = 
+	$query_string =
 		"SELECT tt.* FROM test_type tt, lab_config_test_type lctt ".
 		"WHERE tt.test_type_id=lctt.test_type_id ".
 		"AND lctt.lab_config_id=$lab_config_id ".
@@ -10042,7 +10022,7 @@ function get_users_by_site_map($lab_config_id)
 	# Returns a list of usernames configured for a particular site
 	$saved_db = DbUtil::switchToGlobal();
 	$retval = array();
-	$query_string = 
+	$query_string =
 		"SELECT u.* FROM user u ".
 		"WHERE lab_config_id=$lab_config_id ORDER BY u.username";
 	$resultset = query_associative_all($query_string);
@@ -10068,7 +10048,7 @@ function get_tech_users_by_site_map($lab_config_id)
 	# Returns a list of technician usernames configured for a particular site
 	$saved_db = DbUtil::switchToGlobal();
 	$retval = array();
-	$query_string = 
+	$query_string =
 		"SELECT u.* FROM user u ".
 		"WHERE lab_config_id = $lab_config_id ORDER BY u.username";
 	$resultset = query_associative_all($query_string);
@@ -10098,7 +10078,7 @@ function get_specimen_types_by_site($lab_config_id="")
 		$query_string = "SELECT * FROM specimen_type WHERE disabled=0 ORDER BY NAME";
 	else
 		/*
-		$query_string = 
+		$query_string =
 			"SELECT st.* FROM specimen_type st, lab_config_specimen_type lcst ".
 			"WHERE st.disabled=0  AND st.specimen_type_id=lcst.specimen_type_id ".
 			"AND lcst.lab_config_id=$lab_config_id ORDER BY st.name";
@@ -10123,7 +10103,7 @@ function add_specimen_type($specimen_name, $specimen_descr, $test_list=array())
 	$specimen_descr = mysql_real_escape_string($specimen_descr, $con);
 	# Adds a new specimen type in DB with compatible tests in $test_list
 	$saved_db = DbUtil::switchToLabConfigRevamp();
-	$query_string = 
+	$query_string =
 		"INSERT INTO specimen_type(name, description) ".
 		"VALUES ('$specimen_name', '$specimen_descr')";
 	query_insert_one($query_string);
@@ -10133,7 +10113,7 @@ function add_specimen_type($specimen_name, $specimen_descr, $test_list=array())
 		# For each compatible test type, add a new entry in 'specimen_test' map table
 		foreach($test_list as $test_type_id)
 		{
-			$query_string = 
+			$query_string =
 				"INSERT INTO specimen_test(test_type_id, specimen_type_id) ".
 				"VALUES ($test_type_id, $specimen_type_id)";
 			query_insert_one($query_string);
@@ -10174,7 +10154,7 @@ function update_specimen_type($updated_entry, $new_test_list)
 		else
 		{
 			# Remove entry from mapping table
-			$query_del = 
+			$query_del =
 				"DELETE from specimen_test ".
 				"WHERE test_type_id=$test_type_id ".
 				"AND specimen_type_id=$updated_entry->specimenTypeId";
@@ -10192,7 +10172,7 @@ function update_specimen_type($updated_entry, $new_test_list)
 		else
 		{
 			# Add entry in mapping table
-			$query_ins = 
+			$query_ins =
 				"INSERT INTO specimen_test (specimen_type_id, test_type_id) ".
 				"VALUES ($updated_entry->specimenTypeId, $test_type_id)";
 			query_blind($query_ins);
@@ -10213,26 +10193,26 @@ function add_test_type($test_name, $test_descr, $clinical_data, $cat_code, $is_p
 	# Adds a new test type in DB with compatible specimens in 'specimen_list'
 	$saved_db = DbUtil::switchToLabConfigRevamp();
 	$is_panel_num = 1;
-        
+
 	if($is_panel == false)
 	{
 		$is_panel_num = 0;
-	}       
+	}
         if($prevalenceThreshold == "")
             $prevalenceThreshold = 70;
-        
+
         if($targetTat == "")
             $targetTat = 24;
-        
+
 	if($clinical_data=="")
 	{
-	$query_string = 
+	$query_string =
 		"INSERT INTO test_type(name, description,test_category_id, is_panel, hide_patient_name, prevalence_threshold, target_tat) ".
 		"VALUES ('$test_name', '$test_descr','$cat_code', '$is_panel_num', '$hide_patient_name', $prevalenceThreshold, $targetTat)";
 	}
 	else
 	{
-	$query_string = 
+	$query_string =
 		"INSERT INTO test_type(name, description,clinical_data, test_category_id, is_panel, hide_patient_name, prevalence_threshold, target_tat) ".
 		"VALUES ('$test_name', '$test_descr','$clinical_data', '$cat_code', '$is_panel_num', '$hide_patient_name', $prevalenceThreshold, $targetTat)";
 	}
@@ -10301,7 +10281,7 @@ function update_test_type($updated_entry, $new_specimen_list,$lab_config_id)
 		else
 		{
 			# Remove entry from mapping table
-			$query_del = 
+			$query_del =
 				"DELETE from specimen_test ".
 				"WHERE test_type_id=$updated_entry->testTypeId ".
 				"AND specimen_type_id=$specimen_type_id";
@@ -10319,7 +10299,7 @@ function update_test_type($updated_entry, $new_specimen_list,$lab_config_id)
 		else
 		{
 			# Add entry in mapping table
-			$query_ins = 
+			$query_ins =
 				"INSERT INTO specimen_test (specimen_type_id, test_type_id) ".
 				"VALUES ($specimen_type_id, $updated_entry->testTypeId)";
 			query_blind($query_ins);
@@ -10335,7 +10315,7 @@ function add_test_category($cat_name, $cat_descr="")
 	$cat_descr = mysql_real_escape_string($cat_descr, $con);
 	# Adds a new test category to catalog
 	$saved_db = DbUtil::switchToLabConfigRevamp();
-	$query_string = 
+	$query_string =
 		"INSERT INTO test_category(name, description) ".
 		"VALUES ('$cat_name', '$cat_descr')";
 	query_insert_one($query_string);
@@ -10352,7 +10332,7 @@ function add_measure($measure, $range, $unit)
 	$range = mysql_real_escape_string($range, $con);
 	$unit = mysql_real_escape_string($unit, $con);
 	$saved_db = DbUtil::switchToLabConfigRevamp();
-	$query_string = 
+	$query_string =
 		"INSERT INTO measure(`name`, `range`, unit) ".
 		"VALUES ('$measure', '$range', '$unit')";
 	query_insert_one($query_string);
@@ -10445,7 +10425,7 @@ function get_search_fields($lab_config_id=null)
 	$query_sfields ="SELECT pid, p_addl, daily_num, pname, sex, age, dob FROM lab_config WHERE lab_config_id=$lab_config_id";
         $resultset = query_associative_one($query_sfields);
 	//$retval = array();
-	
+
 	DbUtil::switchRestore($saved_db);
 	return $resultset;
 }
@@ -10468,13 +10448,13 @@ function getDoctorNames()
 }
 
 function get_test_categories_data($lab_config_id) {
-	
-        $saved_db = DbUtil::switchToLabConfig($lab_config_id);		
+
+        $saved_db = DbUtil::switchToLabConfig($lab_config_id);
         $query_string = "SELECT test_category_id, name FROM test_category";
 	$resultset = query_associative_all($query_string);
 	$retval = array();
         $i = 0;
-        
+
 	foreach($resultset as $record)
 	{
             $retval[$i] = array(2);
@@ -10487,8 +10467,8 @@ function get_test_categories_data($lab_config_id) {
 }
 
 function get_test_ids_by_category($cat, $lab_config_id) {
-	
-        $saved_db = DbUtil::switchToLabConfig($lab_config_id);		
+
+        $saved_db = DbUtil::switchToLabConfig($lab_config_id);
         $query_string = "SELECT test_type_id FROM test_type WHERE test_category_id = $cat";
 	$resultset = query_associative_all($query_string);
 	$retval = array();
@@ -10552,7 +10532,7 @@ function get_test_category_name_by_id($cat_id)
 	if($CATALOG_TRANSLATION === true)
 	{
 		$saved_db = DbUtil::switchToLabConfig();
-		$query_string = 
+		$query_string =
 			"SELECT * FROM test_category ".
 			"WHERE test_category_id=$cat_id LIMIT 1";
 		$record = query_associative_one($query_string);
@@ -10562,7 +10542,7 @@ function get_test_category_name_by_id($cat_id)
 	else
 	{
 		$saved_db = DbUtil::switchToLabConfigRevamp();
-		$query_string = 
+		$query_string =
 			"SELECT name FROM test_category ".
 			"WHERE test_category_id=$cat_id LIMIT 1";
 		$record = query_associative_one($query_string);
@@ -10591,7 +10571,7 @@ function get_test_types_wcat_catalog()
 			$retval[$record['test_type_id']] = $record['name'];
 	}
 	DbUtil::switchRestore($saved_db);
-	return $retval;	
+	return $retval;
 }
 
 function getMeasuresByLab($labConfigId) {
@@ -10633,7 +10613,7 @@ function get_measure_by_id($measure_id)
 	$measure_id = mysql_real_escape_string($measure_id, $con);
 	# Returns Measure object from DB
 	$saved_db = DbUtil::switchToLabConfigRevamp();
-	$query_measure = 
+	$query_measure =
 		"SELECT * FROM measure WHERE measure_id=$measure_id LIMIT 1";
 	$record = query_associative_one($query_measure);
 	$retval = Measure::getObject($record);
@@ -10656,7 +10636,7 @@ function get_test_type_measure($test_type_id)
 	{
 		$dummy_list = array();
 		return $dummy_list;
-	}	
+	}
 }
 
 function get_specimen_type_by_name($specimen_name)
@@ -10667,7 +10647,7 @@ function get_specimen_type_by_name($specimen_name)
 	$user = get_user_by_id($_SESSION['user_id']);
 	$lab_config_id = $user->labConfigId;
 	$saved_db = DbUtil::switchToLabConfigRevamp($lab_config_id);
-	$query_string = 
+	$query_string =
 		"SELECT * FROM specimen_type WHERE name='$specimen_name' AND disabled=0 LIMIT 1";
 	$record = query_associative_one($query_string);
 	DbUtil::switchRestore($saved_db);
@@ -10699,8 +10679,8 @@ function get_specimen_name_by_id($specimen_type_id)
 	else
 	{
 		//$saved_db = DbUtil::switchToLabConfigRevamp();
-		$saved_db = DbUtil::switchToLabConfig($_SESSION['lab_config_id']);	
-		$query_string = 
+		$saved_db = DbUtil::switchToLabConfig($_SESSION['lab_config_id']);
+		$query_string =
 			"SELECT name FROM specimen_type ".
 			"WHERE specimen_type_id=$specimen_type_id LIMIT 1";
 		$record = query_associative_one($query_string);
@@ -10724,8 +10704,8 @@ function get_test_name_by_id($test_type_id, $lab_config_id=null)
 	else
 	{
 		//$saved_db = DbUtil::switchToLabConfigRevamp($lab_config_id);
-		$saved_db = DbUtil::switchToLabConfig($_SESSION['lab_config_id']);	
-		$query_string = 
+		$saved_db = DbUtil::switchToLabConfig($_SESSION['lab_config_id']);
+		$query_string =
 			"SELECT name FROM test_type ".
 			"WHERE test_type_id=$test_type_id LIMIT 1";
 		$record = query_associative_one($query_string);
@@ -10748,7 +10728,7 @@ function get_clinical_data_by_id($test_type_id)
 	else
 	{
 		$saved_db = DbUtil::switchToLabConfigRevamp();
-		$query_string = 
+		$query_string =
 			"SELECT clinical_data FROM test_type ".
 			"WHERE test_type_id=$test_type_id LIMIT 1";
 		$record = query_associative_one($query_string);
@@ -10819,7 +10799,7 @@ function search_test_types_catalog($test_name)
 	$test_name = mysql_real_escape_string($test_name, $con);
 	global $CATALOG_TRANSLATION;
 	$saved_db = DbUtil::switchToLabConfigRevamp();
-	$query_string = 
+	$query_string =
 		"SELECT * FROM test_type WHERE name LIKE '$test_name%' AND disabled=0";
 	$resultset = query_associative_all($query_string);
 	$retval = array();
@@ -10842,7 +10822,7 @@ function search_specimen_types_catalog($specimen_name)
 	$specimen_name = mysql_real_escape_string($specimen_name, $con);
 	global $CATALOG_TRANSLATION;
 	$saved_db = DbUtil::switchToLabConfigRevamp();
-	$query_string = 
+	$query_string =
 		"SELECT * FROM specimen_type WHERE disabled=0 AND name LIKE '$specimen_name%'";
 	$resultset = query_associative_all($query_string);
 	$retval = array();
@@ -10851,7 +10831,7 @@ function search_specimen_types_catalog($specimen_name)
 		if($CATALOG_TRANSLATION === true)
 			$retval[$record['specimen_type_id']] = LangUtil::getSpecimenName($record['specimen_type_id']);
 		else
-			$retval[$record['specimen_type_id']] = $record['name'];		
+			$retval[$record['specimen_type_id']] = $record['name'];
 	}
 	DbUtil::switchRestore($saved_db);
 	return $retval;
@@ -10894,7 +10874,7 @@ function getDoctorList()
 		return $retval;
 	foreach($resultset as $record)
 	{
-		
+
 		$retval[] = $record['doctor'];
 	}
 		return $retval;
@@ -11029,14 +11009,14 @@ function update_session_number($session_date_string)
 {
 	# Updates count values for session numbers
 	# Called from ajax/session_num_update.php
-	$query_string = 
+	$query_string =
 		"SELECT * FROM specimen_session ".
 		"WHERE session_num='$session_date_string'";
 	$record = query_associative_one($query_string);
 	if($record == null)
 	{
 		# No entry exists. Add one.
-		$query_string = 
+		$query_string =
 			"INSERT INTO specimen_session(session_num, count) ".
 			"VALUES ('$session_date_string', 1)";
 		query_insert_one($query_string);
@@ -11182,7 +11162,7 @@ function update_daily_number($daily_date_string, $curr_count)
 	if($record == null)
 	{
 		# No entry exists. Add one.
-		$query_string = 
+		$query_string =
 			"INSERT INTO patient_daily(datestring, count) ".
 			"VALUES ('$daily_date_string', $count_val)";
 		query_insert_one($query_string);
@@ -11210,7 +11190,7 @@ function add_test_type_measure($test_type_id, $measure_id)
 	$measure_id = mysql_real_escape_string($measure_id, $con);
 	$saved_db = DbUtil::switchToLabConfigRevamp();
 	# Adds a new entry to test_type->measure map table
-	$query_check = 
+	$query_check =
 		"SELECT * FROM test_type_measure ".
 		"WHERE test_type_id=$test_type_id AND measure_id=$measure_id";
 	$flag_exists = query_associative_one($query_check);
@@ -11235,7 +11215,7 @@ function delete_test_type_measure($test_type_id, $measure_id)
 	$test_type_id = mysql_real_escape_string($test_type_id, $con);
 	$measure_id = mysql_real_escape_string($measure_id, $con);
 	$saved_db = DbUtil::switchToLabConfigRevamp();
-	$query_string = 
+	$query_string =
 		"DELETE FROM test_type_measure ".
 		"WHERE test_type_id=$test_type_id AND measure_id=$measure_id";
 	query_delete($query_string);
@@ -11260,7 +11240,7 @@ function add_specimen_test($specimen_type_id, $test_type_id)
 	$specimen_type_id = mysql_real_escape_string($specimen_type_id, $con);
 	$saved_db = DbUtil::switchToLabConfigRevamp();
 	# Adds a new entry to specimen_type->test_type map table
-	$query_check = 
+	$query_check =
 		"SELECT * FROM specimen_test ".
 		"WHERE test_type_id=$test_type_id AND specimen_type_id=$specimen_type_id";
 	$flag_exists = query_associative_one($query_check);
@@ -11285,7 +11265,7 @@ function add_lab_config_test_type($lab_config_id, $test_type_id)
 	$test_type_id = mysql_real_escape_string($test_type_id, $con);
 	$lab_config_id = mysql_real_escape_string($lab_config_id, $con);
 	$saved_db = DbUtil::switchToLabConfigRevamp($lab_config_id);
-	$query_check = 
+	$query_check =
 		"SELECT * FROM lab_config_test_type ".
 		"WHERE test_type_id=$test_type_id AND lab_config_id=$lab_config_id";
 	$flag_exists = query_associative_one($query_check);
@@ -11309,7 +11289,7 @@ function add_lab_config_specimen_type($lab_config_id, $specimen_type_id)
 	$specimen_type_id = mysql_real_escape_string($specimen_type_id, $con);
 	$lab_config_id = mysql_real_escape_string($lab_config_id, $con);
 	$saved_db = DbUtil::switchToLabConfigRevamp($lab_config_id);
-	$query_check = 
+	$query_check =
 		"SELECT * FROM lab_config_specimen_type ".
 		"WHERE specimen_type_id=$specimen_type_id AND lab_config_id=$lab_config_id";
 	$flag_exists = query_associative_one($query_check);
@@ -11333,7 +11313,7 @@ function add_lab_config_access($user_id, $lab_config_id)
 	$user_id = mysql_real_escape_string($user_id, $con);
 	$lab_config_id = mysql_real_escape_string($lab_config_id, $con);
 	$saved_db = DbUtil::switchToGlobal();
-	$query_check = 
+	$query_check =
 		"SELECT * FROM lab_config_access ".
 		"WHERE user_id=$user_id AND lab_config_id like '$lab_config_id'";
 	$flag_exists = query_associative_one($query_check);
@@ -11360,7 +11340,7 @@ function get_compatible_tests($specimen_type_id)
 	global $con;
 	$specimen_type_id = mysql_real_escape_string($specimen_type_id, $con);
 	$saved_db = DbUtil::switchToLabConfigRevamp();
-	$query_string = 
+	$query_string =
 		"SELECT test_type_id FROM specimen_test WHERE specimen_type_id=$specimen_type_id";
 	$resultset = query_associative_all($query_string);
 	$retval = array();
@@ -11380,7 +11360,7 @@ function get_compatible_specimens($test_type_id)
 	global $con;
 	$test_type_id = mysql_real_escape_string($test_type_id, $con);
 	$saved_db = DbUtil::switchToLabConfigRevamp();
-	$query_string = 
+	$query_string =
 		"SELECT specimen_type_id FROM specimen_test WHERE test_type_id=$test_type_id";
 	$resultset = query_associative_all($query_string);
 	$retval = array();
@@ -11401,7 +11381,7 @@ function get_compatible_test_types($lab_config_id, $specimen_type_id)
 	$lab_config_id = mysql_real_escape_string($lab_config_id, $con);
 	$specimen_type_id = mysql_real_escape_string($specimen_type_id, $con);
 	$saved_db = DbUtil::switchToLabConfigRevamp($lab_config_id);
-	$query_string = 
+	$query_string =
 		"SELECT tt.* FROM test_type tt, lab_config_test_type lctt, specimen_test st ".
 		"WHERE tt.test_type_id=lctt.test_type_id ".
 		"AND lctt.lab_config_id=$lab_config_id ".
@@ -11411,7 +11391,7 @@ function get_compatible_test_types($lab_config_id, $specimen_type_id)
 		"ORDER BY tt.name";
 
 	$resultset = query_associative_all($query_string);
-	
+
 	$retval = array();
 	if($resultset != null) {
 		foreach($resultset as $record)
@@ -11428,13 +11408,13 @@ function get_lab_config_test_types($lab_config_id, $to_global=false)
 	## Moved to LabConfig::getTestTypeIds();
 	global $con;
 	//$lab_config_id = 127;
-	
+
 	$lab_config_id = mysql_real_escape_string($lab_config_id, $con);
 	//echo "test ".$lab_config_id;
 	//$saved_db = DbUtil::switchToLabConfig($lab_config_id);
 	$lab_config = LabConfig::getById($lab_config_id);
 	//DbUtil::switchRestore($saved_db);
-	
+
 	return $lab_config->getTestTypeIds();
 }
 
@@ -11457,7 +11437,7 @@ function get_lab_config_specimen_types($lab_config_id, $to_global=false, $lab_co
 		$saved_db = DbUtil::switchToLabConfig($lab_config_id);
 	}
 
-	$query_string = 
+	$query_string =
 		"SELECT specimen_type_id FROM lab_config_specimen_type ".
 		"WHERE lab_config_id=$lab_config_id";
 	$resultset = query_associative_all($query_string);
@@ -11485,7 +11465,7 @@ function get_test_type_measures($test_type_id)
 	{
 		$dummy_list = array();
 		return $dummy_list;
-	}	
+	}
 }
 
 function get_measure_range($measure_id)
@@ -11514,7 +11494,7 @@ function add_custom_field_specimen($custom_field, $lab_config_id=null)
 		$lab_config_id = mysql_real_escape_string($lab_config_id, $con);
 		$saved_db = DbUtil::switchToLabConfig($lab_config_id);
 	}
-	$query_string = 
+	$query_string =
 		"INSERT INTO specimen_custom_field (field_name, field_options, field_type_id) ".
 		"VALUES ('$custom_field->fieldName', '$custom_field->fieldOptions', $custom_field->fieldTypeId)";
 	query_blind($query_string);
@@ -11530,7 +11510,7 @@ function add_custom_field_patient($custom_field, $lab_config_id=null)
 		$lab_config_id = mysql_real_escape_string($lab_config_id, $con);
 		$saved_db = DbUtil::switchToLabConfig($lab_config_id);
 	}
-	$query_string = 
+	$query_string =
 		"INSERT INTO patient_custom_field (field_name, field_options, field_type_id) ".
 		"VALUES ('$custom_field->fieldName', '$custom_field->fieldOptions', $custom_field->fieldTypeId)";
 	query_blind($query_string);
@@ -11546,7 +11526,7 @@ function add_custom_field_labtitle($custom_field, $lab_config_id=null)
 		$lab_config_id = mysql_real_escape_string($lab_config_id, $con);
 		$saved_db = DbUtil::switchToLabConfig($lab_config_id);
 	}
-	$query_string = 
+	$query_string =
 		"INSERT INTO labtitle_custom_field (field_name, field_options, field_type_id) ".
 		"VALUES ('$custom_field->fieldName', '$custom_field->fieldOptions', $custom_field->fieldTypeId)";
 	query_blind($query_string);
@@ -11563,10 +11543,10 @@ function get_custom_fields()
 	$retval = array();
 	foreach($resultset as $record)
 	{
-		
+
 		$retval[] = $record;
 	}
-	
+
 	return $retval;
 }
 function get_custom_fields_specimen()
@@ -11610,7 +11590,7 @@ function get_custom_fields_patient_by_name($field_name)
 	echo "<br/>"; */
 	$retval = array();
 	//foreach($resultset as $record)
-	//{	
+	//{
 		$custom_field = CustomField::getObject($record);
 	//	$retval[] = $custom_field;
 	//}
@@ -11634,7 +11614,7 @@ function get_custom_field_name_specimen($field_id)
 	# Returns name of the specimen custom field
 	global $con;
 	$field_id = mysql_real_escape_string($field_id, $con);
-	$query_string = 
+	$query_string =
 		"SELECT field_name FROM specimen_custom_field ".
 		"WHERE id=$field_id LIMIT 1";
 	$record = query_associative_one($query_string);
@@ -11646,7 +11626,7 @@ function get_custom_field_name_patient($field_id)
 	# Returns name of the patient custom field
 	global $con;
 	$field_id = mysql_real_escape_string($field_id, $con);
-	$query_string = 
+	$query_string =
 		"SELECT field_name FROM patient_custom_field ".
 		"WHERE id=$field_id LIMIT 1";
 	$record = query_associative_one($query_string);
@@ -11658,7 +11638,7 @@ function get_custom_field_name_labtitle($field_id)
 	# Returns name of the specimen custom field
 	global $con;
 	$field_id = mysql_real_escape_string($field_id, $con);
-	$query_string = 
+	$query_string =
 		"SELECT field_name FROM labtitle_custom_field ".
 		"WHERE id=$field_id LIMIT 1";
 	$record = query_associative_one($query_string);
@@ -11668,7 +11648,7 @@ function get_custom_field_name_labtitle($field_id)
 function add_custom_data_specimen($custom_data)
 {
 	# Adds the custom field value to specimen_custom_data table
-	$query_string = 
+	$query_string =
 		"INSERT INTO specimen_custom_data (field_id, specimen_id, field_value) ".
 		"VALUES ($custom_data->fieldId, $custom_data->specimenId, '$custom_data->fieldValue')";
 	query_blind($query_string);
@@ -11677,7 +11657,7 @@ function add_custom_data_specimen($custom_data)
 function add_custom_data_patient($custom_data)
 {
 	# Adds the custom field value to patient_custom_data table
-	$query_string = 
+	$query_string =
 		"INSERT INTO patient_custom_data (field_id, patient_id, field_value) ".
 		"VALUES ($custom_data->fieldId, $custom_data->patientId, '$custom_data->fieldValue')";
 	query_blind($query_string);
@@ -11688,7 +11668,7 @@ function update_custom_data_patient($custom_data)
 {
 	# Updates custom field value in patient_custom_data table
 	## Check if entry already exists
-	$query_string = 
+	$query_string =
 		"SELECT * FROM patient_custom_data ".
 		"WHERE field_id=$custom_data->fieldId ".
 		"AND patient_id=$custom_data->patientId LIMIT 1";
@@ -11696,7 +11676,7 @@ function update_custom_data_patient($custom_data)
 	if($record == null)
 	{
 		## Add a new entry in patient_custom_data table
-		$query_string_new = 
+		$query_string_new =
 			"INSERT INTO patient_custom_data (field_id, patient_id, field_value) ".
 			"VALUES ($custom_data->fieldId, $custom_data->patientId, '$custom_data->fieldValue')";
 		query_blind($query_string_new);
@@ -11704,7 +11684,7 @@ function update_custom_data_patient($custom_data)
 	else
 	{
 		## Record already exists, hence update field_value alone
-		$query_string_update = 
+		$query_string_update =
 			"UPDATE patient_custom_data ".
 			"SET field_value='$custom_data->fieldValue' ".
 			"WHERE patient_id=$custom_data->patientId ".
@@ -11718,10 +11698,10 @@ function get_custom_data_specimen($specimen_id)
 	# Fetches custom data stored for a given specimen ID
 	global $con;
 	$specimen_id = mysql_real_escape_string($specimen_id, $con);
-	$query_string = 
+	$query_string =
 		"SELECT * FROM specimen_custom_data ".
 		"WHERE specimen_id=$specimen_id";
-	$saved_db = DbUtil::switchToLabConfig($_SESSION['lab_config_id']);		
+	$saved_db = DbUtil::switchToLabConfig($_SESSION['lab_config_id']);
 	$resultset = query_associative_all($query_string);
 	DbUtil::switchRestore($saved_db);
 	$retval = array();
@@ -11737,7 +11717,7 @@ function get_custom_data_specimen_bytype($specimen_id, $field_id)
 	global $con;
 	$specimen_id = mysql_real_escape_string($specimen_id, $con);
 	$field_id = mysql_real_escape_string($field_id, $con);
-	$query_string = 
+	$query_string =
 		"SELECT * FROM specimen_custom_data ".
 		"WHERE specimen_id=$specimen_id AND field_id=$field_id LIMIT 1";
 	$record = query_associative_one($query_string);
@@ -11752,7 +11732,7 @@ function get_custom_data_patient($patient_id)
 	# Fetches custom data stored for a given patient ID
 	global $con;
 	$patient_id = mysql_real_escape_string($patient_id, $con);
-	$query_string = 
+	$query_string =
 		"SELECT * FROM patient_custom_data ".
 		"WHERE patient_id=$patient_id";
 	$resultset = query_associative_all($query_string);
@@ -11769,7 +11749,7 @@ function get_custom_data_patient_bytype($patient_id, $field_id)
 	global $con;
 	$patient_id = mysql_real_escape_string($patient_id, $con);
 	$field_id = mysql_real_escape_string($field_id, $con);
-	$query_string = 
+	$query_string =
 		"SELECT * FROM patient_custom_data ".
 		"WHERE patient_id=$patient_id AND field_id=$field_id LIMIT 1";
 	$record = query_associative_one($query_string);
@@ -11785,7 +11765,7 @@ function get_lab_config_specimen_custom_fields($lab_config_id)
 	global $con;
 	$lab_config_id = mysql_real_escape_string($lab_config_id, $con);
 	$saved_db = DbUtil::switchToLabConfig($lab_config_id);
-	$query_string = 
+	$query_string =
 		"SELECT * FROM specimen_custom_field";
 	$resultset = query_associative_all($query_string);
 	$retval = array();
@@ -11803,7 +11783,7 @@ function get_lab_config_patient_custom_fields($lab_config_id)
 	global $con;
 	$lab_config_id = mysql_real_escape_string($lab_config_id);
 	$saved_db = DbUtil::switchToLabConfig($lab_config_id);
-	$query_string = 
+	$query_string =
 		"SELECT * FROM patient_custom_field";
 	$resultset = query_associative_all($query_string);
 	$retval = array();
@@ -11821,7 +11801,7 @@ function get_lab_config_labtitle_custom_fields($lab_config_id)
 	global $con;
 	$lab_config_id = mysql_real_escape_string($lab_config_id, $con);
 	$saved_db = DbUtil::switchToLabConfig($lab_config_id);
-	$query_string = 
+	$query_string =
 		"SELECT * FROM labtitle_custom_field";
 	$resultset = query_associative_all($query_string);
 	$retval = array();
@@ -11903,9 +11883,9 @@ function get_backup_folders($lab_config_id)
 	// echo "hi ";
 	// echo $start_dir;
 	// echo " hi";
-	if($handle = opendir($start_dir)) 
+	if($handle = opendir($start_dir))
 	{
-		while (false !== ($file = readdir($handle))) 
+		while (false !== ($file = readdir($handle)))
 		{
 			// echo "debugging ", $file, " -> ", "<br>";
 			if(strpos($file, "blis_backup_") !== false)
@@ -11929,7 +11909,7 @@ function get_backup_folders($lab_config_id)
 							$lab_config_match = true;
 							break;
 						}
-					}					
+					}
 				}
 				if($lab_config_match === false)
 					continue;
@@ -11960,7 +11940,7 @@ class TestTypeMapping {
 	public $userId;
 	public $labIdTestId;
 	public $testCategoryId;
-	
+
 	public static function getObject($record)
 	{
 		# Converts a test type mapping record in DB into a TestTypeMapping object
@@ -11974,7 +11954,7 @@ class TestTypeMapping {
 		$testTypeMapping->testCategoryId = $record['test_category_id'];
 		return $testTypeMapping;
 	}
-	
+
 	public function getName()
 	{
 		global $CATALOG_TRANSLATION;
@@ -11987,7 +11967,7 @@ class TestTypeMapping {
 			return $this->name;
 		}
 	}
-	
+
 	public function getDescription()
 	{
 		if(trim($this->description) == "" || $this->description == null)
@@ -11995,7 +11975,7 @@ class TestTypeMapping {
 		else
 			return trim($this->description);
 	}
-	
+
 	public function getClinicalData()
 	{
 		if(trim($this->clinical_data) == "" || $this->clinical_data == null)
@@ -12003,14 +11983,14 @@ class TestTypeMapping {
 		else
 			return trim($this->clinical_data);
 	}
-	
+
 	public static function getByCategory($catCode)
 	{
 		# Returns all test types belonging to a particular category (aka section)
 		if($catCode == null || $catCode == "")
 			return null;
 		$retval = array();
-		$query_string = 
+		$query_string =
 			"SELECT * FROM test_mapping ".
 			"WHERE test_category_id=$catCode";
 		$saved_db = DbUtil::switchToGlobal();
@@ -12020,7 +12000,7 @@ class TestTypeMapping {
 		DbUtil::switchRestore($saved_db);
 		return $retval;
 	}
-	
+
 	public static function getById($testTypeId) {
 		# Returns global test type record in DB
 		$saved_db = DbUtil::switchToGlobal();
@@ -12029,7 +12009,7 @@ class TestTypeMapping {
 		$record = query_associative_one($query_string);
 		return TestTypeMapping::getObject($record);
 	}
-        
+
         public static function getTestTypeById($testTypeId, $user_id) {
 		# Returns global test type record in DB
 		$saved_db = DbUtil::switchToGlobal();
@@ -12038,7 +12018,7 @@ class TestTypeMapping {
 		$record = query_associative_one($query_string);
 		return TestTypeMapping::getObject($record);
 	}
-        
+
         public static function getTestCatById($testTypeId, $user_id) {
 		# Returns global test type record in DB
 		$saved_db = DbUtil::switchToGlobal();
@@ -12047,12 +12027,12 @@ class TestTypeMapping {
 		$record = query_associative_one($query_string);
 		return $record;
 	}
-	
+
 	public function getMeasures()
 	{
 		# Returns list of measures included in a test type
 		$saved_db = DbUtil::switchToGlobal();
-		$query_string = 
+		$query_string =
 			"SELECT measure_id FROM global_measures ".
 			"WHERE test_id=$this->testId";
 		$resultset = query_associative_all($query_string);
@@ -12065,12 +12045,12 @@ class TestTypeMapping {
 		DbUtil::switchRestore($saved_db);
 		return $retval;
 	}
-	
+
 	public function getMeasureIds()
 	{
 		# Returns list of measure IDs included in a test type
 		$saved_db = DbUtil::switchToGlobal();
-		$query_string = 
+		$query_string =
 			"SELECT measure_id FROM global_measures ".
 			"WHERE test_id=$this->testId";
 		$resultset = query_associative_all($query_string);
@@ -12081,14 +12061,14 @@ class TestTypeMapping {
 		DbUtil::switchRestore($saved_db);
 		return $retval;
 	}
-	
+
 	/*
 	public static function deleteById($test_type_id)
 	{
 		# Deletes test type from database
 		# 1. Delete entries in lab_config_test_type
 		$saved_db = DbUtil::switchToLabConfigRevamp();
-		$query_string = 
+		$query_string =
 			"DELETE FROM lab_config_test_type WHERE test_type_id=$test_type_id";
 		query_blind($query_string);
 		# 2. Delete entries from specimen_test
@@ -12107,21 +12087,21 @@ class TestTypeMapping {
 class GlobalMeasure
 {
 	# For each test indicator in 'measure' table
-	
+
 	public $measureId;
 	public $name;
 	public $unit;
 	public $description;
 	public $range;
 	public $testId;
-	
+
 	public static $RANGE_ERROR = 0;
 	public static $RANGE_OPTIONS = 1;
 	public static $RANGE_NUMERIC = 2;
 	public static $RANGE_MULTI = 3;
 	public static $RANGE_AUTOCOMPLETE = 4;
 
-	
+
 	public static function getObject($record) {
 		# Converts a measure record in DB into a Measure object
 		if($record == null)
@@ -12136,7 +12116,7 @@ class GlobalMeasure
 		$measure->range = $record['range'];
 		return $measure;
 	}
-	
+
 	public function getName() {
 		global $CATALOG_TRANSLATION;
 		if($CATALOG_TRANSLATION === true) {
@@ -12146,7 +12126,7 @@ class GlobalMeasure
 			return $this->name;
 		}
 	}
-	
+
 	public function getRangeType()
 	{
 		if(strpos($this->range, "_") !== false)
@@ -12160,22 +12140,22 @@ class GlobalMeasure
 		else if(strpos($this->range, "*") !== false)
 		{
 			return GlobalMeasure::$RANGE_MULTI;
-		}	
+		}
 		else if(strpos($this->range, "/") !== false)
 		{
 			return GlobalMeasure::$RANGE_OPTIONS;
-		}	
-		else 
+		}
+		else
 		{
 			return GlobalMeasure::$RANGE_ERROR;
 		}
 	}
-	
+
 	/*
 	public function getRangeValues($patient=null)
 	{
 		# Returns range values in a list
-		
+
 		$range_type = $this->getRangeType();
 		$retval = array();
 		switch($range_type)
@@ -12185,7 +12165,7 @@ class GlobalMeasure
 				$ref_range = null;
 				if($patient != null)
 				{	$ref_range = ReferenceRange::getByAgeAndSex($patient->getAgeNumber(), $patient->sex, $this->measureId, $_SESSION['lab_config_id']);
-				
+
 				}
 				if($ref_range == null)
 					# Fetch from default entry in 'measure' table
@@ -12194,13 +12174,13 @@ class GlobalMeasure
 					$retval = array($ref_range->rangeLower, $ref_range->rangeUpper);
 				break;
 			case Measure::$RANGE_OPTIONS:
-			
+
 			{
 			$retval = explode("/", $this->range);
-				
+
 				foreach($retval as $key=>$value)
 				{
-				
+
 				$retval[$key]=str_replace("#","/",$value);
 				}
 			break;
@@ -12215,7 +12195,7 @@ class GlobalMeasure
 		}
 		return $retval;
 	}
-	
+
 	public function getRangeString($patient=null)
 	{
 		# Returns range in string for printing or displaying
@@ -12246,16 +12226,16 @@ class GlobalMeasure
 				$retval .= "  ".$this->unit;
 			$retval .= ")";
 		}
-		
+
 		return $range_parts;
 	}
-	
+
 	public function getUnits()
 	{
 		return $this->unit;
 	}
 	*/
-	
+
 	public static function getById($measure_id)
 	{
 		# Returns a test measure by ID
@@ -12265,26 +12245,26 @@ class GlobalMeasure
 		$query_string = "SELECT * FROM global_measures WHERE measure_id=$measure_id LIMIT 1";
 		$record = query_associative_one($query_string);
 		DbUtil::switchRestore($saved_db);
-		return GlobalMeasure::getObject($record);		
+		return GlobalMeasure::getObject($record);
 	}
-	
+
 	public function updateToDb()
 	{
 		# Updates an existing global measure entry in DB
 		$saved_db = DbUtil::switchToGlobal();
-		$query_string = 
+		$query_string =
 			"UPDATE global_measures SET name='$this->name', range='$this->range', unit='$this->unit' ".
 			"WHERE measure_id=$this->measureId";
 		query_blind($query_string);
 		DbUtil::switchRestore($saved_db);
 	}
-	
+
 	/*
 	public function setInterpretation($inter)
 	{
 		# Updates an existing measure entry in DB
 		$saved_db = DbUtil::switchToLabConfigRevamp();
-		$query_string = 
+		$query_string =
 			"UPDATE measure SET description='$inter'".
 			"WHERE measure_id=$this->measureId";
 		query_blind($query_string);
@@ -12320,11 +12300,11 @@ class GlobalMeasure
 						}else
 							{
 							//update
-						$query_string = 
+						$query_string =
 						"UPDATE numeric_interpretation SET range_u=$range_u_list[$count], range_l=$range_l_list[$count], age_u=$age_u_list[$count], age_l=$age_l_list[$count], gender='$gender_list[$count]' , description='$remarks_list[$count]' ".
 						"WHERE id=$id_list[$count]";
 						query_update($query_string);
-						
+
 						}
 				}else
 					{
@@ -12332,13 +12312,13 @@ class GlobalMeasure
 			"VALUES($range_u_list[$count],$range_l_list[$count],$age_u_list[$count],$age_l_list[$count],'$gender_list[$count]','$remarks_list[$count]',$this->measureId)";
 			query_insert_one($query_string);
 				}
-		
+
 		$count++;
 		}
 	}
 	DbUtil::switchRestore($saved_db);
 	}
-	
+
 	public function getNumericInterpretation()
 	{
 	$saved_db = DbUtil::switchToLabConfigRevamp();
@@ -12359,7 +12339,7 @@ class GlobalMeasure
 				$measure_id=$record['measure_id'];
 				$retval[] =array($range_l,$range_u,$age_l,$age_u,$gender,$description,$id,$measure_id);
 			}
-			
+
 		}else
 			{
 		//get interpretation ka loop
@@ -12367,19 +12347,19 @@ class GlobalMeasure
 	DbUtil::switchRestore($saved_db);
 	return $retval;
 	}
-	
+
 	public function addToDb()
 	{
 		# Updates an existing measure entry in DB
 		$saved_db = DbUtil::switchToLabConfigRevamp();
-		$query_string = 
+		$query_string =
 			"INSERT INTO measure (name, range, unit) ".
 			"VALUES ('$this->name', '$this->range', '$this->unit')".
 		query_insert_one($query_string);
 		DbUtil::switchRestore($saved_db);
 	}
 	*/
-	
+
 	public function getReferenceRanges($user_id)
 	{
 		# Fetches reference ranges from database for this measure
@@ -12393,19 +12373,19 @@ class GlobalMeasure
 			{
 				$retval[] = ReferenceRangeGlobal::getObject($record);
 			}
-		}	
+		}
 			DbUtil::switchRestore($saved_db);
 			return $retval;
 	}
-	
+
 	/*
 	public function getInterpretation()
-	{	
+	{
 		$retval= array();
 		$numeric_description=array();
 		if(trim($this->description) == "" || $this->description == null)
 			return $retval;
-		else 
+		else
 		{
 		$description=substr(($this->description),2);
 		if(strpos($description,"##")===false)
@@ -12413,10 +12393,10 @@ class GlobalMeasure
 		else
 		$retval=explode("##",$description);
 		}
-		
+
 		return $retval;
 	}
-	
+
 	public function getDescription()
 	{
 		if(trim($this->description) == "" || $this->description == null)
@@ -12436,7 +12416,7 @@ class ReferenceRangeGlobal
 	public $rangeLower;
 	public $rangeUpper;
 	public $userId;
-	
+
 	public static function getObject($record)
 	{
 		if($record == null)
@@ -12472,19 +12452,19 @@ class ReferenceRangeGlobal
 			$reference_range->rangeUpper = null;
 		return $reference_range;
 	}
-	
+
 	public function addToDb($user_id)
 	{
 		# Adds this entry to database
 		$saved_db = DbUtil::switchToGlobal();
-		$query_string = 
+		$query_string =
 			"INSERT INTO reference_range_global (measure_id, age_min, age_max, sex, range_lower, range_upper, user_id) ".
 			"VALUES ($this->measureId, '$this->ageMin', '$this->ageMax', '$this->sex', '$this->rangeLower', '$this->rangeUpper', $user_id)";
 		//;
 		query_insert_one($query_string);
 		DbUtil::switchRestore($saved_db);
 	}
-	
+
 	public static function deleteByMeasureId($measure_id)
 	{
 		# Deletes all entries for the given measure
@@ -12495,7 +12475,7 @@ class ReferenceRangeGlobal
 		query_delete($query_string);
 		DbUtil::switchRestore($saved_db);
 	}
-	
+
 	public static function getByAgeAndSex($age, $sex, $measure_id, $user_id)
 	{
 		# Fetches the reference range based on supplied age and sex values
@@ -12539,7 +12519,7 @@ class GlobalInfectionReport
 	public $ageGroups;
 	public $measureGroups;
 	public $userId;
-	
+
 	public static function getObject($record)
 	{
 		if($record == null)
@@ -12556,7 +12536,7 @@ class GlobalInfectionReport
 			$retval->measureGroups = $record['measure_groups'];
 		return $retval;
 	}
-	
+
 	public function addToDb()
 	{
 		$infectionReportSettings = $this;
@@ -12569,7 +12549,7 @@ class GlobalInfectionReport
 			"AND measure_id=$this->measureId";
 		query_blind($query_string);
 		# Add updated entry
-		$query_string = 
+		$query_string =
 			"INSERT INTO infection_report_settings( ".
 				"id, ".
 				"user_id, ".
@@ -12593,7 +12573,7 @@ class GlobalInfectionReport
 		query_insert_one($query_string);
 		DbUtil::switchRestore($saved_db);
 	}
-	
+
 	public static function getByKeys($user_id, $test_type_id, $measure_id)
 	{
 		# Fetches a record by compound key
@@ -12608,7 +12588,7 @@ class GlobalInfectionReport
 		DbUtil::switchRestore($saved_db);
 		return $retval;
 	}
-	
+
 	public function getAgeGroupAsList()
 	{
 		# Returns the age_group field as a PHP list
@@ -12623,7 +12603,7 @@ class GlobalInfectionReport
 		}
 		return $retval;
 	}
-	
+
 	public function getMeasureGroupAsList()
 	{
 		# Returns the measure_group field as a PHP list
@@ -12642,7 +12622,7 @@ class GlobalInfectionReport
 
 class GlobalPatient
 {
-	public $patientId; 
+	public $patientId;
 	public $addlId;
 	public $name;
 	public $dob;
@@ -12668,7 +12648,7 @@ class GlobalPatient
 		$date_parts = explode(" ", date($record['ts']));
 		$date_parts_1=explode("-",$date_parts[0]);
 		$patient->regDate=$date_parts_1[2]."-".$date_parts_1[1]."-".$date_parts_1[0];
-		
+
 		if(isset($record['partial_dob']))
 			$patient->partialDob = $record['partial_dob'];
 		else
@@ -12687,12 +12667,12 @@ class GlobalPatient
 			$patient->hashValue = null;
 		return $patient;
 	}
-	
+
 	public static function checkNameExists($name, $country)
 	{
 		# Checks if the given patient name (or similar match) already exists
 		$saved_db = DbUtil::switchToCountry($country);
-		$query_string = 
+		$query_string =
 			"SELECT COUNT(patient_id) AS val FROM patient WHERE name LIKE '%$name%'";
 		$resultset = query_associative_one($query_string);
 		DbUtil::switchRestore($saved_db);
@@ -12701,7 +12681,7 @@ class GlobalPatient
 		else
 			return true;
 	}
-	
+
 	public function getName()
 	{
 		if(trim($this->name) == "")
@@ -12709,7 +12689,7 @@ class GlobalPatient
 		else
 			return $this->name;
 	}
-	
+
 	public function getAddlId()
 	{
 		if($this->addlId == "")
@@ -12717,7 +12697,7 @@ class GlobalPatient
 		else
 			return $this->addlId;
 	}
-	
+
 	public function getAssociatedTests() {
 		if( $this->patientId == "" )
 			return " - ";
@@ -12734,7 +12714,7 @@ class GlobalPatient
 			return $result;
 		}
 	}
-	
+
 	public function getAge()
 	{
 		# Returns patient age value
@@ -12745,7 +12725,7 @@ class GlobalPatient
 				# DoB present in patient record
 				return DateLib::dobToAge($this->dob);
 			}
-			else 
+			else
 			{	$age_value=-1*$this->age;
 				if($age_value>100){
 					$age_value=200-$age_value;
@@ -12780,7 +12760,7 @@ class GlobalPatient
 			return DateLib::dobToAge($approx_dob);
 		}
 	}
-	
+
 	public function getAgeNumber()
 	{
 		# Returns patient age value (numeric part alone)
@@ -12796,7 +12776,7 @@ class GlobalPatient
 					$this->age=200+$this->age;
 				else if($this->age<0)
 					$this->age=-1*$this->age;
-			
+
 				return $this->age;
 			}
 		}
@@ -12817,7 +12797,7 @@ class GlobalPatient
 			return DateLib::dobToAgeNumber($approx_dob);
 		}
 	}
-	
+
 	public function getDob()
 	{
 		# Returns patient dob value
@@ -12834,11 +12814,11 @@ class GlobalPatient
 			return DateLib::mysqlToString($this->dob);
 		}
 	}
-	
+
 	public static function getByAddDate($date)
 	{
 		# Returns all patient records added on that date
-		$query_string = 
+		$query_string =
 			"SELECT * FROM patient ".
 			"WHERE ts LIKE '%$date%' ORDER BY patient_id";
 		$resultset = query_associative_all($query_string);
@@ -12847,11 +12827,11 @@ class GlobalPatient
 			$retval[] = Patient::getObject($record);
 		return $retval;
 	}
-	
+
 	public static function getByAddDateRange($date_from, $date_to)
 	{
 		# Returns all patient records added on that date range
-		$query_string = 
+		$query_string =
 			"SELECT * FROM patient ".
 			"WHERE UNIX_TIMESTAMP(ts) >= UNIX_TIMESTAMP('$date_from 00:00:00') ".
 			"AND UNIX_TIMESTAMP(ts) <= UNIX_TIMESTAMP('$date_to 23:59:59') ".
@@ -12862,7 +12842,7 @@ class GlobalPatient
 			$retval[] = Patient::getObject($record);
 		return $retval;
 	}
-	
+
 	public static function getByRegDateRange($date_from , $date_to)
 	{
 	$query_string =
@@ -12878,8 +12858,8 @@ class GlobalPatient
 				$record_each= query_associative_one($query_string);
 				$record_p[]=Patient::getObject($record_each);
 			}
-		return $record_p;	
-	
+		return $record_p;
+
 	}
 
 	public static function getReportedByRegDateRange($date_from , $date_to)
@@ -12902,10 +12882,10 @@ class GlobalPatient
 				$record_p[]=Patient::getObject($record_each);
 			}
 		}
-		return $record_p;	
-	
+		return $record_p;
+
 	}
-	
+
 
 	public static function getUnReportedByRegDateRange($date_from , $date_to)
 	{
@@ -12927,7 +12907,7 @@ class GlobalPatient
 		return $record_p;
 	}
 
-	
+
 	public static function getById($patient_id)
 	{
 		# Returns patient record by ID
@@ -12936,7 +12916,7 @@ class GlobalPatient
 		//return 1;
 		return Patient::getObject($record);
 	}
-	
+
 	public function getSurrogateId()
 	{
 		if($this->surrogateId == null || trim($this->surrogateId) == "")
@@ -12944,7 +12924,7 @@ class GlobalPatient
 		else
 			return $this->surrogateId;
 	}
-	
+
 	public function getDailyNum()
 	{
 		# Returns daily number ("patient number")
@@ -12954,7 +12934,7 @@ class GlobalPatient
 			"WHERE s.patient_id=p.patient_id ".
 			"AND p.patient_id=$this->patientId ".
 			"ORDER BY s.date_collected DESC";
-		$record = query_associative_one($query_string);		
+		$record = query_associative_one($query_string);
 		$retval = "";
 		if($record == null || trim($record['daily_num']) == "")
 			$retval = "-";
@@ -12970,7 +12950,7 @@ class GlobalPatient
 		$sex_part = strtolower($this->sex);
 		$dob_part = "";
 		if($this->partialDob != null && trim($this->partialDob) != "")
-		{	
+		{
 			# Determine unix timestamp based on partial (approximate) date of birth
 			$approx_dob = "";
 			if(strpos($this->partialDob, "-") === false)
@@ -12998,33 +12978,33 @@ class GlobalPatient
 		$retval = sha1($hash_input);
 		return $retval;
 	}
-	
+
 	public function getHashValue()
 	{
 		$retval = $this->hashValue;
 		return $retval;
 	}
-	
+
 	public function getSex()
 	{
 	$sex=$this->sex;
-	
+
 	return $sex;
 	}
-	
+
 	public function setHashValue($hash_value)
 	{
 		if($hash_value == null || trim($hash_value) == "")
 			return;
-		$query_string = 
+		$query_string =
 			"UPDATE patient SET hash_value='$hash_value' ".
 			"WHERE patient_id=$this->patientId";
 		query_update($query_string);
 	}
 }
 
-/** 
-	Aggregation Helper Functions 
+/**
+	Aggregation Helper Functions
 */
 function getTestCatName_by_cat_id($lab_config_id, $cat_id){
 	$saved_db = DbUtil::switchToLabConfig($lab_config_id);
@@ -13042,12 +13022,12 @@ function addAggregateMeasure($measure, $range, $testId, $userId, $unit)
 {
 	# Adds a new measure to catalog
 	$saved_db = DbUtil::switchToGlobal();
-	$query_string = 
+	$query_string =
 		"SELECT MAX(measure_id) AS measure_id FROM global_measures ".
 		"WHERE user_id=$userId";
 	$record = query_associative_one($query_string);
 	$measureId = intval($record['measure_id']) + 1;
-	$query_string = 
+	$query_string =
 		"INSERT INTO global_measures (`name`, `range`, test_id, user_id, unit, measure_id ) ".
 		"VALUES ('$measure', '$range', $testId, $userId, '$unit', $measureId)";
 	query_insert_one($query_string);
@@ -13087,7 +13067,7 @@ function updateAggregateTestType($updated_entry, $userId) {
 		else
 		{
 			# Remove entry from mapping table
-			$query_del = 
+			$query_del =
 				"DELETE from specimen_test ".
 				"WHERE test_type_id=$updated_entry->testTypeId ".
 				"AND specimen_type_id=$specimen_type_id";
@@ -13105,7 +13085,7 @@ function updateAggregateTestType($updated_entry, $userId) {
 		else
 		{
 			# Add entry in mapping table
-			$query_ins = 
+			$query_ins =
 				"INSERT INTO specimen_test (specimen_type_id, test_type_id) ".
 				"VALUES ($specimen_type_id, $updated_entry->testTypeId)";
 			query_blind($query_ins);
@@ -13131,7 +13111,7 @@ function getAggregateMeasureById($measureId)
 {
 	# Returns Measure object from DB
 	$saved_db = DbUtil::switchToGlobal();
-	$query_measure = 
+	$query_measure =
 		"SELECT * FROM global_measures WHERE measure_id=$measureId LIMIT 1";
 	$record = query_associative_one($query_measure);
 	$retval = GlobalMeasure::getObject($record);
@@ -13156,7 +13136,7 @@ function addTestCategoryAgg($cat_name, $cat_descr="")
 {
 	# Adds a new test category to catalog
 	$saved_db = DbUtil::switchToGlobal();
-	$query_string = 
+	$query_string =
 		"INSERT INTO test_category(name, description) ".
 		"VALUES ('$cat_name', '$cat_descr')";
 	query_insert_one($query_string);
@@ -13168,7 +13148,7 @@ function addTestCategoryAgg($cat_name, $cat_descr="")
 function updateTestMappingWithCategory($testId, $catCode) {
 	$saved_db = DbUtil::switchToGlobal();
 	/*
-	$query_string = 
+	$query_string =
 		"SELECT test_category_id ".
 		"FROM test_category_mapping ".
 		"WHERE lab_id_test_category_id='$catCode' ";
@@ -13176,7 +13156,7 @@ function updateTestMappingWithCategory($testId, $catCode) {
 	if($record != null)
 		$testCategoryId = $record['test_category_id'];
 	*/
-	$query_string = 
+	$query_string =
 		"UPDATE test_mapping ".
 		"SET test_category_id=$catCode ".
 		"WHERE test_id=$testId ";
@@ -13188,7 +13168,7 @@ function getTestCategoryAggNameById($cat_id)
 {
 	# Returns test category name as string
 	$saved_db = DbUtil::switchToGlobal();
-	$query_string = 
+	$query_string =
 		"SELECT test_category_name FROM test_category_mapping ".
 		"WHERE test_category_id=$cat_id LIMIT 1";
 	$record = query_associative_one($query_string);
@@ -13201,7 +13181,7 @@ function getTestCategoryAggNameById($cat_id)
 
 function getLabMeasureIdFromGlobalMeasureId($labConfigId, $globalTestType, $currentMeasureCount) {
 	$saved_db = DbUtil::switchToGlobal();
-	$query_string = 
+	$query_string =
 		"SELECT lab_id_test_id FROM test_mapping ".
 		"WHERE test_id=$globalTestType->testId ";
 	$record = query_associative_one($query_string);
@@ -13233,7 +13213,7 @@ function getLabMeasureIdFromGlobalMeasureId($labConfigId, $globalTestType, $curr
 function getLabMeasureIdFromGlobalName($measureName, $labConfigId) {
 	$saved_db = DbUtil::switchToGlobal();
 	$userId= $_SESSION['user_id'];
-	$query_string = 
+	$query_string =
 		"SELECT lab_id_measure_id FROM measure_mapping ".
 		"WHERE measure_name='$measureName' ".
 		"AND user_id=$userId LIMIT 1";
@@ -13250,7 +13230,7 @@ function getLabMeasureIdFromGlobalName($measureName, $labConfigId) {
 	return $measureIds[$labConfigId];
 }
 
-/** 
+/**
 	DB Merging Helper Functions Begin Here
 */
 function searchPatientByName($q) {
@@ -13258,56 +13238,56 @@ function searchPatientByName($q) {
 	$country = strtolower($user->country);
 	$saved_db = DbUtil::switchToCountry($country);
 	# Searches for patients with exact name in the global database
-	$query_string = 
+	$query_string =
 		"SELECT * FROM patient ".
 		"WHERE name LIKE '$q'";
 	$record = query_associative_one($query_string);
 	DbUtil::switchRestore($saved_db);
 	if( $record )
 		$patient = Patient::getObject($record);
-	else 
+	else
 		$patient = null;
 	return $patient;
 }
 
 function autoImportPatientEntry($importPatient, $patientName) {
-	$query_string = 
+	$query_string =
 		"SELECT * FROM patient ".
 		"WHERE name LIKE '$patientName'";
-	$record = query_associative_one($query_string);	
-	
+	$record = query_associative_one($query_string);
+
 	if( $record ) {
 		$saved_db = DbUtil::switchToGlobal();
 		$userId = $_SESSION['user_id'];
 		$query = "SELECT * FROM lab_config_access where user_id = $userId";
 		$record = query_associative_one($query);
 		$labConfigId = $record['lab_config_id'];
-	
+
 		$currentLabPatient = Patient::getObject($record);
 		$globalPatientId = $importPatient->patientId;
 		$importLabConfigId = substr($globalPatientId, 0, 3);
-		
+
 		if( $importLabConfigId == $labConfigId )
 			return;
-		
+
 		$subValue = $importLabConfigId."00000000000";
 		$importPatientIdStr = bcsub($globalPatientId, $subValue);
 		$importPatientId = intval($importPatientIdStr);
-		
-		$saved_db = DbUtil::switchToLabConfig($importLabConfigId); 
 
-		$querySelect = 
+		$saved_db = DbUtil::switchToLabConfig($importLabConfigId);
+
+		$querySelect =
 			"SELECT * FROM specimen ".
 			"WHERE patient_id=$importPatientId";
 		$resultset = query_associative_all($querySelect);
-	
+
 		if($resultset) {
 			foreach($resultset as $record)
 				$specimenRecords[] = Specimen::getObject($record);
-			
+
 
 			foreach($specimenRecords as $specimenRecord) {
-				$querySelect = 
+				$querySelect =
 					"SELECT * FROM test ".
 					"WHERE specimen_id=$specimenRecord->specimenId";
 				$resultset = query_associative_all($querySelect);
@@ -13316,10 +13296,10 @@ function autoImportPatientEntry($importPatient, $patientName) {
 			}
 		}
 		DbUtil::switchRestore($saved_db);
-		
+
 		/* Build a mapping of Specimens from the Global Table & make appropriate substitutions */
 		$saved_db = DbUtil::switchToGlobal();
-		$querySelect = 
+		$querySelect =
 			"SELECT * FROM specimen_mapping";
 		$resultset = query_associative_all($querySelect);
 		if($resultset) {
@@ -13337,11 +13317,11 @@ function autoImportPatientEntry($importPatient, $patientName) {
 					if ( $specimenIds[$labConfigId] == $specimenRecord->specimenTypeId )
 						$specimenRecord->specimenTypeId = $specimenIds[$importLabConfigId];
 				}
-			}	
+			}
 		}
 
 		/* Build a mapping of Tests from the Global Table & make appropriate substitutions */
-		$querySelect = 
+		$querySelect =
 			"SELECT * FROM test_mapping";
 		$resultset = query_associative_all($querySelect);
 		if($resultset) {
@@ -13360,13 +13340,13 @@ function autoImportPatientEntry($importPatient, $patientName) {
 				}
 			}
 		}
-		DbUtil::switchRestore($saved_db);	
-	
+		DbUtil::switchRestore($saved_db);
+
 		$i=0;
 		if($specimenRecords) {
 			foreach($specimenRecords as $specimenRecord) {
-				$saved_db = DbUtil::switchToLabConfig($importLabConfigId); 
-				$querySelect = 
+				$saved_db = DbUtil::switchToLabConfig($importLabConfigId);
+				$querySelect =
 					"SELECT * FROM test ".
 					"WHERE specimen_id=$specimenRecord->specimenId";
 				$resultset = query_associative_all($querySelect);
@@ -13375,7 +13355,7 @@ function autoImportPatientEntry($importPatient, $patientName) {
 				$specimenRecord->patientId = $currentLabPatient->patientId;
 				$specimenRecord->userId = $_SESSION['user_id'];
 				$specimenRecord->doctor = '';
-				
+
 				add_specimen($specimenRecord);
 				for($j=0;$j<count($resultset);$j++) {
 					$testRecord = $testRecords[$i];
@@ -13407,7 +13387,7 @@ function getTestCountGroupedConfig($lab_config_id)
 		/*$query_string =
 			"SELECT * FROM report_disease ".
 			"WHERE lab_config_id = 9999009";
-                 * 
+                 *
                  */
                 $nineID = 9999009;
                 $query_string = "SELECT * FROM report_config WHERE landscape = $nineID";
@@ -13419,7 +13399,7 @@ function getTestCountGroupedConfig($lab_config_id)
                     $query_string_add = "INSERT INTO report_disease (group_by_age, group_by_gender, age_groups, measure_groups, measure_id, lab_config_id, test_type_id) VALUES (1, 1, '0:4,4:9,9:14,14:19,19:24,24:29,29:34,34:39,39:44,44:49,49:54,54:59,59:64,64:+', '0', 1, 9999009, 1)";
                     query_insert_one($query_string_add);
                     $record = query_associative_one($query_string);
-                     
+
                      */
                     $query_string_add = "INSERT INTO report_config (header, footer, margins, p_fields, s_fields, t_fields, p_custom_fields, s_custom_fields, test_type_id, title, landscape ) VALUES ('Grouped Test Count Report Configuration', '0:4,4:9,9:14,14:19,19:24,24:29,29:34,34:39,39:44,44:49,49:54,54:59,59:64,64:+', '0', '1', '1', '1', '1', '0', '$nineID' , '0', $nineID)";
                     query_insert_one($query_string_add);
@@ -13428,8 +13408,8 @@ function getTestCountGroupedConfig($lab_config_id)
                         $saved_db = DbUtil::switchToLabConfig($lab_config_id);
                         $record = query_associative_one($query_string);
                 }
-                
-                
+
+
 		DbUtil::switchRestore($saved_db);
                 $retval = array();
                 /*$byAge = $configArray['group_by_age'];
@@ -13437,15 +13417,15 @@ function getTestCountGroupedConfig($lab_config_id)
                 $byGender = $configArray['group_by_gender'];
                 $bySection = $configArray['measure_id'];
                 $combo = $configArray['test_type_id']; // 1 - registered, 2 - completed, 3 - completed / pending */
-                
+
                 $retval['group_by_age'] = intval($record['p_fields']); //group_by_age
                 $retval['age_groups'] = $record['footer']; //age_groups
                 $retval['group_by_gender'] = intval($record['s_fields']); //group_by_gender
                 $retval['measure_id'] = intval($record['t_fields']); //group_by_section
                 $retval['test_type_id'] = intval($record['p_custom_fields']); //combo
-                
+
 		return $retval;
-                
+
 }
 
 function getTestCountGroupedConfigCountryDir($lab_config_id)
@@ -13453,7 +13433,7 @@ function getTestCountGroupedConfigCountryDir($lab_config_id)
 	/*$query_string =
 	"SELECT * FROM report_disease ".
 	"WHERE lab_config_id = 9999009";
-     * 
+     *
      */
     $nineID = 9999009;
     $query_string = "SELECT * FROM report_config WHERE landscape = $nineID";
@@ -13465,7 +13445,7 @@ function getTestCountGroupedConfigCountryDir($lab_config_id)
         $query_string_add = "INSERT INTO report_disease (group_by_age, group_by_gender, age_groups, measure_groups, measure_id, lab_config_id, test_type_id) VALUES (1, 1, '0:4,4:9,9:14,14:19,19:24,24:29,29:34,34:39,39:44,44:49,49:54,54:59,59:64,64:+', '0', 1, 9999009, 1)";
         query_insert_one($query_string_add);
         $record = query_associative_one($query_string);
-         
+
          */
         $query_string_add = "INSERT INTO report_config (header, footer, margins, p_fields, s_fields, t_fields, p_custom_fields, s_custom_fields, test_type_id, title, landscape, age_unit ) VALUES ('Grouped Test Count Report Configuration', '0:4,4:9,9:14,14:19,19:24,24:29,29:34,34:39,39:44,44:49,49:54,54:59,59:64,64:+', '0', '1', '1', '1', '1', '0', '$nineID' , '0', $nineID, 4)";
         query_insert_one($query_string_add);
@@ -13474,8 +13454,8 @@ function getTestCountGroupedConfigCountryDir($lab_config_id)
         $saved_db = DbUtil::switchToLabConfig($lab_config_id);
         $record = query_associative_one($query_string);
     }
-                
-                
+
+
 	DbUtil::switchRestore($saved_db);
     $retval = array();
     /*$byAge = $configArray['group_by_age'];
@@ -13483,15 +13463,15 @@ function getTestCountGroupedConfigCountryDir($lab_config_id)
     $byGender = $configArray['group_by_gender'];
     $bySection = $configArray['measure_id'];
     $combo = $configArray['test_type_id']; // 1 - registered, 2 - completed, 3 - completed / pending */
-    
+
     $retval['group_by_age'] = intval($record['p_fields']); //group_by_age
     $retval['age_groups'] = $record['footer']; //age_groups
     $retval['group_by_gender'] = intval($record['s_fields']); //group_by_gender
     $retval['measure_id'] = intval($record['t_fields']); //group_by_section
     $retval['test_type_id'] = intval($record['p_custom_fields']); //combo
-    $retval['age_unit'] = intval($record['age_unit']); //the unit of age represented by integer [1: Years, 2: Months, 3: Weeks, 4: Days]           
+    $retval['age_unit'] = intval($record['age_unit']); //the unit of age represented by integer [1: Years, 2: Months, 3: Weeks, 4: Days]
 	return $retval;
-                
+
 }
 
 # nc40
@@ -13510,7 +13490,7 @@ function decodeAgeGroups($ageGroups)
 		return $retval;
 	}
 
- # nc40       
+ # nc40
 function getSpecimenCountGroupedConfig($lab_config_id)
 {
                 $nineID = 9999019;
@@ -13523,7 +13503,7 @@ function getSpecimenCountGroupedConfig($lab_config_id)
                     $query_string_add = "INSERT INTO report_disease (group_by_age, group_by_gender, age_groups, measure_groups, measure_id, lab_config_id, test_type_id) VALUES (1, 1, '0:4,4:9,9:14,14:19,19:24,24:29,29:34,34:39,39:44,44:49,49:54,54:59,59:64,64:+', '0', 1, 9999009, 1)";
                     query_insert_one($query_string_add);
                     $record = query_associative_one($query_string);
-                     
+
                      */
                     $query_string_add = "INSERT INTO report_config (header, footer, margins, p_fields, s_fields, t_fields, p_custom_fields, s_custom_fields, test_type_id, title, landscape ) VALUES ('Grouped Specimen Count Report Configuration', '0:4,4:9,9:14,14:19,19:24,24:29,29:34,34:39,39:44,44:49,49:54,54:59,59:64,64:+', '0', '1', '1', '1', '1', '0', '$nineID' , '0', $nineID)";
                     query_insert_one($query_string_add);
@@ -13532,8 +13512,8 @@ function getSpecimenCountGroupedConfig($lab_config_id)
                         $saved_db = DbUtil::switchToLabConfig($lab_config_id);
                         $record = query_associative_one($query_string);
                 }
-                
-                
+
+
 		DbUtil::switchRestore($saved_db);
                 $retval = array();
                 /*$byAge = $configArray['group_by_age'];
@@ -13541,13 +13521,13 @@ function getSpecimenCountGroupedConfig($lab_config_id)
                 $byGender = $configArray['group_by_gender'];
                 $bySection = $configArray['measure_id'];
                 $combo = $configArray['test_type_id']; // 1 - registered, 2 - completed, 3 - completed / pending */
-                
+
                 $retval['group_by_age'] = intval($record['p_fields']); //group_by_age
                 $retval['age_groups'] = $record['footer']; //age_groups
                 $retval['group_by_gender'] = intval($record['s_fields']); //group_by_gender
                 $retval['measure_id'] = intval($record['t_fields']); //group_by_section
                 $retval['test_type_id'] = intval($record['p_custom_fields']); //combo
-                
+
 		return $retval;
 }
 
@@ -13563,7 +13543,7 @@ function getSpecimenCountGroupedConfigCountryDir($lab_config_id)
         $query_string_add = "INSERT INTO report_disease (group_by_age, group_by_gender, age_groups, measure_groups, measure_id, lab_config_id, test_type_id) VALUES (1, 1, '0:4,4:9,9:14,14:19,19:24,24:29,29:34,34:39,39:44,44:49,49:54,54:59,59:64,64:+', '0', 1, 9999009, 1)";
         query_insert_one($query_string_add);
         $record = query_associative_one($query_string);
-         
+
          */
         $query_string_add = "INSERT INTO report_config (header, footer, margins, p_fields, s_fields, t_fields, p_custom_fields, s_custom_fields, test_type_id, title, landscape, age_unit ) VALUES ('Grouped Specimen Count Report Configuration', '0:4,4:9,9:14,14:19,19:24,24:29,29:34,34:39,39:44,44:49,49:54,54:59,59:64,64:+', '0', '1', '1', '1', '1', '0', '$nineID' , '0', $nineID, 4)";
         query_insert_one($query_string_add);
@@ -13572,8 +13552,8 @@ function getSpecimenCountGroupedConfigCountryDir($lab_config_id)
             $saved_db = DbUtil::switchToLabConfig($lab_config_id);
             $record = query_associative_one($query_string);
     }
-            
-            
+
+
 	DbUtil::switchRestore($saved_db);
     $retval = array();
     /*$byAge = $configArray['group_by_age'];
@@ -13581,7 +13561,7 @@ function getSpecimenCountGroupedConfigCountryDir($lab_config_id)
     $byGender = $configArray['group_by_gender'];
     $bySection = $configArray['measure_id'];
     $combo = $configArray['test_type_id']; // 1 - registered, 2 - completed, 3 - completed / pending */
-    
+
     $retval['group_by_age'] = intval($record['p_fields']); //group_by_age
     $retval['age_groups'] = $record['footer']; //age_groups
     $retval['group_by_gender'] = intval($record['s_fields']); //group_by_gender
@@ -13595,22 +13575,22 @@ function getSpecimenCountGroupedConfigCountryDir($lab_config_id)
 # nc40
 function updateGroupedReportsConfig($byAge, $byGender, $ageGroups, $bySection, $combo, $entryID, $lab_config_id)
 	{
-                $saved_db = DbUtil::switchToLabConfig($lab_config_id);		
-                
+                $saved_db = DbUtil::switchToLabConfig($lab_config_id);
+
                 if($entryID == 9999019)
                     $header = "Grouped Specimen Count Report Configuration";
                 else
                     $header = "Grouped Test Count Report Configuration";
-                
+
                 # Remove existing entry
 		$query_string =
 			"DELETE FROM report_config ".
 			"WHERE landscape = $entryID ";
-			
+
 		query_blind($query_string);
-		
+
                 # Add updated entry
-		$query_string = 
+		$query_string =
 			"INSERT INTO report_config( ".
 				"header, ".
 				"footer, ".
@@ -13640,25 +13620,25 @@ function updateGroupedReportsConfig($byAge, $byGender, $ageGroups, $bySection, $
 		query_insert_one($query_string);
 		DbUtil::switchRestore($saved_db);
 	}
-     
+
      function updateGroupedReportsConfigCountryDir($byAge, $byGender, $ageGroups, $bySection, $combo, $entryID, $lab_config_id, $age_unit)
 	{
-                $saved_db = DbUtil::switchToLabConfig($lab_config_id);		
-                
+                $saved_db = DbUtil::switchToLabConfig($lab_config_id);
+
                 if($entryID == 9999019)
                     $header = "Grouped Specimen Count Report Configuration";
                 else
                     $header = "Grouped Test Count Report Configuration";
-                
+
                 # Remove existing entry
 		$query_string =
 			"DELETE FROM report_config ".
 			"WHERE landscape = $entryID ";
-			
+
 		query_blind($query_string);
-		
+
                 # Add updated entry
-		$query_string = 
+		$query_string =
 			"INSERT INTO report_config( ".
 				"header, ".
 				"footer, ".
@@ -13689,7 +13669,7 @@ function updateGroupedReportsConfig($byAge, $byGender, $ageGroups, $bySection, $
 			")";
 		query_insert_one($query_string);
 		DbUtil::switchRestore($saved_db);
-	}   
+	}
         #nc44
         function getTestRecordsByDate($date, $test_type_id)
 	{
@@ -13706,7 +13686,7 @@ function updateGroupedReportsConfig($byAge, $byGender, $ageGroups, $bySection, $
 			$retval[] = Test::getObject($record);
 		return $retval;
 	}
-        
+
         function updateTestRecordByIds($test_id, $result)
 	{
             //$count_tests = count($test_ids);
@@ -13731,12 +13711,12 @@ function updateGroupedReportsConfig($byAge, $byGender, $ageGroups, $bySection, $
 			//"AND result<>''";
 		$retval = array();
 		$resultset = query_associative_all($query_string);
-                
+
 		foreach($resultset as $record)
 			$retval[] = $record['test_id'];
 		return $retval;
 	}
-        
+
         function get_test_date_by_id($test_type_id, $lab_config_id=null)
 {
 	global $con;
@@ -13749,7 +13729,7 @@ function updateGroupedReportsConfig($byAge, $byGender, $ageGroups, $bySection, $
 	else
 	{
 		$saved_db = DbUtil::switchToLabConfigRevamp($lab_config_id);
-		$query_string = 
+		$query_string =
 			"SELECT date(ts) FROM test_type ".
 			"WHERE test_type_id=$test_type_id LIMIT 1";
 		$record = query_associative_one($query_string);
@@ -13771,7 +13751,7 @@ function getSubmeasureIDs($id)
 		$saved_db = DbUtil::switchToLabConfig($lab_config_id);
 		$recordset = query_associative_all($query_string);
                 DbUtil::switchRestore($saved_db);
-                foreach( $recordset as $record ) 
+                foreach( $recordset as $record )
                 {
 				$measureName = $record['name'];
                                 $smID = intval($record['measure_id']);
@@ -13782,68 +13762,68 @@ function getSubmeasureIDs($id)
 		}
                 return $submeasureList;
         }
-        
-        
+
+
 function setBaseConfig($from_id, $to_id)
 {
     $saved_db = DbUtil::switchToLabConfig($to_id);
-    
+
     $query_string = "DELETE FROM test_category WHERE test_category_id > 0";
     query_blind($query_string);
     $dbn = "blis_".$from_id.".test_category";
     $dbnn = "blis_".$to_id.".test_category";
     $query_string = "INSERT INTO ".$dbnn." (test_category_id, name, description) SELECT test_category_id, name, description FROM ".$dbn;
     query_insert_one($query_string);
-    
+
     $query_string = "DELETE FROM measure WHERE measure_id > 0";
     query_blind($query_string);
     $dbn = "blis_".$from_id.".measure";
     $dbnn = "blis_".$to_id.".measure";
     $query_string = "INSERT INTO ".$dbnn." (measure_id, name, unit_id, range, description, unit) SELECT measure_id, name, unit_id, range, description, unit FROM ".$dbn;
     query_insert_one($query_string);
-    
+
     $query_string = "DELETE FROM specimen_type WHERE specimen_type_id > 0";
     query_blind($query_string);
     $dbn = "blis_".$from_id.".specimen_type";
     $dbnn = "blis_".$to_id.".specimen_type";
     $query_string = "INSERT INTO ".$dbnn." (specimen_type_id, name, description) SELECT specimen_type_id, name, description FROM ".$dbn;
     query_insert_one($query_string);
-    
+
     $query_string = "DELETE FROM reference_range WHERE id > 0";
     query_blind($query_string);
     $dbn = "blis_".$from_id.".reference_range";
     $dbnn = "blis_".$to_id.".reference_range";
     $query_string = "INSERT INTO ".$dbnn." (id, measure_id, age_min, age_max, sex, range_lower, range_upper) SELECT id, measure_id, age_min, age_max, sex, range_lower, range_upper FROM ".$dbn;
     query_insert_one($query_string);
-    
+
     $query_string = "DELETE FROM test_type WHERE test_type_id > 0";
     query_blind($query_string);
     $dbn = "blis_".$from_id.".test_type";
     $dbnn = "blis_".$to_id.".test_type";
     $query_string = "INSERT INTO ".$dbnn." (test_type_id, name, description, test_category_id, is_panel, disabled, clinical_data, hide_patient_name, prevalence_threshold, target_tat) SELECT test_type_id, name, description, test_category_id, is_panel, disabled, clinical_data, hide_patient_name, prevalence_threshold, target_tat FROM ".$dbn;
     query_insert_one($query_string);
-  
+
     $query_string = "DELETE FROM test_type_measure WHERE test_type_id > 0";
     query_blind($query_string);
     $dbn = "blis_".$from_id.".test_type_measure";
     $dbnn = "blis_".$to_id.".test_type_measure";
     $query_string = "INSERT INTO ".$dbnn." (test_type_id, measure_id) SELECT test_type_id, measure_id FROM ".$dbn;
     query_insert_one($query_string);
-    
+
     $query_string = "DELETE FROM unit WHERE unit_id > 0";
     query_blind($query_string);
     $dbn = "blis_".$from_id.".unit";
     $dbnn = "blis_".$to_id.".unit";
     $query_string = "INSERT INTO ".$dbnn." (unit_id, unit) SELECT unit_id, unit FROM ".$dbn;
     query_insert_one($query_string);
-    
+
     $query_string = "DELETE FROM custom_field_type WHERE id > 0";
     query_blind($query_string);
     $dbn = "blis_".$from_id.".custom_field_type";
     $dbnn = "blis_".$to_id.".custom_field_type";
     $query_string = "INSERT INTO ".$dbnn." (id, field_type) SELECT id, field_type FROM ".$dbn;
     query_insert_one($query_string);
-    
+
     /*
     $query_string = "DELETE FROM labtitle_custom_field WHERE id > 0";
     query_blind($query_string);
@@ -13852,24 +13832,24 @@ function setBaseConfig($from_id, $to_id)
     $query_string = "INSERT INTO ".$dbnn." (id, field_name, field_options, field_type_id) SELECT id, field_name, field_options, field_type_id FROM ".$dbn;
     query_insert_one($query_string);
     */
-    
+
     $query_string = "DELETE FROM patient_custom_field WHERE id > 0";
     query_blind($query_string);
     $dbn = "blis_".$from_id.".patient_custom_field";
     $dbnn = "blis_".$to_id.".patient_custom_field";
     $query_string = "INSERT INTO ".$dbnn." (id, field_name, field_options, field_type_id) SELECT id, field_name, field_options, field_type_id FROM ".$dbn;
     query_insert_one($query_string);
-    
+
     $query_string = "DELETE FROM specimen_custom_field WHERE id > 0";
     query_blind($query_string);
     $dbn = "blis_".$from_id.".specimen_custom_field";
     $dbnn = "blis_".$to_id.".specimen_custom_field";
     $query_string = "INSERT INTO ".$dbnn." (id, field_name, field_options, field_type_id) SELECT id, field_name, field_options, field_type_id FROM ".$dbn;
     query_insert_one($query_string);
-    
+
     DbUtil::switchRestore($saved_db);
-    
-}   
+
+}
 
 function setBaseConfigSpecimens($from_id, $to_id)
 {
@@ -13879,7 +13859,7 @@ function setBaseConfigSpecimens($from_id, $to_id)
 			"SELECT * FROM test_category ";
     $recordset = query_associative_all($query_string);
     DbUtil::switchRestore($saved_db);
-    
+
     $saved_db = DbUtil::switchToLabConfig($to_id);
     $query_string = "DELETE FROM test_category WHERE test_category_id > 0";
     query_blind($query_string);
@@ -13892,14 +13872,14 @@ function setBaseConfigSpecimens($from_id, $to_id)
         query_insert_one($query_string);
     }
     DbUtil::switchRestore($saved_db);
-    
+
     # measure table
     $saved_db = DbUtil::switchToLabConfig($from_id);
     $query_string =
 			"SELECT * FROM measure ";
     $recordset = query_associative_all($query_string);
     DbUtil::switchRestore($saved_db);
-    
+
     $saved_db = DbUtil::switchToLabConfig($to_id);
      $query_string = "DELETE FROM measure WHERE measure_id > 0";
     query_blind($query_string);
@@ -13930,15 +13910,15 @@ function setBaseConfigSpecimens($from_id, $to_id)
      query_insert_one($query_string);
     DbUtil::switchRestore($saved_db);
     return;
-    
-    
+
+
     # specimen_type table
     $saved_db = DbUtil::switchToLabConfig($from_id);
     $query_string =
 			"SELECT * FROM specimen_type ";
     $recordset = query_associative_all($query_string);
     DbUtil::switchRestore($saved_db);
-    
+
     $saved_db = DbUtil::switchToLabConfig($to_id);
      $query_string = "DELETE FROM specimen_type WHERE specimen_type_id > 0";
     query_blind($query_string);
@@ -13951,14 +13931,14 @@ function setBaseConfigSpecimens($from_id, $to_id)
         query_insert_one($query_string);
     }
     DbUtil::switchRestore($saved_db);
-    
+
     # reference_range table
     $saved_db = DbUtil::switchToLabConfig($from_id);
     $query_string =
 			"SELECT * FROM reference_range ";
     $recordset = query_associative_all($query_string);
     DbUtil::switchRestore($saved_db);
-    
+
     $saved_db = DbUtil::switchToLabConfig($to_id);
      $query_string = "DELETE FROM reference_range WHERE id > 0";
     query_blind($query_string);
@@ -13975,14 +13955,14 @@ function setBaseConfigSpecimens($from_id, $to_id)
         query_insert_one($query_string);
     }
     DbUtil::switchRestore($saved_db);
-    
+
     # test_type table
     $saved_db = DbUtil::switchToLabConfig($from_id);
     $query_string =
 			"SELECT * FROM test_type ";
     $recordset = query_associative_all($query_string);
     DbUtil::switchRestore($saved_db);
-    
+
     $saved_db = DbUtil::switchToLabConfig($to_id);
      $query_string = "DELETE FROM test_type WHERE test_type_id > 0";
     query_blind($query_string);
@@ -14002,14 +13982,14 @@ function setBaseConfigSpecimens($from_id, $to_id)
         query_insert_one($query_string);
     }
     DbUtil::switchRestore($saved_db);
-    
+
      # test_type_measure table
     $saved_db = DbUtil::switchToLabConfig($from_id);
     $query_string =
 			"SELECT * FROM test_type_measure ";
     $recordset = query_associative_all($query_string);
     DbUtil::switchRestore($saved_db);
-    
+
     $saved_db = DbUtil::switchToLabConfig($to_id);
      $query_string = "DELETE FROM test_type_measure WHERE test_type_id > 0";
     query_blind($query_string);
@@ -14021,14 +14001,14 @@ function setBaseConfigSpecimens($from_id, $to_id)
         query_insert_one($query_string);
     }
     DbUtil::switchRestore($saved_db);
-    
+
     # unit table
     $saved_db = DbUtil::switchToLabConfig($from_id);
     $query_string =
 			"SELECT * FROM unit ";
     $recordset = query_associative_all($query_string);
     DbUtil::switchRestore($saved_db);
-    
+
     $saved_db = DbUtil::switchToLabConfig($to_id);
      $query_string = "DELETE FROM unit WHERE unit_id > 0";
     query_blind($query_string);
@@ -14040,14 +14020,14 @@ function setBaseConfigSpecimens($from_id, $to_id)
         query_insert_one($query_string);
     }
     DbUtil::switchRestore($saved_db);
-    
+
     # custom_field_type table
     $saved_db = DbUtil::switchToLabConfig($from_id);
     $query_string =
 			"SELECT * FROM custom_field_type ";
     $recordset = query_associative_all($query_string);
     DbUtil::switchRestore($saved_db);
-    
+
     $saved_db = DbUtil::switchToLabConfig($to_id);
      $query_string = "DELETE FROM custom_field_type WHERE id > 0";
     query_blind($query_string);
@@ -14059,14 +14039,14 @@ function setBaseConfigSpecimens($from_id, $to_id)
         query_insert_one($query_string);
     }
     DbUtil::switchRestore($saved_db);
- 
+
     # labtitle_custom_field table
     $saved_db = DbUtil::switchToLabConfig($from_id);
     $query_string =
 			"SELECT * FROM labtitle_custom_field ";
     $recordset = query_associative_all($query_string);
     DbUtil::switchRestore($saved_db);
-    
+
     $saved_db = DbUtil::switchToLabConfig($to_id);
      $query_string = "DELETE FROM labtitle_custom_field WHERE id > 0";
     query_blind($query_string);
@@ -14080,14 +14060,14 @@ function setBaseConfigSpecimens($from_id, $to_id)
         query_insert_one($query_string);
     }
     DbUtil::switchRestore($saved_db);
-    
+
     # patient_custom_field table
     $saved_db = DbUtil::switchToLabConfig($from_id);
     $query_string =
 			"SELECT * FROM patient_custom_field; ";
     $recordset = query_associative_all($query_string);
     DbUtil::switchRestore($saved_db);
-    
+
     $saved_db = DbUtil::switchToLabConfig($to_id);
     $query_string = "DELETE FROM patient_custom_field WHERE id > 0";
     query_blind($query_string);
@@ -14101,14 +14081,14 @@ function setBaseConfigSpecimens($from_id, $to_id)
         query_insert_one($query_string);
     }
     DbUtil::switchRestore($saved_db);
-    
+
     # specimen_custom_field table
     $saved_db = DbUtil::switchToLabConfig($from_id);
     $query_string =
 			"SELECT * FROM specimen_custom_field; ";
     $recordset = query_associative_all($query_string);
     DbUtil::switchRestore($saved_db);
-    
+
     $saved_db = DbUtil::switchToLabConfig($to_id);
     $query_string = "DELETE FROM specimen_custom_field WHERE id > 0";
     query_blind($query_string);
@@ -14140,7 +14120,7 @@ function import_test_between_labs($test_id, $from_id, $to_id)
     $measure_objs = $test_type->getMeasures();
     //print_r($measure_objs);
     DbUtil::switchRestore($saved_db);
-    
+
     $saved_db = DbUtil::switchToLabConfig($to_id);
     //$test_type->testTypeId;
     $test_name = $test_type->name;
@@ -14187,9 +14167,9 @@ function import_test_between_labs($test_id, $from_id, $to_id)
             $sm_id = add_measure($enc_name, $mo->range, $mo->unit);
             array_push($id_list, $sm_id);
         }
-            
+
     }
-    
+
     foreach($id_list as $measure_id)
     {
         add_test_type_measure($new_test_id, $measure_id);
@@ -14204,35 +14184,35 @@ function import_test_between_labs($test_id, $from_id, $to_id)
 function remove_specimens($lid, $sp, $remarks, $category="test")
 {
             $created_by = $_SESSION["user_id"];
-            
-            $saved_db = DbUtil::switchToLabConfig($lid);            
-            
+
+            $saved_db = DbUtil::switchToLabConfig($lid);
+
             $query_string = "INSERT INTO removal_record (r_id, type, remarks, user_id, status, category) ".
                             "VALUES ($sp, 1, '$remarks', $created_by, 1, '$category')";
             //;
             query_insert_one($query_string);
-            
+
             DbUtil::switchRestore($saved_db);
 }
-  
+
 function get_removed_specimens($lid, $category="test")
 {
             $lab_config_id = $lid;
-            
-            $saved_db = DbUtil::switchToLabConfig($lab_config_id);     
-            
+
+            $saved_db = DbUtil::switchToLabConfig($lab_config_id);
+
             $query_string = "SELECT * from removal_record WHERE type = 1 AND category='$category' AND status = 1";
-            
+
             $recordset = query_associative_all($query_string);
-            
+
             DbUtil::switchRestore($saved_db);
-            
+
             return $recordset;
 }
 
 function retrieve_deleted_items($lid, $sp, $category="test"){
 	$lab_config_id = $lid;
-	
+
 	$saved_db = DbUtil::switchToLabConfig($lab_config_id);
 	if($category == "patient"){
 		$specimen_list = get_specimens_by_patient_id($sp);
@@ -14240,7 +14220,7 @@ function retrieve_deleted_items($lid, $sp, $category="test"){
 			foreach($specimen_list as $specimen){
 				retrieve_deleted_items($lid,$specimen->specimenId, "specimen");
 			}
-			
+
 		}
 	} else if($category == "specimen"){
 		$testsList = get_tests_by_specimen_id($sp);
@@ -14253,7 +14233,7 @@ function retrieve_deleted_items($lid, $sp, $category="test"){
 	    $query_string = "UPDATE removal_record SET status = 0 WHERE r_id = $sp AND category='$category' AND status = 1 AND type = 1";
 		//."<br/>";
 	    query_update($query_string);
-    
+
 	DbUtil::switchRestore($saved_db);
 	return 1;
 }
@@ -14261,23 +14241,23 @@ function retrieve_deleted_items($lid, $sp, $category="test"){
 function retrieve_specimens($lid, $sp, $category="test")
 {
         $lab_config_id = $lid;
-            
-        $saved_db = DbUtil::switchToLabConfig($lab_config_id);  
-    
+
+        $saved_db = DbUtil::switchToLabConfig($lab_config_id);
+
         $query_string = "UPDATE removal_record SET status = 0 WHERE r_id = $sp AND category='$category' AND status = 1 AND type = 1";
             query_update($query_string);
-            
+
         DbUtil::switchRestore($saved_db);
 }
 
 function check_removal_record($lid, $sp, $category="test")
 {
             $lab_config_id = $lid;
-            
-            $saved_db = DbUtil::switchToLabConfig($lab_config_id);     
-            
+
+            $saved_db = DbUtil::switchToLabConfig($lab_config_id);
+
             $query_string = "SELECT count(*) as val from removal_record WHERE type = 1 AND category='$category' AND status = 1 AND r_id = $sp";
-            
+
             //;
             $recordset = query_associative_one($query_string);
             //."<br/>";
@@ -14288,34 +14268,34 @@ function check_removal_record($lid, $sp, $category="test")
 function get_date_of_latest_test_type_cost_update($test_type_id)
 {
     $lab_config_id = $_SESSION['lab_config_id'];
-    
+
     $saved_db = DbUtil::switchToLabConfig($lab_config_id);
-    
+
     $query_string = "SELECT earliest_date_valid FROM test_type_costs WHERE test_type_id=$test_type_id ORDER BY earliest_date_valid DESC LIMIT 1";
-    
+
     $result = query_associative_one($query_string);
-            
+
     DbUtil::switchRestore($saved_db);
-    
+
     return $result['earliest_date_valid'];
 }
 
 function instantiate_new_cost_of_test_type($cost, $test_type_id)
 {
     $lab_config_id = $_SESSION['lab_config_id'];
-        
+
     $saved_db = DbUtil::switchToLabConfig($lab_config_id);
-    
+
     $query_string = "SELECT count(*) AS val FROM test_type_costs WHERE test_type_id=$test_type_id";
-    
+
     $count = query_associative_one($query_string);
-    
+
     DbUtil::switchRestore($saved_db);
-    
+
     if ($count['val'] != 0) {
         return 0;
     }
-    
+
     $saved_db = DbUtil::switchToLabConfig($lab_config_id);
 
     $query_string = "INSERT INTO test_type_costs (amount, test_type_id) VALUES ($cost, $test_type_id)";
@@ -14323,7 +14303,7 @@ function instantiate_new_cost_of_test_type($cost, $test_type_id)
     query_insert_one($query_string);
 
     DbUtil::switchRestore($saved_db);
-    
+
     return 1;
 }
 
@@ -14352,7 +14332,7 @@ function insert_new_cost_of_test_type($cost, $test_type_id)
 
         DbUtil::switchRestore($saved_db);
     }
-    
+
     return 1;
 }
 
@@ -14361,13 +14341,13 @@ function get_latest_cost_of_test_type($test_type_id)
     instantiate_new_cost_of_test_type(0.00, $test_type_id);
 
     $lab_config_id = $_SESSION['lab_config_id'];
-    
+
     $saved_db = DbUtil::switchToLabConfig($lab_config_id);
-    
+
     $query_string = "SELECT amount FROM test_type_costs WHERE ".
                     "test_type_id=$test_type_id ORDER BY earliest_date_valid DESC LIMIT 1";
     $result = query_associative_one($query_string);
-   
+
     DbUtil::switchRestore($saved_db);
     return $result['amount'];
 }
@@ -14375,17 +14355,17 @@ function get_latest_cost_of_test_type($test_type_id)
 function get_cost_of_test_type_for_closest_date($date, $test_type_id)
 {
     instantiate_new_cost_of_test_type(0.00, $test_type_id);
-    
+
     $date = date("Y-m-d H:i:s", strtotime($date));
-	
+
     $lab_config_id = $_SESSION['lab_config_id'];
-    
+
     $saved_db = DbUtil::switchToLabConfig($lab_config_id);
 
     $query_string = "SELECT amount, earliest_date_valid FROM test_type_costs WHERE test_type_id=$test_type_id AND earliest_date_valid<='$date' ORDER BY earliest_date_valid DESC LIMIT 1";
-    
+
     $result = query_associative_one($query_string);
-    
+
     DbUtil::switchRestore($saved_db);
 
     return $result;
@@ -14394,24 +14374,24 @@ function get_cost_of_test_type_for_closest_date($date, $test_type_id)
 function get_all_tests_for_patient_and_date_range($patient_id, $small_date, $large_date, $labsection=0)
 {
     $lab_config_id = $_SESSION['lab_config_id'];
-    
+
     $large_date = date("Y-m-d H:i:s", strtotime($large_date) + 86400); // Gives us a range from the day we want to the next day.
     $small_date = date("Y-m-d H:i:s", strtotime($small_date));
-    
+
     $saved_db = DbUtil::switchToLabConfig($lab_config_id);
-    
+
 	if($labsection == 0){
 		$query_string = "SELECT DISTINCT test_id, ts FROM test WHERE specimen_id IN (SELECT specimen_id FROM specimen WHERE patient_id=$patient_id) AND ts<='$large_date' AND ts>='$small_date'";
     } else {
-		$query_string = "SELECT DISTINCT t.test_id, t.ts FROM test t, test_type tt ". 
+		$query_string = "SELECT DISTINCT t.test_id, t.ts FROM test t, test_type tt ".
 						 "WHERE t.specimen_id IN (SELECT specimen_id FROM specimen WHERE patient_id=$patient_id) ".
 						 "AND t.test_type_id IN (SELECT test_type_id from test_type where test_category_id=$labsection) AND t.ts<='$large_date' AND t.ts>='$small_date'";
 	}
-	
+
     $result = query_associative_all($query_string);
-    
+
     DbUtil::switchRestore($saved_db);
-    
+
     return $result;
 }
 
@@ -14433,31 +14413,31 @@ function get_test_names_and_costs_from_ids($id_array)
     $ret_array = array();
     $ret_array['costs'] = $cost_array;
     $ret_array['names'] = $name_array;
-    
+
     return $ret_array;
 }
 
 function get_cost_of_test($test)
 {
 	$cost = get_cost_of_test_type_for_closest_date($test->timestamp, $test->testTypeId);
-	
+
 	return $cost;
 }
 
 function generate_bill_data_for_patient_and_date_range($patient_id, $first_date, $second_date, $labsection=0)
 {
 	//echo "Lab Section ".$labsection;
-	$saved_db = DbUtil::switchToLabConfig($_SESSION['lab_config_id']);	
+	$saved_db = DbUtil::switchToLabConfig($_SESSION['lab_config_id']);
     $test_info = get_all_tests_for_patient_and_date_range($patient_id, $first_date, $second_date, $labsection);
 	DbUtil::switchRestore($saved_db);
-	
+
     $test_ids = array();
     $test_dates = array();
     foreach ($test_info as $test) {
         $test_ids[] = $test['test_id'];
         $test_dates[] = date("Y-m-d", strtotime($test['ts']));
     }
-    $saved_db = DbUtil::switchToLabConfig($_SESSION['lab_config_id']);	
+    $saved_db = DbUtil::switchToLabConfig($_SESSION['lab_config_id']);
     $names_and_costs = get_test_names_and_costs_from_ids($test_ids);
     DbUtil::switchRestore($saved_db);
 	$bill_total = array_sum($names_and_costs['costs']);
@@ -14466,54 +14446,54 @@ function generate_bill_data_for_patient_and_date_range($patient_id, $first_date,
     $bill_fields['names'] = $names_and_costs['names'];
     $bill_fields['costs'] = $names_and_costs['costs'];
     $bill_fields['dates'] = $test_dates;
-    
+
     return $bill_fields;
 }
 
 function get_test_type_id_from_test_id($test_id)
 {
     $lab_config_id = $_SESSION['lab_config_id'];
-    
+
     $saved_db = DbUtil::switchToLabConfig($lab_config_id);
-    
+
     $query_string = "SELECT test_type_id FROM test WHERE test_id=$test_id";
-    
+
     $result = query_associative_one($query_string);
-            
+
     DbUtil::switchRestore($saved_db);
-    
+
     return $result['test_type_id'];
 }
 
 /***************************
  * Billing Functions
  ***************************/
- 
+
 function functional_number_to_editable_money($number)
 {
 	$string = get_currency_delimiter_from_lab_config_settings(); // i.e. get DDD(.)CC
-	
+
 	$dollars = floor($number); // i.e. get (DDD).CC
 	$cents = $number - $dollars; // i.e. get DDD.(CC)
-	
+
 	$cents_as_whole_number = get_cents_as_whole_number($cents); // turn 0.(CC) into (CC).0
-	
+
 	$string = $dollars . $string . $cents; // i.e. (DDD)(.)(CC) = DDD.CC
-	
+
 	return $string;
 }
 
 function editable_money_to_functional_number($string)
 {
 	$delimiter = get_currency_delimiter_from_lab_config_settings();
-	
+
 	$values = explode($delimiter, $string);
 	$dollars = $values[0];
 	$cents = $values[1];
-	
+
 	$numeric_cents = get_cents_from_whole_number($cents); // turn (CC).0 into 0.(CC)
 	$numeric_dollars = intval($dollars); // force dealing with an int to ensure no type problems arise.
-	
+
 	return $numeric_dollars + $nuermic_cents;
 }
 
@@ -14521,12 +14501,12 @@ function format_number_to_money($number)
 {
     $dollars = floor($number);
     $cents = $number - $dollars;
-    
+
     $cents_as_whole_number = get_cents_as_whole_number($cents);
-    
+
     if ($cents_as_whole_number < 10)
         $cents_as_whole_number = "0" . strval($cents_as_whole_number);
-    
+
     return $dollars . get_currency_delimiter_from_lab_config_settings() . $cents_as_whole_number . " " . get_currency_type_from_lab_config_settings();
 }
 
@@ -14534,12 +14514,12 @@ function format_number_to_money_currencyName($number, $currencyName)
 {
     $dollars = floor($number);
     $cents = $number - $dollars;
-    
+
     $cents_as_whole_number = get_cents_as_whole_number($cents);
-    
+
     if ($cents_as_whole_number < 10)
         $cents_as_whole_number = "0" . strval($cents_as_whole_number);
-    
+
     return $dollars . get_currency_delimiter_from_lab_config_settings() . $cents_as_whole_number . " " . $currencyName;
 }
 
@@ -14552,7 +14532,7 @@ function get_cents_as_whole_number($cents)
 function get_cents_from_whole_number($cents)
 {
 	$cost_cents = floor(ltrim($cents, "0")); // Remove any leading zeroes in case the user typed 01 or similar.
-	
+
 	return $cost_cents / 100;
 }
 
@@ -14560,25 +14540,25 @@ function get_cents_from_whole_number($cents)
 function insert_lab_config_settings_billing($enabled, $currency_name, $currency_delimiter)
 {
     $id = 3; // ID for billing settings
-    
+
     $lab_config_id = $_SESSION['lab_config_id'];
-            
-    $saved_db = DbUtil::switchToLabConfig($lab_config_id);     
-    
+
+    $saved_db = DbUtil::switchToLabConfig($lab_config_id);
+
     $query_string = "SELECT count(*) as val from lab_config_settings WHERE id = $id";
     $recordset = query_associative_one($query_string);
-    
+
     if($recordset[val] != 0)
         return 0;
-    
+
     $remarks = "Billing Settings";
-    
+
     $query_string = "INSERT INTO lab_config_settings (id, flag1, setting1, setting2, remarks) ".
                             "VALUES ($id, $enabled, '$currency_name', '$currency_delimiter', '$remarks')";
     query_insert_one($query_string);
-            
+
     DbUtil::switchRestore($saved_db);
-    
+
     return 1;
 }
 
@@ -14587,22 +14567,22 @@ function get_lab_config_settings_billing()
     insert_lab_config_settings_billing(1, "USD", ".");
     $id = 3; // ID for billing settings
     $lab_config_id = $_SESSION['lab_config_id'];
-            
-    $saved_db = DbUtil::switchToLabConfig($lab_config_id);     
-            
+
+    $saved_db = DbUtil::switchToLabConfig($lab_config_id);
+
     $query_string = "SELECT * from lab_config_settings WHERE id = $id";
     $recordset = query_associative_one($query_string);
-            
+
     DbUtil::switchRestore($saved_db);
-    
+
     $retval = array();
-    
+
     // barcode settings = type, width, height, font_size
-    
+
     $retval['enabled'] = $recordset['flag1'];
     $retval['currency_name'] = $recordset['setting1'];
     $retval['currency_delimiter'] = $recordset['setting2'];
-    
+
     return $retval;
 }
 
@@ -14611,44 +14591,44 @@ function update_lab_config_settings_billing($new_settings)
     $enable = $new_settings['enabled'];
     $currency_name = $new_settings['currency_name'];
     $currency_delimiter = $new_settings['currency_delimiter'];
-    
+
     insert_lab_config_settings_billing(1, "USD", ".");
     $id = 3; // ID for billing settings
     $lab_config_id = $_SESSION['lab_config_id'];
-            
-    $saved_db = DbUtil::switchToLabConfig($lab_config_id);     
-    
+
+    $saved_db = DbUtil::switchToLabConfig($lab_config_id);
+
     if($enable != 0)
         $enable = 1;
-        
+
     $query_string = "UPDATE lab_config_settings SET flag1=$enable, setting1='$currency_name', setting2='$currency_delimiter' WHERE id=$id";
     query_update($query_string);
-            
+
     DbUtil::switchRestore($saved_db);
-    
+
     return 1;
 }
 
 function get_currency_type_from_lab_config_settings()
 {
     $settings = get_lab_config_settings_billing();
-    
+
     return $settings['currency_name'];
 }
 
 function get_currency_delimiter_from_lab_config_settings()
 {
     $settings = get_lab_config_settings_billing();
-    
+
     return $settings['currency_delimiter'];
 }
 
 function update_currency_name_in_lab_config_settings($new_currency)
 {
     $settings = get_lab_config_settings_billing();
-    
+
     $settings['currency_name'] = $new_currency;
-   
+
     update_lab_config_settings_billing($settings);
     $lab_config_id = $_SESSION['lab_config_id'];
     currencyConfig::setDefaultCurrency($lab_config_id, $new_currency);
@@ -14658,18 +14638,18 @@ function update_currency_name_in_lab_config_settings($new_currency)
 function update_currency_delimiter_in_lab_config_settings($new_delimiter)
 {
     $settings = get_lab_config_settings_billing();
-    
+
     $settings['currency_delimiter'] = $new_delimiter;
-    
+
     update_lab_config_settings_billing($settings);
-    
+
     return 1;
 }
 
 function get_selected_if_currency_is_used($currency)
 {
     $currency_set = get_currency_type_from_lab_config_settings();
-    
+
     if ($currency_set == $currency) {
         return "checked";
     } else {
@@ -14681,9 +14661,9 @@ function enable_billing()
 {
     $current_state = get_lab_config_settings_billing();
     $current_state['enabled'] = 1;
-    
+
     update_lab_config_settings_billing($current_state);
-    
+
     return 1;
 }
 
@@ -14691,9 +14671,9 @@ function disable_billing()
 {
     $current_state = get_lab_config_settings_billing();
     $current_state['enabled'] = 0;
-    
+
     update_lab_config_settings_billing($current_state);
-    
+
     return 1;
 }
 
@@ -14716,7 +14696,7 @@ function render_pdf_from_html($html, $page_title, $page_author)
 
     // Instantiate the pdf
     $pdf = new TCPDF(PDF_PAGE_ORIENTATION, PDF_UNIT, PDF_PAGE_FORMAT, true, 'UTF-8', false);
-    
+
     // set document information
     $pdf->SetCreator(PDF_CREATOR);
     $pdf->SetAuthor('BLIS');
@@ -14742,24 +14722,24 @@ function getBarcodeTypes()
 function insert_lab_config_settings_barcode($type, $width, $height, $textsize, $enable)
 {
     $id = 1; // ID for barcode settings
-    
+
     $lab_config_id = $_SESSION['lab_config_id'];
-            
-    $saved_db = DbUtil::switchToLabConfig($lab_config_id);     
-    
+
+    $saved_db = DbUtil::switchToLabConfig($lab_config_id);
+
     $query_string = "SELECT count(*) as val from lab_config_settings WHERE id = $id";
-    $recordset = query_associative_one($query_string);        
-    
+    $recordset = query_associative_one($query_string);
+
     if($recordset[val] != 0)
         return 0;
-    
+
     $remarks = "Barcode Settings";
     $query_string = "INSERT INTO lab_config_settings (id, flag1, flag2, flag3, flag4, setting1, remarks) ".
                             "VALUES ($id, $enable, $width, $height, $textsize, '$type', '$remarks')";
             query_insert_one($query_string);
-            
+
     DbUtil::switchRestore($saved_db);
-    
+
     return 1;
 }
 
@@ -14768,24 +14748,24 @@ function get_lab_config_settings_barcode()
     insert_lab_config_settings_barcode('code39', 2, 30, 11, 1);
     $id = 1; // ID for barcode settings
     $lab_config_id = $_SESSION['lab_config_id'];
-            
-    $saved_db = DbUtil::switchToLabConfig($lab_config_id);     
-            
+
+    $saved_db = DbUtil::switchToLabConfig($lab_config_id);
+
     $query_string = "SELECT * from lab_config_settings WHERE id = $id";
     $recordset = query_associative_one($query_string);
-            
+
     DbUtil::switchRestore($saved_db);
-    
+
     $retval = array();
-    
+
     // barcode settings = type, width, height, font_size
-    
+
     $retval['enabled'] = $recordset['flag1'];
     $retval['width'] = $recordset['flag2'];
     $retval['height'] = $recordset['flag3'];
     $retval['textsize'] = $recordset['flag4'];
     $retval['type'] = $recordset['setting1'];
-    
+
     return $retval;
 }
 
@@ -14794,17 +14774,17 @@ function update_lab_config_settings_barcode($type, $width, $height, $textsize, $
     insert_lab_config_settings_barcode('code39', 2, 30, 11, 1);
     $id = 1; // ID for barcode settings
     $lab_config_id = $_SESSION['lab_config_id'];
-            
-    $saved_db = DbUtil::switchToLabConfig($lab_config_id);     
-    
+
+    $saved_db = DbUtil::switchToLabConfig($lab_config_id);
+
     if($enable != 0)
-        $enable = 1;    
-        
+        $enable = 1;
+
     $query_string = "UPDATE lab_config_settings SET flag1 = $enable, flag2 = $width, flag3 = $height, flag4 = $textsize, setting1 = '$type' WHERE id = $id";
             query_update($query_string);
-            
+
     DbUtil::switchRestore($saved_db);
-    
+
     return 1;
 }
 
@@ -14817,22 +14797,22 @@ function update_lab_config_settings_barcode($type, $width, $height, $textsize, $
 function insert_lab_config_settings_search($num)
 {
     $id = 2; // ID for search settings
-    
+
     $lab_config_id = $_SESSION['lab_config_id'];
-    $saved_db = DbUtil::switchToLabConfig($lab_config_id);     
-    
+    $saved_db = DbUtil::switchToLabConfig($lab_config_id);
+
     $query_string = "SELECT count(*) as val from lab_config_settings WHERE id = $id";
-    $recordset = query_associative_one($query_string);        
-    
+    $recordset = query_associative_one($query_string);
+
     if($recordset[val] != 0)
         return 0;
     $remarks = "Search Settings";
     $query_string = "INSERT INTO lab_config_settings (id, flag1, remarks) ".
                             "VALUES ($id, $num, '$remarks')";
             query_insert_one($query_string);
-            
+
     DbUtil::switchRestore($saved_db);
-    
+
     return 1;
 }
 
@@ -14841,21 +14821,21 @@ function get_lab_config_settings_search()
     insert_lab_config_settings_search(20);
     $id = 2; // ID for search settings
     $lab_config_id = $_SESSION['lab_config_id'];
-            
-    $saved_db = DbUtil::switchToLabConfig($lab_config_id);     
-            
+
+    $saved_db = DbUtil::switchToLabConfig($lab_config_id);
+
     $query_string = "SELECT * from lab_config_settings WHERE id = $id";
     $recordset = query_associative_one($query_string);
-            
+
     DbUtil::switchRestore($saved_db);
-    
+
     $retval = array();
-    
+
     // search settings = results_per_page
-    
+
     $retval['results_per_page'] = $recordset['flag1'];
-    
-    
+
+
     return $retval;
 }
 
@@ -14864,14 +14844,14 @@ function update_lab_config_settings_search($num)
     insert_lab_config_settings_search(20);
     $id = 2; // ID for search settings
     $lab_config_id = $_SESSION['lab_config_id'];
-            
-    $saved_db = DbUtil::switchToLabConfig($lab_config_id);     
-        
+
+    $saved_db = DbUtil::switchToLabConfig($lab_config_id);
+
     $query_string = "UPDATE lab_config_settings SET flag1 = $num WHERE id = $id";
             query_update($query_string);
-            
+
     DbUtil::switchRestore($saved_db);
-    
+
     return 1;
 }
 
@@ -14897,270 +14877,270 @@ class Inventory
 	public $unit;
 	public $remarks;
 	public $quantity;
-	        
+
         public function addReagent($name, $unit, $remarks)
         {
             $created_by = $_SESSION["user_id"];
             $lab_config_id = $_SESSION["lab_config_id"];
-            
-            $saved_db = DbUtil::switchToLabConfig($lab_config_id);            
-            
+
+            $saved_db = DbUtil::switchToLabConfig($lab_config_id);
+
             $query_string = "INSERT INTO inv_reagent (name, unit, remarks, created_by) ".
                             "VALUES ('$name', '$unit', '$remarks', $created_by)";
             query_insert_one($query_string);
-            
+
             DbUtil::switchRestore($saved_db);
         }
-        
+
         public function editReagent()
         {
-            
+
         }
-        
+
         public function addStock($reagent_id, $lot, $e_date, $manu, $sup, $quant, $cost, $r_date, $remarks)
         {
             $created_by = $_SESSION["user_id"];
             $lab_config_id = $_SESSION["lab_config_id"];
             if($cost == '')
                 $cost = 0;
-            $saved_db = DbUtil::switchToLabConfig($lab_config_id);     
-            
+            $saved_db = DbUtil::switchToLabConfig($lab_config_id);
+
             $query_string = "INSERT INTO inv_supply (reagent_id, lot, expiry_date, manufacturer, supplier, quantity_ordered, quantity_supplied, cost_per_unit, user_id, date_of_order, date_of_supply, date_of_reception, remarks) ".
                             "VALUES ($reagent_id, '$lot', '$e_date', '$manu', '$sup', 0, $quant, $cost, $created_by, '$r_date', '$r_date', '$r_date', '$remarks')";
             query_insert_one($query_string);
-            
+
             DbUtil::switchRestore($saved_db);
         }
-        
+
         public function useStock($reagent_id, $lot, $quant, $u_date, $remarks)
         {
             $created_by = $_SESSION["user_id"];
             $lab_config_id = $_SESSION["lab_config_id"];
-            
-            $saved_db = DbUtil::switchToLabConfig($lab_config_id);     
-            
+
+            $saved_db = DbUtil::switchToLabConfig($lab_config_id);
+
             $query_string = "INSERT INTO inv_usage (reagent_id, lot, quantity_used, date_of_use, user_id, remarks) ".
                             "VALUES ($reagent_id, '$lot', $quant, '$u_date', $created_by, '$remarks')";
             query_insert_one($query_string);
-            
+
             DbUtil::switchRestore($saved_db);
         }
-        
+
         public function editStock()
         {
-            
+
         }
-        
+
         public function getQuantity($lid, $r_id)
         {
             $lab_config_id = $lid;
-            
-            $saved_db = DbUtil::switchToLabConfig($lab_config_id);     
-            
+
+            $saved_db = DbUtil::switchToLabConfig($lab_config_id);
+
             $query_string = "SELECT sum(quantity_supplied) as val from inv_supply where reagent_id = $r_id";
             $recordset = query_associative_one($query_string);
             $supply = $recordset['val'];
-            
+
             $query_string = "SELECT sum(quantity_used) as val from inv_usage where reagent_id = $r_id";
             $recordset2 = query_associative_one($query_string);
             $usage = $recordset2['val'];
-                        
+
             $quantity = $supply - $usage;
-            
+
             DbUtil::switchRestore($saved_db);
-            
+
             return $quantity;
         }
-        
+
         public function checkReagent($lid, $name)
         {
             $lab_config_id = $lid;
-            
-            $saved_db = DbUtil::switchToLabConfig($lab_config_id);     
-            
+
+            $saved_db = DbUtil::switchToLabConfig($lab_config_id);
+
             $query_string = "SELECT count(*) as val from inv_reagent WHERE name = '$name'";
             $recordset = query_associative_one($query_string);
             $count = $recordset['val'];
-            
+
             $check = 0;
-            
+
             if($count > 0)
                 $check = 1;
-            
+
             DbUtil::switchRestore($saved_db);
-           
+
             return $check;
         }
-        
+
         public function checkLot($lid, $r_id, $lot)
         {
             $lab_config_id = $lid;
-            
-            $saved_db = DbUtil::switchToLabConfig($lab_config_id);     
-            
+
+            $saved_db = DbUtil::switchToLabConfig($lab_config_id);
+
             $query_string = "SELECT count(*) as val from inv_supply WHERE lot = '$lot' AND reagent_id = $r_id";
             $recordset = query_associative_one($query_string);
             $count = $recordset['val'];
-            
+
             $check = 0;
-            
+
             if($count > 0)
                 $check = 1;
-            
+
             DbUtil::switchRestore($saved_db);
-            
+
             return $check;
         }
-        
+
         public function getLotQuantity($lid, $r_id, $lot)
         {
             $lab_config_id = $lid;
-            
-            $saved_db = DbUtil::switchToLabConfig($lab_config_id);     
-            
+
+            $saved_db = DbUtil::switchToLabConfig($lab_config_id);
+
             $query_string = "SELECT * from inv_supply where reagent_id = $r_id AND lot = '$lot'";
             $recordset2 = query_associative_one($query_string);
             $quantity = $recordset2['quantity_supplied'];
-            
+
             $query_string = "SELECT * from inv_usage where reagent_id = $r_id AND lot = '$lot'";
             $recordset = query_associative_all($query_string);
             if(isset($recordset))
             foreach($recordset as $rec)
-                $quantity = $quantity - $rec['quantity_used']; 
-            
+                $quantity = $quantity - $rec['quantity_used'];
+
             DbUtil::switchRestore($saved_db);
-            
+
             return $quantity;
         }
-        
+
         public function getStockDetails($lid, $r_id)
         {
-           
+
         }
-        
+
         public function getReagentById($lid, $r_id)
         {
             $lab_config_id = $lid;
-            
-            $saved_db = DbUtil::switchToLabConfig($lab_config_id);     
-            
+
+            $saved_db = DbUtil::switchToLabConfig($lab_config_id);
+
             $query_string = "SELECT * from inv_reagent WHERE id = $r_id";
             $recordset = query_associative_one($query_string);
-            
+
             DbUtil::switchRestore($saved_db);
-            
+
             return $recordset;
         }
-        
+
         public function getLot($lid, $r_id, $lot)
         {
             $lab_config_id = $lid;
-            
-            $saved_db = DbUtil::switchToLabConfig($lab_config_id);     
-            
+
+            $saved_db = DbUtil::switchToLabConfig($lab_config_id);
+
             $query_string = "SELECT * from inv_supply WHERE reagent_id = $r_id AND lot = '$lot'";
             $recordset = query_associative_one($query_string);
-            
+
             DbUtil::switchRestore($saved_db);
-            
+
             return $recordset;
         }
-        
+
         public function getLot2($lid, $r_id, $lot)
         {
             $lab_config_id = $lid;
-            
-            $saved_db = DbUtil::switchToLabConfig($lab_config_id);     
-            
+
+            $saved_db = DbUtil::switchToLabConfig($lab_config_id);
+
             $query_string = "SELECT count(*) as val from inv_supply WHERE reagent_id = $r_id AND lot = '$lot'";
-            $rc = query_associative_one($query_string);            
-            
+            $rc = query_associative_one($query_string);
+
             $query_string = "SELECT * from inv_supply WHERE reagent_id = $r_id AND lot = '$lot'";
             $recordset = query_associative_one($query_string);
-            
+
             DbUtil::switchRestore($saved_db);
             if($rc['val'] > 0)
                 return $recordset;
             else
                 return -1;
         }
-        
+
         public function getAllReagents($lid)
         {
             $lab_config_id = $lid;
-            
-            $saved_db = DbUtil::switchToLabConfig($lab_config_id);     
-            
+
+            $saved_db = DbUtil::switchToLabConfig($lab_config_id);
+
             $query_string = "SELECT * from inv_reagent";
             $recordset = query_associative_all($query_string);
-            
+
             DbUtil::switchRestore($saved_db);
-            
+
             return $recordset;
         }
-        
+
         public function getStocksList($lid, $r_id)
         {
             $lab_config_id = $lid;
-            
-            $saved_db = DbUtil::switchToLabConfig($lab_config_id);     
-            
+
+            $saved_db = DbUtil::switchToLabConfig($lab_config_id);
+
             $query_string = "SELECT * from inv_supply WHERE reagent_id = $r_id";
             $recordset = query_associative_all($query_string);
-            
+
             DbUtil::switchRestore($saved_db);
-            
+
             return $recordset;
         }
-        
+
         public function getReagentUnit($lid, $id)
         {
             $lab_config_id = $lid;
-            
-            $saved_db = DbUtil::switchToLabConfig($lab_config_id);     
-            
+
+            $saved_db = DbUtil::switchToLabConfig($lab_config_id);
+
             $query_string = "SELECT unit from inv_reagent WHERE id=$id";
             $recordset = query_associative_one($query_string);
-            
+
             DbUtil::switchRestore($saved_db);
-            
+
             return $recordset['unit'];
         }
-        
+
         public function updateReagent($lid, $r_id, $name, $unit, $remarks)
         {
             $lab_config_id = $lid;
-            
-            $saved_db = DbUtil::switchToLabConfig($lab_config_id);    
-            
+
+            $saved_db = DbUtil::switchToLabConfig($lab_config_id);
+
             $query_string = "UPDATE inv_reagent SET name = '$name', unit = '$unit' , remarks = '$remarks' WHERE id = $r_id";
             query_update($query_string);
-                                
-            DbUtil::switchRestore($saved_db);            
+
+            DbUtil::switchRestore($saved_db);
         }
-        
+
         public function updateStock($lid, $r_id, $lot, $n_lot, $e_date, $manu, $sup, $cost, $r_date, $remarks)
         {
             $lab_config_id = $lid;
             if($cost == '')
                 $cost = 0;
-            $saved_db = DbUtil::switchToLabConfig($lab_config_id);    
-            
+            $saved_db = DbUtil::switchToLabConfig($lab_config_id);
+
             $query_string = "UPDATE inv_supply SET lot='$n_lot', expiry_date='$e_date', manufacturer='$manu', supplier='$sup', cost_per_unit='$cost', date_of_reception='$r_date', remarks='$remarks' WHERE reagent_id = $r_id AND lot='$lot'";
             query_update($query_string);
-                                
+
             $query_string = "UPDATE inv_usage SET lot='$n_lot' WHERE reagent_id = $r_id AND lot='$lot'";
             query_update($query_string);
-            
+
             DbUtil::switchRestore($saved_db);
-            
+
         }
-        
+
         public function get_inv_supply_by_user($lid, $user)
         {
                     $lab_config_id = $lid;
 
-                    $saved_db = DbUtil::switchToLabConfig($lab_config_id);     
+                    $saved_db = DbUtil::switchToLabConfig($lab_config_id);
 
                     $query_string = "SELECT * from inv_supply WHERE user_id = $user";
                     $recordset = query_associative_all($query_string);
@@ -15174,7 +15154,7 @@ class Inventory
         {
                     $lab_config_id = $lid;
 
-                    $saved_db = DbUtil::switchToLabConfig($lab_config_id);     
+                    $saved_db = DbUtil::switchToLabConfig($lab_config_id);
 
                     $query_string = "SELECT * from inv_usage WHERE user_id = $user";
                     $recordset = query_associative_all($query_string);
@@ -15183,7 +15163,7 @@ class Inventory
 
                     return $recordset;
         }
-        
+
 }
 
 /*****************************************
@@ -15192,7 +15172,7 @@ class Inventory
 function checkVersionDataTable()
 {
    $saved_db = DbUtil::switchToGlobal();
-		
+
    /*$query = "SELECT * FROM version_data WHERE version = 'start_entry' LIMIT 1";
    $record = query_associative_one($query);
    if(!$record)
@@ -15210,7 +15190,7 @@ function checkVersionDataTable()
        $code = 1;   #version_data table exists
    }
    DbUtil::switchRestore($saved_db);
-   return $code; 
+   return $code;
 }
 function checkUsernameAvailability($user_name){
 
@@ -15218,7 +15198,7 @@ function checkUsernameAvailability($user_name){
 function checkVersionDataEntry($vers)
 {
    $saved_db = DbUtil::switchToGlobal();
-		
+
    $query = "SELECT * FROM version_data WHERE version = '$vers' LIMIT 1";
    $record = query_associative_one($query);
    if(!$record)
@@ -15234,13 +15214,13 @@ function checkVersionDataEntry($vers)
        $code = 2;  #version entry exists and update procedure complete
    }
    DbUtil::switchRestore($saved_db);
-   return $code; 
+   return $code;
 }
 
 function checkVersionDataEntryExists($vers)
 {
    $saved_db = DbUtil::switchToGlobal();
-		
+
    $query = "SELECT * FROM version_data WHERE version = '$vers' LIMIT 1";
    $record = query_associative_one($query);
    if(!$record)
@@ -15251,21 +15231,21 @@ function checkVersionDataEntryExists($vers)
    {
        $code = 1;  #version entry exists implying db update has been completed and update procedure incomplete
    }
-   
+
    DbUtil::switchRestore($saved_db);
-   return $code; 
+   return $code;
 }
 
 
 function setVersionDataFlag($fl, $vers)
 {
    $code = 0;
-   
+
    $saved_db = DbUtil::switchToGlobal();
-   
+
    $query = "SELECT * FROM version_Data WHERE version = '$vers' LIMIT 1";
    $record = query_associative_one($query);
-   
+
    if(!$record)
    {
        $code = 1;   #version entry doesnt exist
@@ -15276,7 +15256,7 @@ function setVersionDataFlag($fl, $vers)
    {
        $code = 2; #version entry exists
    }
-   
+
    $query = "UPDATE version_data SET flag = $fl WHERE version = '$vers'";
    $ret = query_blind($query);
    if(!$ret)
@@ -15288,7 +15268,7 @@ function setVersionDataFlag($fl, $vers)
        $code = 4;
    }
    DbUtil::switchRestore($saved_db);
-   return $code; 
+   return $code;
 }
 
 function update_language_files(){
@@ -15300,21 +15280,21 @@ function update_language_files(){
 			if (strpos($directory,'langdata_') !== false && is_dir("../../local/".$directory)) {
 				copy("../Language/en.php","../../local/".$directory."/en.php");
 				copy("../Language/en.xml","../../local/".$directory."/en.xml");
-				
+
 				copy("../Language/default.php","../../local/".$directory."/default.php");
 				copy("../Language/default.xml","../../local/".$directory."/default.xml");
-				
+
 				copy("../Language/fr.php","../../local/".$directory."/fr.php");
 				copy("../Language/fr.xml","../../local/".$directory."/fr.xml");
 			}
-	
+
 		}
 	}
-	
+
 }
 function insertVersionDataEntry()
 {
-   
+
    $saved_db = DbUtil::switchToGlobal();
    global $VERSION;
    $vers = $VERSION;
@@ -15323,8 +15303,8 @@ function insertVersionDataEntry()
    $query_string = "INSERT INTO version_data (version, status, user_id, i_ts) ".
                             "VALUES ('$vers', $status, $uid, NOW())";
    query_insert_one($query_string);
-   
-   
+
+
    DbUtil::switchRestore($saved_db);
 }
 
@@ -15397,8 +15377,8 @@ function search_patients_by_db_id_count($patient_code, $labsection)
     			"(select specimen_id from specimen where specimen_type_id in ".
     			"(select specimen_type_id from specimen_test where test_type_id in ".
     			"(select test_type_id as lab_section from test_type where test_category_id = $labsection)))";
-    	
-    	$saved_db = DbUtil::switchToLabConfig($_SESSION['lab_config_id']);	
+
+    	$saved_db = DbUtil::switchToLabConfig($_SESSION['lab_config_id']);
 	$resultset = query_associative_one($query_string);
 	DbUtil::switchRestore($saved_db);
     	return $resultset['val'];
@@ -15472,12 +15452,12 @@ function get_tat_data_per_test_per_lab_dir_new($test_type_id, $lab_config_id, $d
 		$progression_val = array();
 		$progression_count = array();
                 $cc = 1;
-		$date_from_parts = explode("-", $date_from);		
+		$date_from_parts = explode("-", $date_from);
 		$date_to_parts = explode("-", $date_to);
 		$date_ts = mktime(0, 0, 0, $date_from_parts[1], $date_from_parts[2], $date_from_parts[0]);
 		$date_to_ts=mktime(0, 0, 0, $date_to_parts[1], $date_to_parts[2], $date_to_parts[0]);
-		
-		while($date_ts<=$date_to_ts) {     
+
+		while($date_ts<=$date_to_ts) {
 			$second_day_ts= mktime(0, 0, 0, $date_from_parts[1],$date_from_parts[2]+$i,$date_from_parts[0]);
 			$date_fromp=date("Y-m-d", $date_ts);
 			$date_top=date("Y-m-d", $second_day_ts);
@@ -15508,21 +15488,21 @@ function get_tat_data_per_test_per_lab_dir_new($test_type_id, $lab_config_id, $d
 				//$progression_val[$week_ts][4] = array();
 			}
 			else {
-                            
+
 				$progression_val[$date_ts] += $date_diff;
 				//$percentile_count[$week_ts][] = $date_diff;
 				$progression_count[$date_ts] += 1;
                                 //$formattedValue = round($value[0],2);
                                 //$formattedDate = bcmul($key,1000);
-                                //ksort($stat_list); 
+                                //ksort($stat_list);
 			}
-			
+
                     }
-                        
+
                         $date_ts = $second_day_ts;
                         $i=$i+7;
                 }
-                                
+
                 $cc = 1;
 		$rstat = array();
 		foreach($progression_val as $key=>$value) {
@@ -15539,7 +15519,7 @@ function get_tat_data_per_test_per_lab_dir_new($test_type_id, $lab_config_id, $d
                         $rstat[$cc][1] = round($progression_val[$key],2);
                         }
                         $rstat[$cc][0] =  date('d M Y', $key);
-                                //ksort($stat_list); 
+                                //ksort($stat_list);
                         $cc++;
 			# Determine percentile value
 			//$progression_val[$key][1] = getPercentile2($percentile_count[$key], $percentile_tofind);
@@ -15556,24 +15536,24 @@ function get_tat_data_per_test_per_lab_dir_new($test_type_id, $lab_config_id, $d
 function get_prevalence_data_per_test_per_lab_dir($test_type_id, $lab_config_id, $date_from, $date_to, $gender=null)
 
 {
-   $i=7;		
+   $i=7;
 		# Fetch all test types with one measure having discrete P/N range
 		$retval = array();
                 					$lab_config = LabConfig::getById($lab_config_id);
 
 		$saved_db = DbUtil::switchToLabConfig($lab_config->id);
-		$date_from_parts = explode("-", $date_from);		
+		$date_from_parts = explode("-", $date_from);
 		$date_to_parts = explode("-", $date_to);
 		$date_ts = mktime(0, 0, 0, $date_from_parts[1], $date_from_parts[2], $date_from_parts[0]);
 		$date_to_ts=mktime(0, 0, 0, $date_to_parts[1], $date_to_parts[2], $date_to_parts[0]);
-		
-		while($date_ts<=$date_to_ts) {     
+
+		while($date_ts<=$date_to_ts) {
 			$second_day_ts= mktime(0, 0, 0, $date_from_parts[1],$date_from_parts[2]+$i,$date_from_parts[0]);
 			$date_fromp=date("Y-m-d", $date_ts);
 			$date_top=date("Y-m-d", $second_day_ts);
-		
-			if($gender=='M'||$gender=='F') { 
-				$query_string = 
+
+			if($gender=='M'||$gender=='F') {
+				$query_string =
 						"SELECT COUNT(*) AS count_val  FROM test t, patient p, specimen s ".
 						"WHERE t.test_type_id=$test_type_id ".
 						"AND p.patient_id=s.patient_id ".
@@ -15583,7 +15563,7 @@ function get_prevalence_data_per_test_per_lab_dir($test_type_id, $lab_config_id,
 						"AND  (t.result LIKE 'N,%' OR t.result LIKE 'nÃƒÂ¯Ã‚Â¿Ã‚Â½gatif,%' OR t.result LIKE 'negatif,%' OR t.result LIKE 'n,%' OR t.result LIKE 'negative,%')";
 			}
 			else {
-				$query_string = 
+				$query_string =
 				"SELECT COUNT(*) AS count_val  FROM test t, specimen s ".
 				"WHERE t.test_type_id=$test_type_id ".
 				"AND t.specimen_id=s.specimen_id ".
@@ -15593,8 +15573,8 @@ function get_prevalence_data_per_test_per_lab_dir($test_type_id, $lab_config_id,
 				}
 			$record = query_associative_one($query_string);
 			$count_negative = $record['count_val'];
-			
-			$query_string = 
+
+			$query_string =
 				"SELECT COUNT(*) AS count_val  FROM test t, specimen s ".
 				"WHERE t.test_type_id=$test_type_id ".
 				"AND t.specimen_id=s.specimen_id ".
@@ -15604,11 +15584,11 @@ function get_prevalence_data_per_test_per_lab_dir($test_type_id, $lab_config_id,
 			$count_all = $record['count_val'];
 			/*if($count_all != 0)*/
 				$retval[$date_ts] = array($count_all, $count_negative);
-			
+
 		$date_ts = $second_day_ts;
 		$i=$i+7;
-			
-					
+
+
 
 	}
         $rstat = array();
@@ -15620,7 +15600,7 @@ function get_prevalence_data_per_test_per_lab_dir($test_type_id, $lab_config_id,
                                                 $rstat[$cc][2] = $value[1];
 
                         $rstat[$cc][0] =  date('d M Y', $key);
-                                //ksort($stat_list); 
+                                //ksort($stat_list);
                         $cc++;
 			# Determine percentile value
 			//$progression_val[$key][1] = getPercentile2($percentile_count[$key], $percentile_tofind);
@@ -15629,9 +15609,9 @@ function get_prevalence_data_per_test_per_lab_dir($test_type_id, $lab_config_id,
 			//$progression_val[$key][2] = $goal_tat[$key];
 		}
 		DbUtil::switchRestore($saved_db);
-		
+
 		return $rstat;
-	
+
 }
 
 function get_prevalence_data_per_test_per_lab_dir22($test_type_id, $lab_config_id, $date_from, $date_to)
@@ -15646,11 +15626,11 @@ function get_prevalence_data_per_test_per_lab_dir22($test_type_id, $lab_config_i
 					$lab_config = LabConfig::getById($lab_config_id);
                                         //print_r($lab_config);
 					//$test_type_id = $mapping_list[$lab_config->id];
-					$saved_db = DbUtil::switchToLabConfig($lab_config->id);	
-					
+					$saved_db = DbUtil::switchToLabConfig($lab_config->id);
+
 					# For particular test type, fetch negative records
-			
-						$query_string = 
+
+						$query_string =
 							"SELECT COUNT(*) AS count_val FROM test t, specimen s ".
 							"WHERE t.test_type_id=$test_type_id ".
 							"AND t.specimen_id=s.specimen_id ".
@@ -15658,7 +15638,7 @@ function get_prevalence_data_per_test_per_lab_dir22($test_type_id, $lab_config_i
 							"AND (result LIKE 'N,%' OR result LIKE 'nÃƒÂ¯Ã‚Â¿Ã‚Â½gatif,%' OR result LIKE 'negatif,%' OR result LIKE 'n,%' OR result LIKE 'negative,%')";
 						$record = query_associative_one($query_string);
 						$count_negative = intval($record['count_val']);
-						$query_string = 
+						$query_string =
 							"SELECT COUNT(*) AS count_val FROM test t, specimen s ".
 							"WHERE t.test_type_id=$test_type_id ".
 							"AND t.specimen_id=s.specimen_id ".
@@ -15672,15 +15652,15 @@ function get_prevalence_data_per_test_per_lab_dir22($test_type_id, $lab_config_i
 							continue;
 						$testName = get_test_name_by_id($test_type_id);
 						$labName = $lab_config->name;
-						$query_string = 
+						$query_string =
 							"SELECT prevalence_threshold FROM test_type ".
 							"WHERE test_type_id=$test_type_id ";
 						$record = query_associative_one($query_string);
 						$threshold = intval($record['prevalence_threshold']);
-						
+
 						$retval[$labName] = array( $count_all, $count_negative, $threshold );
                                // }
-                                DbUtil::switchRestore($saved_db);		
+                                DbUtil::switchRestore($saved_db);
 				return $retval;
 }
 
@@ -15735,7 +15715,7 @@ function get_tat_data_per_test_per_lab_dir2($test_type_id, $lab_config_id, $date
 				$percentile_count[$month_ts][] = $date_diff;
 				$progression_count[$month_ts] += 1;
 			}
-			
+
 		}
 		if($include_pending === true)
 		{
@@ -15784,7 +15764,7 @@ function get_tat_data_per_test_per_lab_dir2($test_type_id, $lab_config_id, $date
 			# Convert from sec timestamp to days
 			$progression_val[$key][1] = $progression_val[$key][1]/(60*60*24);
 			$progression_val[$key][2] = $goal_tat[$key];
-		}		
+		}
 		DbUtil::switchRestore($saved_db);
 		return $progression_val;
 }
@@ -15833,9 +15813,9 @@ function get_tat_data_per_test_per_lab_dir($test_type_id, $lab_config_id, $date_
                 $week_end_ts = date("W", $end_ts);
 		$year_end_ts = date("Y", $end_ts);
                 $endingWeek = week_to_date2($week_end_ts, $year_end_ts);
-                
+
                 $weekDiff = mktime(1, 1, 1, 1, 1, 2000) - mktime(1, 1, 1, 1, 10, 2000);
-                
+
                 $wc = 0;
                 $currentWeek = $startingWeek;
                 $currentTS = $startingWeek;
@@ -15875,15 +15855,15 @@ function get_tat_data_per_test_per_lab_dir($test_type_id, $lab_config_id, $date_
 				//$progression_val[$week_ts][4] = array();
 			}
 			else {
-                            
+
 				$progression_val[$week_ts] += $date_diff;
 				//$percentile_count[$week_ts][] = $date_diff;
 				$progression_count[$week_ts] += 1;
                                 //$formattedValue = round($value[0],2);
                                 //$formattedDate = bcmul($key,1000);
-                                //ksort($stat_list); 
+                                //ksort($stat_list);
 			}
-			
+
 		}
 		if($include_pending === true) {
 			$pending_tat_value = $lab_config->getPendingTatValue(); # in hours
@@ -15892,7 +15872,7 @@ function get_tat_data_per_test_per_lab_dir($test_type_id, $lab_config_id, $date_
 			$resultset_pending = get_pendingtat_tests_by_type($test_type_id, $date_from, $date_to);
 			$num_pending = count($resultset_pending);
 			foreach($resultset_pending as $record) {
-			
+
 				$date_collected = $record['date_collected'];
 				$week_collected = date("W", $date_collected);
 				$year_collected = date("Y", $date_collected);
@@ -15931,7 +15911,7 @@ function get_tat_data_per_test_per_lab_dir($test_type_id, $lab_config_id, $date_
 			$progression_val[$key] = ($progression_val[$key]/(60*60*24));
                         $rstat[$cc][1] = round($progression_val[$key],2);
                         $rstat[$cc][0] =  date('d M Y', $key);
-                                //ksort($stat_list); 
+                                //ksort($stat_list);
                         $cc++;
 			# Determine percentile value
 			//$progression_val[$key][1] = getPercentile2($percentile_count[$key], $percentile_tofind);
@@ -15951,7 +15931,7 @@ function get_country_from_user_id()
     $usr_c = strtolower($usr_c);
     //$usr_c = ucfirst($usr_c);
     $usr_cs = substr($usr_c, 0, strpos($usr_c, "_"));
-    return $usr_cs; 
+    return $usr_cs;
 }
 
 function get_coordinates($lab_id)
@@ -15967,9 +15947,9 @@ function get_coordinates($lab_id)
                 $retval[1] = -1;
 		return $retval;
 	}
-        
+
 	$retval = explode(',', $resultset['coordinates']);
-       
+
 	DbUtil::switchRestore($saved_db);
 	return $retval;
 }
@@ -15978,7 +15958,7 @@ function getGlobalTestName($tid)
 {
     $saved_db = DbUtil::switchToGlobal();
     $query_configs = "SELECT * from test_mapping WHERE test_id = $tid";
-    
+
 	$resultset = query_associative_one($query_configs);
 	if($resultset == null)
 	{
@@ -15986,9 +15966,9 @@ function getGlobalTestName($tid)
                 $retval = 'Unknown';
 		return $retval;
 	}
-        
+
 	$retval = $resultset['test_name'];
-       
+
 	DbUtil::switchRestore($saved_db);
 	return $retval;
 }
@@ -16002,9 +15982,9 @@ function get_labs_for_director($director)
 {
 	$lab_config_id = $_SESSION['lab_config_id'];
 	$saved_db = DbUtil::switchToLabConfigRevamp($lab_config_id);
-	
+
 	$query_string = "SELECT lab_config_id FROM lab_config_access WHERE user_id = $director";
-	
+
 	$retVal = query_associative_all($query_string);
 	DbUtil::switchRestore($saved_db);
 
@@ -16018,9 +15998,9 @@ function get_lab_name_by_id_revamp($lab_id)
 {
 	$lab_config_id = $_SESSION['lab_config_id'];
 	$saved_db = DbUtil::switchToLabConfigRevamp($lab_config_id);
-	
+
 	$query_string = "SELECT name FROM lab_config WHERE lab_config_id = $lab_id";
-	
+
 	$retVal = query_associative_all($query_string);
 	DbUtil::switchRestore($saved_db);
 
@@ -16031,11 +16011,11 @@ function get_lab_name_by_id_revamp($lab_id)
 * Returns whether or not a lab has been placed on the director map.
 */
 function is_lab_placed($lab, $user)
-{	
+{
 	$lab_config_id = $_SESSION['lab_config_id'];
-	
+
 	$query_string = "SELECT coordinates FROM map_coordinates WHERE lab_id = $lab AND user_id = $user";
-	
+
 	$saved_db = DbUtil::switchToLabConfigRevamp($lab_config_id);
 	$retVal = query_associative_one($query_string);
 	DbUtil::switchRestore($saved_db);
@@ -16054,14 +16034,14 @@ function create_or_update_map_coords_entry($lab_id, $dir_id, $x, $y)
 {
 	$lab_config_id = $_SESSION['lab_config_id'];
 	$coordinate_string = $x . "," . $y;
-	
+
 	// Check and see if an entry exists.
 	$query_string = "SELECT COUNT(*) FROM map_coordinates WHERE lab_id = $lab_id AND user_id = $dir_id";
-	
+
 	$saved_db = DbUtil::switchToLabConfigRevamp($lab_config_id);
 	$retVal = query_associative_one($query_string);
 	DbUtil::switchRestore($saved_db);
-	
+
 	if ($retVal["COUNT(*)"] > 0)
 	{
 		$query_string = "UPDATE map_coordinates SET coordinates = '$coordinate_string' WHERE lab_id = $lab_id AND user_id = $dir_id";
@@ -16073,7 +16053,7 @@ function create_or_update_map_coords_entry($lab_id, $dir_id, $x, $y)
 	} else
 	{
 		$query_string = "INSERT INTO map_coordinates (coordinates, lab_id, user_id) VALUES ('$coordinate_string', $lab_id, $dir_id)";
-		
+
 		$saved_db = DbUtil::switchToLabConfigRevamp($lab_config_id);
 		$retVal = query_insert_one($query_string);
 		DbUtil::switchRestore($saved_db);
@@ -16217,7 +16197,7 @@ function db_analysis_patients($lb)
 	$ic = 1;
 	while(1)
 	{
-		
+
 		$startdate = mktime( 0, 0, 0, $mth, $day, $yr );
 		$enddate = mktime( 0, 0, 0, $mth, $day + 7, $yr );
 		$query_string = "SELECT COUNT(*) FROM $labdb.patient where ts >= FROM_UNIXTIME($startdate) AND ts < FROM_UNIXTIME($enddate)";
@@ -16282,7 +16262,7 @@ function db_analysis_tests($lb)
 	$ic = 1;
 	while(1)
 	{
-		
+
 		$startdate = mktime( 0, 0, 0, $mth, $day, $yr );
 		$enddate = mktime( 0, 0, 0, $mth, $day+7, $yr );
 		$query_string = "SELECT COUNT(*) FROM $labdb.test where ts >= FROM_UNIXTIME($startdate) AND ts < FROM_UNIXTIME($enddate)";
@@ -16322,7 +16302,7 @@ function api_get_patient_records($lab_config, $patient_id, $date_from, $date_to,
 
 		$query_string .= "ORDER BY sp.date_collected DESC";
 
-	
+
 
 	}
 
@@ -16341,23 +16321,23 @@ function api_get_patient_records($lab_config, $patient_id, $date_from, $date_to,
 
 			$query_string .= "AND (sp.date_collected BETWEEN '$date_from' AND '$date_to') ";
 
-		$query_string .= "ORDER BY sp.date_collected DESC";		
+		$query_string .= "ORDER BY sp.date_collected DESC";
 
-	
+
 
 	}
 
-	
+
 
 	$resultset = query_associative_all($query_string);
 
-	
+
 
 	if(count($resultset) == 0 || $resultset == null)
 
 		return $retval;
 
-	
+
 
 	foreach($resultset as $record) {
 
@@ -16365,21 +16345,21 @@ function api_get_patient_records($lab_config, $patient_id, $date_from, $date_to,
 
 		$hide_patient_name = TestType::toHidePatientName($test->testTypeId);
 
-		
+
 
 		if( $hide_patient_name == 1 )
 
 					$hidePatientName = 1;
 
-		
+
 
 		$specimen = get_specimen_by_id($test->specimenId);
 
-		$retval[] = array($test, $specimen, $hide_patient_name);		
+		$retval[] = array($test, $specimen, $hide_patient_name);
 
 	}
 
-	
+
 
 	return $retval;
 
@@ -16399,17 +16379,17 @@ function api_decode_results($testObj)
                // print_r($measure_list);
                 foreach($measure_list as $measure)
                 {
-                    
+
                     $submeasure_list = $measure->getSubmeasuresAsObj();
                     //echo "<br>".count($submeasure_list);
                     //print_r($submeasure_list);
                     $submeasure_count = count($submeasure_list);
-                    
+
                     if($measure->checkIfSubmeasure() == 1)
                     {
                         continue;
                     }
-                        
+
                     if($submeasure_count == 0)
                     {
                         array_push($comb_measure_list, $measure);
@@ -16418,7 +16398,7 @@ function api_decode_results($testObj)
                     {
                         array_push($comb_measure_list, $measure);
                         foreach($submeasure_list as $submeasure)
-                           array_push($comb_measure_list, $submeasure); 
+                           array_push($comb_measure_list, $submeasure);
                     }
                 }
                 $measure_list = $comb_measure_list;
@@ -16460,7 +16440,7 @@ function api_decode_results($testObj)
                     //echo "$testto<br>$subb<br>";
                     $result_csv = $testt;
                     if(strpos($testt, ",") == 0)
-                            $result_csv = substr($testt, 1, strlen($testt)); 
+                            $result_csv = substr($testt, 1, strlen($testt));
                     $result_list = explode(",", $result_csv);
                     //echo "<br>";
                     //print_r($result_list);
@@ -16485,7 +16465,7 @@ function api_decode_results($testObj)
 			if($curr_measure->getRangeType() != Measure::$RANGE_FREETEXT)
                         {
                             if(isset($result_list[$i]))
-                            {    
+                            {
                                 //echo "Num->".$i;
                                     # If matching result value exists (e.g. after a new measure was added to this test type)
                                     if(count($measure_list) == 1)
@@ -16523,14 +16503,14 @@ function api_decode_results($testObj)
                                          if(strpos($curr_measure->name, "\$sub") !== false)
                                                             {
                                                                 $decName = "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;".$curr_measure->truncateSubmeasureTag();
-                                                                
+
                                                             }
                                                             else
                                                             {
                                                                 $decName = $curr_measure->name;
                                                             }
                                             $retval .= "<br>".$decName.":"."&nbsp;";
-                                        
+
                                             if($curr_measure->getRangeType() == Measure::$RANGE_AUTOCOMPLETE)
                                             {
                                                     $result_string = "";
@@ -16551,7 +16531,7 @@ function api_decode_results($testObj)
                                                     $retval .= "<b>".$result_list[$i]."</b>"."&nbsp;";
                                                      $rts[$decName] = $result_list[$i];
                                             }
-                                            
+
                                     }
 
                                     if($show_range === true)
@@ -16571,7 +16551,7 @@ function api_decode_results($testObj)
                                             if(strpos($curr_measure->name, "\$sub") !== false)
                                                             {
                                                                 $decName = "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;".$curr_measure->truncateSubmeasureTag();
-                                                                
+
                                                             }
                                                             else
                                                             {
@@ -16590,14 +16570,14 @@ function api_decode_results($testObj)
 
                             if(count($measure_list) == 1)
                             {
-                                $retval .= "<br>".$ft_result."&nbsp;";   
+                                $retval .= "<br>".$ft_result."&nbsp;";
                             }
                             else
                             {
                                 if(strpos($curr_measure->name, "\$sub") !== false)
                                                             {
                                                                 $decName = "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;".$curr_measure->truncateSubmeasureTag();
-                                                                
+
                                                             }
                                                             else
                                                             {
@@ -16614,14 +16594,14 @@ function api_decode_results($testObj)
                                                 $retval .= "<br>";
                                         }
                             $j++;
-                            
+
                              $rts[$decName] = $ft_result;
-                            
+
                         }$c++;
 		}//end
 		//$retval = str_replace("_",",",$retval); # Replace all underscores with a comma
 		return $rts;
-	
+
 }
 
  function check_api_token($tok)
@@ -16646,9 +16626,9 @@ function api_decode_results($testObj)
             // invalid token
             return -2;
         }
-        
-       
-        
+
+
+
             return -2;
     }
 
@@ -16658,20 +16638,20 @@ function is_admin_check($user)
 	global $LIS_TECH_RO, $LIS_TECH_RW, $LIS_ADMIN, $LIS_SUPERADMIN, $LIS_CLERK, $LIS_TECH_SHOWPNAME, $LIS_COUNTRYDIR, $READONLYMODE, $LIS_PHYSICIAN;
 /*	if
 	(
-		$user->level == $LIS_TECH_RO || 
-		$user->level == $LIS_TECH_RW || 
-		$user->level == $LIS_CLERK || 
+		$user->level == $LIS_TECH_RO ||
+		$user->level == $LIS_TECH_RW ||
+		$user->level == $LIS_CLERK ||
 		$user->level == $LIS_TECH_SHOWPNAME ||
 		$user->level == $READONLYMODE ||
 		$user->level == $LIS_PHYSICIAN ||
-		$user->level == $LIS_PHYSICIAN 
+		$user->level == $LIS_PHYSICIAN
 	)
 		return false;
 	return true;*/
 if($user->level==$LIS_ADMIN||$user->level==$LIS_SUPERADMIN||$user->level==$LIS_COUNTRYDIR)
 return true;
 return false;
-}    
+}
 
 function is_super_admin_check($user)
 {
@@ -16714,7 +16694,7 @@ function getDoctorNamesForPatients($patient, $lab_config_id, $lab_section, $repo
 			}
 		}
 	} else {
-		// unreported 
+		// unreported
 		foreach($specimen_list as $specimen){
 			$test = Test::getTestBySpecimenID($specimen->specimenId);
 			//echo "Test ".$test->specimenId;
@@ -16723,7 +16703,7 @@ function getDoctorNamesForPatients($patient, $lab_config_id, $lab_section, $repo
 			}
 		}
 	}
-	
+
 	return array_unique($doctors);
 }
 
@@ -16736,7 +16716,7 @@ class API
     {
         return "# API test String".$data." #";
     }
-    
+
    public function login($username, $password)
     {
        print_r($_SESSION);
@@ -16744,7 +16724,7 @@ class API
 	$username = mysql_real_escape_string($username, $con);
 	$saved_db = DbUtil::switchToGlobal();
 	$password = encrypt_password($password);
-	$query_string = 
+	$query_string =
 		"SELECT * FROM user ".
 		"WHERE username='$username' ".
 		"AND password='$password' AND lab_config_id != 0 LIMIT 1";
@@ -16762,16 +16742,16 @@ class API
             return $tok;
         }
     }
-    
-    
-    
+
+
+
     public function start_session($username, $password)
     {
          session_start();
-        
+
          $sid = session_id();
          //$_SESSION['tok'] = $sid;
-        
+
          $user = get_user_by_name($username);
 	$_SESSION['username'] = $username;
 	$_SESSION['user_id'] = $user->userId;
@@ -16784,10 +16764,10 @@ class API
 
 		$_SESSION['doctorConfig'] = $combinedString;
 	}
-        
+
 	if(is_admin_check($user))
 	{
-		
+
 		$lab_id=get_lab_config_id_admin($user->userId);
 		$_SESSION['lab_config_id'] = $lab_id;
 		$_SESSION['db_name'] = "blis_".$lab_id;
@@ -16834,36 +16814,36 @@ class API
 			$_SESSION['refout'] = $arr1[9];
 			$_SESSION['pname'] = $arr1[10];
 			$_SESSION['sex'] = $arr1[11];
-			$_SESSION['doctor'] = $arr1[12];			
+			$_SESSION['doctor'] = $arr1[12];
 		}
 		if($SERVER == $ON_PORTABLE)
 			$_SESSION['langdata_path'] = $LOCAL_PATH."langdata_".$lab_config->id."/";
 		else
 			$_SESSION['langdata_path'] = $LOCAL_PATH."langdata_revamp/";
 	}
-	
-	
+
+
 	# Set session variables for recording latency/user props
 	$_SESSION['PROPS_RECORDED'] = false;
 	$_SESSION['DELAY_RECORDED'] = false;
 	#TODO: Add other session variables here
 	$_SESSION['user_role'] = "garbage";
-         return 1; 
+         return 1;
     }
-    
+
     public function stop_session()
     {
          //$_SESSION['tok'] = -1;
          //session_destroy();
          return 1;
     }
-    
+
     public function search_patients($by, $str)
     {
         //by 1 = name, 2 = id, 3 = number
         global $con;
 	$q = mysql_real_escape_string($str, $con);
-        
+
         if($by == 2)
          {
              //$count = search_patients_by_id_count($q);
@@ -16896,15 +16876,15 @@ class API
             return -1;
          }
          return $ret;
-         
+
     }
-    
+
     public function search_specimens($by, $str)
     {
         //by 3 = patient name, 2 = patient id, 1 = specimen_id
         global $con;
 	$q = mysql_real_escape_string($str, $con);
-        
+
         if($by == 1)
          {
              $patient_list = search_specimens_by_id($q);
@@ -16934,9 +16914,9 @@ class API
             return -1;
          }
          return $ret;
-         
+
     }
-    
+
     public function get_tests($specimen_id)
     {
         $test_list = get_tests_by_specimen_id($specimen_id);
@@ -16944,25 +16924,25 @@ class API
                 $ret = $test_list;
              else
                 $ret = 0;
-             
+
         return $ret;
     }
-    
+
     public function get_patient($patient_id)
     {
          /*$chk = check_api_token($tok);
         if($chk != 1)
         return $chk;*/
-        
+
         $pat = get_patient_by_id($patient_id);
         if($pat != 3)
                 $ret = $pat;
              else
                 $ret = 0;
-             
+
         return $ret;
     }
-    
+
     public function get_specimen($specimen_id)
     {
         $spec = get_specimen_by_id($specimen_id);
@@ -16970,10 +16950,10 @@ class API
                 $ret = $spec;
              else
                 $ret = 0;
-             
+
         return $ret;
     }
-     
+
     public function get_specimen_catalog()
     {
         global $CATALOG_TRANSLATION;
@@ -17007,11 +16987,11 @@ class API
                 $ret = $catalog;
              else
                 $ret = 0;
-             
+
         return $ret;
     }
-    
-    
+
+
     public function get_test_catalog()
     {
         global $CATALOG_TRANSLATION;
@@ -17045,17 +17025,17 @@ class API
                 $ret = $catalog;
              else
                 $ret = 0;
-             
+
         return $ret;
     }
-    
-    
+
+
     public function get_lab_sections()
     {
         /*$chk = check_api_token($tok);
         if($chk != 1)
         return $chk;*/
-        
+
         global $CATALOG_TRANSLATION;
         if($_SESSION['level'] < 2 || $_SESSION['level'] > 4)
         {
@@ -17078,10 +17058,10 @@ class API
 	}
         else
              $ret = 0;
-	             
+
         return $ret;
     }
-    
+
     public function get_test_type($test_type_id)
     {
         global $con;
@@ -17100,9 +17080,9 @@ class API
 		$query_string =
 			"SELECT * FROM test_type WHERE test_type_id=$test_type_id LIMIT 1";
 		$record = query_associative_one($query_string);
-		
+
 		$test_type = TestType::getObject($record);
-         
+
         //print_r($test_type);
                 $ret = array();
         if($test_type != null)
@@ -17114,23 +17094,23 @@ class API
          $measure_list_objs = $test_type->getMeasures();
                 //print_r($measure_list);
                 $submeasure_list_objs = array();
-                
+
                 $comb_measure_list = array();
                // print_r($measure_list);
-                
+
                 foreach($measure_list_objs as $measure)
                 {
-                    
+
                     $submeasure_list_objs = $measure->getSubmeasuresAsObj();
                     //echo "<br>".count($submeasure_list);
                     //print_r($submeasure_list);
                     $submeasure_count = count($submeasure_list_objs);
-                    
+
                     if($measure->checkIfSubmeasure() == 1)
                     {
                         continue;
                     }
-                        
+
                     if($submeasure_count == 0)
                     {
                         array_push($comb_measure_list, $measure);
@@ -17139,10 +17119,10 @@ class API
                     {
                         array_push($comb_measure_list, $measure);
                         foreach($submeasure_list_objs as $submeasure)
-                           array_push($comb_measure_list, $submeasure); 
+                           array_push($comb_measure_list, $submeasure);
                     }
                 }
-                
+
                 $measure_list_ids = array();
                 //echo "<pre>";
                 //print_r($comb_measure_list);
@@ -17154,7 +17134,7 @@ class API
                 /*
                 echo "<pre>";
                 print_r($measure_list);
-                
+
                 print_r($measure_list_ids);
                 echo "</pre>";
                 */
@@ -17163,8 +17143,8 @@ class API
                 $ret['measures'] = $measure_list_objs;
              DbUtil::switchRestore($saved_db);
         return $ret;
-    } 
-    
+    }
+
     public function get_patient_results($patient_id, $date_from, $date_to, $ip)
     {
         if($_SESSION['level'] < 2 || $_SESSION['level'] > 4)
@@ -17183,11 +17163,11 @@ class API
         $rtt = array();
         foreach($recs as $tobj)
             $rtt[$tobj[0]->testId] = api_decode_results ($tobj[0]);
-        
+
         return $rtt;
-            
+
     }
-    
+
     public function get_inventory()
     {
         //print_r($_SESSION);
@@ -17208,7 +17188,7 @@ class API
             }
          $reagents_list = Inventory::getAllReagents($lid);
          $cc = 1;
-        foreach($reagents_list as $reagent) 
+        foreach($reagents_list as $reagent)
         {
             $quant = Inventory::getQuantity($lid, $reagent['id']);
             // $uni = $reagent['unit'];
@@ -17224,10 +17204,10 @@ class API
                 $ret = $spec;
              else
                 $ret = 0;
-             
+
         return $ret;
     }
-   
+
     public function get_stock_lots($r_id)
     {
         if($_SESSION['level'] < 2 || $_SESSION['level'] > 4)
@@ -17241,9 +17221,9 @@ class API
                 $lid = get_lab_config_id_admin($_SESSION['user_id']);
             }
         $stocks_list = Inventory::getStocksList($lid, $r_id);
-    
+
          $cc = 1;
-        foreach($stocks_list as $stock) 
+        foreach($stocks_list as $stock)
         {
             $quant = Inventory::getQuantity($lid, $reagent['id']);
             // $uni = $reagent['unit'];
@@ -17255,21 +17235,21 @@ class API
                $spec[$cc]['remarks'] =  $stock['remarks'];
                $dp = explode("-", $stock['expiry_date']);
                             $e_date = $dp[2]."/".$dp[1]."/".$dp[0];
-               $spec[$cc]['expiry_date'] =  $e_date;             
+               $spec[$cc]['expiry_date'] =  $e_date;
                $spec[$cc]['current_quantity'] =  Inventory::getLotQuantity($lid, $r_id, $stock['lot']);
                $spec[$cc]['quantity_supplied'] =  $stock['quantity_suppied'];
                $cc++;
         }
-        
+
         //$spec = get_specimen_by_id($specimen_id);
         if(count($spec) > 0)
                 $ret = $spec;
              else
                 $ret = 0;
-             
+
         return $ret;
     }
-    
+
     public function get_stock_usage($r_id, $lot)
     {
         if($_SESSION['level'] < 2 || $_SESSION['level'] > 4)
@@ -17285,7 +17265,7 @@ class API
         //$stocks_list = Inventory::getStocksList($lid, $r_id);
         $lab_config_id = $lid;
 
-                    $saved_db = DbUtil::switchToLabConfig($lab_config_id);     
+                    $saved_db = DbUtil::switchToLabConfig($lab_config_id);
 
                     $query_string = "SELECT * from inv_usage WHERE reagent_id = $r_id AND lot = '$lot'";
                     $recordset = query_associative_all($query_string);
@@ -17295,7 +17275,7 @@ class API
          //echo "-".$recordset."-";
          //print_r($recordset);
          $spec = array();
-        foreach($recordset as $stock) 
+        foreach($recordset as $stock)
         {
             $quant = Inventory::getQuantity($lid, $reagent['id']);
             // $uni = $reagent['unit'];
@@ -17305,19 +17285,19 @@ class API
                $spec[$cc]['remarks'] =  $reagent['remarks'];
                $dp = explode("-", $stock['date_of_use']);
                             $e_date = $dp[2]."/".$dp[1]."/".$dp[0];
-               $spec[$cc]['date_of_use'] =  $e_date;             
+               $spec[$cc]['date_of_use'] =  $e_date;
                $cc++;
         }
-        
+
         //$spec = get_specimen_by_id($specimen_id);
         if(count($spec) > 0)
                 $ret = $spec;
              else
                 $ret = 0;
-             
+
         return $ret;
     }
-    
+
     public function get_test_cost($tid)
     {
         if($_SESSION['level'] < 2 || $_SESSION['level'] > 4)
@@ -17333,24 +17313,24 @@ class API
         //$stocks_list = Inventory::getStocksList($lid, $r_id);
         $lab_config_id = $lid;
 
-                    $saved_db = DbUtil::switchToLabConfig($lab_config_id);     
+                    $saved_db = DbUtil::switchToLabConfig($lab_config_id);
 
                     $query_string = "SELECT * from test_type_costs WHERE test_type_id = $tid ORDER BY earliest_date_valid DESC LIMIT 1";
                     $record = query_associative_one($query_string);
 
                     DbUtil::switchRestore($saved_db);
-        
+
         if($record != null)
                 $ret = $record['amount'];
              else
                 $ret = -1;
-             
+
         return $ret;
     }
-    
+
 }
-	
-   
+
+
 /* API ends here */
 class DHIMS2
 {
@@ -17365,7 +17345,7 @@ class DHIMS2
 	public $blisTestID;
 	public $blisAgegroup;
 	public $blisGender;
-	
+
 	public function Save($lab_config_id)
 	{
 		$sql="INSERT INTO `dhims2_api_config` (
@@ -17373,37 +17353,37 @@ class DHIMS2
 `dataelement` ,`categorycombo` ,`gender` ,`period`)
 VALUES (NULL , '$this->username', '$this->password', '$this->orgUnit', '$this->dataSet',
  '$this->dataElement".'|'."$this->blisTestID', '$this->categoryCombo".'|'."$this->blisAgegroup', '$this->blisGender', '$this->entryPeriod');";
-		query_blind($sql,$db);	
+		query_blind($sql,$db);
 		return 1;
 	}
-	
+
 	public function deleteItems($lab_config_id,$items)
 	{
 		$sql ="delete from dhims2_api_config where id in ($items)";
-		query_blind($sql,$db);	
+		query_blind($sql,$db);
 		return 1;
 	}
-	
+
 	public function getSendingConfigs($lab_config_id)
 	{
-		
+
 		$sql="select * from dhims2_api_config";
-		$resultset = query_associative_all($sql, $row_count);		
+		$resultset = query_associative_all($sql, $row_count);
 		$results = array();
-		$larr = array();		
-		$icount= count($resultset);	
-		
+		$larr = array();
+		$icount= count($resultset);
+
 		for($i=0;$i<$icount;$i++)
 		{
-			$orgunit = explode('^',$resultset[$i]['orgunit']);						
-			$larr['orgUnit'] = $orgunit[0];					
+			$orgunit = explode('^',$resultset[$i]['orgunit']);
+			$larr['orgUnit'] = $orgunit[0];
 			$dataset = explode('^',$resultset[$i]['dataset']);
-			$larr['dataSet'] = $dataset[0];			
+			$larr['dataSet'] = $dataset[0];
 			$dataelement = explode('|',$resultset[$i]['dataelement']);
 			$dsetparts = explode('^',$dataelement[0]);
 			$larr['dataElement'] = $dsetparts[0];
-			
-			$elementname = "";			
+
+			$elementname = "";
 			for($dcount=1;$dcount<count($dataelement);$dcount++)
 			{
 				$tmp = explode('^',$dataelement[$dcount]);
@@ -17411,42 +17391,42 @@ VALUES (NULL , '$this->username', '$this->password', '$this->orgUnit', '$this->d
 					$elementname .= $tmp[0];
 				else
 					$elementname .= '+'.$tmp[0];
-			}			
-			
-			$larr['blistestID']=$elementname;			
+			}
+
+			$larr['blistestID']=$elementname;
 			$categorycombo = explode('^',$resultset[$i]['categorycombo']);
 			$larr['categoryOptionCombo'] = $categorycombo[0];
-			$comboname = explode('|',$categorycombo[1]);			
-			$larr['blisageGroup'] = $comboname[1];			
+			$comboname = explode('|',$categorycombo[1]);
+			$larr['blisageGroup'] = $comboname[1];
 			$larr['gender'] = $resultset[$i]['gender'];
-			$larr['period'] = $resultset[$i]['period'];			
+			$larr['period'] = $resultset[$i]['period'];
 			$results[] = $larr;
-			$larr = array();					
-		
+			$larr = array();
+
 		}
 		//file_put_contents("dhims2.txt",print_r($results));
-				
+
 		return $results;
-		
+
 		//print_r($results);
-	}	
-	
+	}
+
 	public function getConfigs($lab_config_id)
-	{		
+	{
 		$sql="select * from dhims2_api_config";
-		$resultset = query_associative_all($sql);		
+		$resultset = query_associative_all($sql);
 		$results = array();
-		$larr = array();	
-		$orgunitTrimList = array();	
-		$datasetTrimList = array();	
+		$larr = array();
+		$orgunitTrimList = array();
+		$datasetTrimList = array();
 		$dataelementTrimList = array();
 		$genderTrimList = array();
-		$icount= count($resultset);	
+		$icount= count($resultset);
 		for($i=0;$i<$icount;$i++)
 		{
 			$orgunit = explode('^',$resultset[$i]['orgunit']);
 			if(!in_array($orgunit[0],$orgunitTrimList))
-			{				
+			{
 				$larr['id'] = $orgunit[0];
 				$larr['pId'] = 0;
 				$larr['name'] = $orgunit[1];
@@ -17456,7 +17436,7 @@ VALUES (NULL , '$this->username', '$this->password', '$this->orgUnit', '$this->d
 				$larr = array();
 				$orgunitTrimList[] = $orgunit[0];
 			}
-			
+
 			$dataset = explode('^',$resultset[$i]['dataset']);
 			if(!in_array($dataset[0],$datasetTrimList))
 			{
@@ -17469,8 +17449,8 @@ VALUES (NULL , '$this->username', '$this->password', '$this->orgUnit', '$this->d
 				$results[] = $larr;
 				$larr = array();
 				$datasetTrimList[] = $dataset[0];
-			}			
-			
+			}
+
 			$dataelement = explode('|',$resultset[$i]['dataelement']);
 			//$elementname = explode('|',$dataelement[1]);
 			$elementname = "";
@@ -17483,12 +17463,12 @@ VALUES (NULL , '$this->username', '$this->password', '$this->orgUnit', '$this->d
 				else
 					$elementname .= '+'.$tmp[1];
 			}
-			
+
 			$dsetElem = $dsetparts[0];
 			if(!in_array($dsetElem,$dataelementTrimList))
 			{
 				$larr['id'] = $dsetElem;
-				$larr['pId'] = $dataset[0];				
+				$larr['pId'] = $dataset[0];
 				$larr['name'] = $dsetparts[1].'-->'.$elementname;
 				$larr['open'] = true;
 				$larr['isParent'] = true;
@@ -17497,15 +17477,15 @@ VALUES (NULL , '$this->username', '$this->password', '$this->orgUnit', '$this->d
 				$larr = array();
 				$dataelementTrimList[] = $dsetElem;
 			}
-			
-					
+
+
 			if(	$resultset[$i]['gender'] =="M")
 			{
 				if(!in_array( $dsetElem.'_M',$genderTrimList))
 				{
 					$larr['id'] = $dsetElem.'_M';
 					$larr['pId'] = $dsetElem;
-					$comboname = explode('|',$categorycombo[1]);			
+					$comboname = explode('|',$categorycombo[1]);
 					$larr['name'] ="Male";
 					$larr['open'] = true;
 					$larr['isParent'] = true;
@@ -17514,11 +17494,11 @@ VALUES (NULL , '$this->username', '$this->password', '$this->orgUnit', '$this->d
 					$larr = array();
 					$genderTrimList[] = $dsetElem.'_M';
 				}
-			
+
 				$categorycombo = explode('^',$resultset[$i]['categorycombo']);
 				$larr['id'] = $categorycombo[0];
 				$larr['pId'] =  $dsetElem.'_M';
-				$comboname = explode('|',$categorycombo[1]);			
+				$comboname = explode('|',$categorycombo[1]);
 				$larr['name'] = $comboname[0].'-->'.$comboname[1];
 				$larr['open'] = true;
 				$larr['ename'] = $resultset[$i]['id'];
@@ -17531,7 +17511,7 @@ VALUES (NULL , '$this->username', '$this->password', '$this->orgUnit', '$this->d
 				{
 					$larr['id'] = $dsetElem.'_F';
 					$larr['pId'] = $dsetElem;
-					$comboname = explode('|',$categorycombo[1]);			
+					$comboname = explode('|',$categorycombo[1]);
 					$larr['name'] ="Female";
 					$larr['open'] = true;
 					$larr['isParent'] = true;
@@ -17540,11 +17520,11 @@ VALUES (NULL , '$this->username', '$this->password', '$this->orgUnit', '$this->d
 					$larr = array();
 					$genderTrimList[] = $dsetElem.'_F';
 				}
-				
+
 				$categorycombo = explode('^',$resultset[$i]['categorycombo']);
 				$larr['id'] = $categorycombo[0];
 				$larr['pId'] =  $dsetElem.'_F';
-				$comboname = explode('|',$categorycombo[1]);			
+				$comboname = explode('|',$categorycombo[1]);
 				$larr['name'] = $comboname[0].'-->'.$comboname[1];
 				$larr['open'] = true;
 				$larr['ename'] = $resultset[$i]['id'];
@@ -17557,7 +17537,7 @@ VALUES (NULL , '$this->username', '$this->password', '$this->orgUnit', '$this->d
 				{
 					$larr['id'] = $dsetElem.'_B';
 					$larr['pId'] = $dsetElem;
-					$comboname = explode('|',$categorycombo[1]);			
+					$comboname = explode('|',$categorycombo[1]);
 					$larr['name'] ="Male & Female";
 					$larr['open'] = true;
 					$larr['isParent'] = true;
@@ -17566,51 +17546,51 @@ VALUES (NULL , '$this->username', '$this->password', '$this->orgUnit', '$this->d
 					$larr = array();
 					$genderTrimList[] = $dsetElem.'_B';
 				}
-				
+
 				$categorycombo = explode('^',$resultset[$i]['categorycombo']);
 				$larr['id'] = $categorycombo[0];
 				$larr['pId'] =  $dsetElem.'_B';
-				$comboname = explode('|',$categorycombo[1]);			
+				$comboname = explode('|',$categorycombo[1]);
 				$larr['name'] = $comboname[0].'-->'.$comboname[1];
 				$larr['open'] = true;
 				$larr['ename'] = $resultset[$i]['id'];
 				$results[] = $larr;
 				$larr = array();
 			}
-			
+
 			//if($i==2)
 			//break;
 		}
 		//file_put_contents("dhims2.txt",print_r($results));
-				
+
 		return $results;
-		
+
 		//print_r($results);
-	}	
+	}
 
 }
 
-	
+
 	function getEquipmentList()
 	{
 		$saved_db = DbUtil::switchToGlobal();
 		$query_configs = "SELECT id,equipment_name from interfaced_equipment";
-		
+
 		$resultset = query_associative_all($query_configs);
-		
-		   
+
+
 		DbUtil::switchRestore($saved_db);
 		return $resultset;
 	}
-	
+
 	function getEquipmentDetails($id)
 	{
 		$saved_db = DbUtil::switchToGlobal();
 		$query_configs = "SELECT * from interfaced_equipment where id={$id}";
-		
+
 		$resultset = query_associative_all($query_configs);
-		
-		   
+
+
 		DbUtil::switchRestore($saved_db);
 		return $resultset;
 	}
@@ -17618,10 +17598,10 @@ VALUES (NULL , '$this->username', '$this->password', '$this->orgUnit', '$this->d
 	{
 		$saved_db = DbUtil::switchToGlobal();
 		$query_configs = "SELECT * from equip_config where equip_id={$id}";
-		
+
 		$resultset = query_associative_all($query_configs);
-		
-		   
+
+
 		DbUtil::switchRestore($saved_db);
 		return $resultset;
 	}

--- a/htdocs/includes/field_order_update.php
+++ b/htdocs/includes/field_order_update.php
@@ -73,13 +73,13 @@ $short_name = "ageLimit";
 return $short_name;
 }
 
-public static function install_first_order($lab_config, $formId){ 
-	$field_ordering_for_curent_lab = FieldOrdering::getByFormId($_SESSION['lab_config_id'], $formId);
+public static function install_first_order($lab_config, $formId, $lab_config_id){
+	$field_ordering_for_curent_lab = FieldOrdering::getByFormId($lab_config_id, $formId);
 
 	if($field_ordering_for_curent_lab == null){
 	// insert the order for the first time
 	// 1. Get the current lab config info from the LabConfig Class
-		//$lab_config = LabConfig::getById($_SESSION['lab_config_id']);
+		//$lab_config = LabConfig::getById($lab_config_id);
 		//$custom_field_list_patients = get_lab_config_patient_custom_fields($lab_config->id);
 	// 2. Parse the object and populate the new fieldOrder Object
 		//$fieldOrdering_new = new FieldOrdering();
@@ -87,12 +87,12 @@ public static function install_first_order($lab_config, $formId){
 
 		 // default values
 		$field_ordering->form_id = $formId;
-		$field_ordering->id = $_SESSION['lab_config_id'];
+		$field_ordering->id = $lab_config_id;
 
 		$count = 1;
-		
+
 		$field_order = "";
-		
+
 		if($formId == 1){
 			// pid
 			if(isset($lab_config->pid) && $lab_config->pid > 0){
@@ -107,7 +107,7 @@ public static function install_first_order($lab_config, $formId){
 				$count++;
 			}//dnum
 			if(isset($lab_config->dailyNum) &&  $lab_config->dailyNum > 0){
-				$field_ordering->{field.$count} = "Daily Number";
+				// $field_ordering->{field.$count} = "Daily Number";
 				$field_order = $field_order.","."Daily Number";
 				$count++;
 			}//pname
@@ -139,7 +139,7 @@ public static function install_first_order($lab_config, $formId){
 				$field_order = $field_order.",".$value->fieldName;
 				$count++;
 			}
-		} 
+		}
 		else if($formId == 2){
 			// specimen field
 			$field_order = "Specimen ID";
@@ -158,13 +158,13 @@ public static function install_first_order($lab_config, $formId){
 				$field_order = $field_order.","."Lab Reciept Date";
 				$count++;
 			}
-			
+
 			//refout
 			if(isset($lab_config->refout) && $lab_config->refout > 0){
 				$field_order = $field_order.","."Referred Out";
 				$count++;
 			}
-			
+
 			//doctor
 			if(isset($lab_config->doctor) && $lab_config->doctor > 0){
 				$field_order = $field_order.","."Physician";
@@ -172,7 +172,7 @@ public static function install_first_order($lab_config, $formId){
 			}
 
 			$custom_field_list_specimen = get_lab_config_specimen_custom_fields($lab_config->id);
-				
+
 			foreach($custom_field_list_specimen as $value){
 				//$field_ordering->{field.$count} = $value->fieldName;
 				$field_order = $field_order.",".$value->fieldName;
@@ -189,9 +189,7 @@ public static function install_first_order($lab_config, $formId){
 
 	// 3. Insert the newly created order
 		$field_ordering->form_field_inOrder = $field_order;
-
 		FieldOrdering::add_fieldOrdering($field_ordering);
-
 		$field_ordering_for_curent_lab = $field_ordering;
 	}
 

--- a/htdocs/includes/page_elems.php
+++ b/htdocs/includes/page_elems.php
@@ -19,9 +19,9 @@ class PageElems
 			"<div class='sidetip'>".
 			"<b>".$heading."</b><br><br>".$contents.
 			"</div>";
-		echo $html_code;		
+		echo $html_code;
 	}
-	
+
 	public function getSideTipBatchResults($heading, $contents)
 	{
 		$html_code =
@@ -30,13 +30,13 @@ class PageElems
 		"</div>";
 		echo $html_code;
 	}
-	
+
 	public function getProgressSpinner($message)
 	{
 		?>
 		<img src='includes/img/small_spinner.gif'></img><?php echo "<small> ".$message."</small>";
 	}
-	
+
 	public function getProgressSpinnerBig($message)
 	{
 		?>
@@ -50,14 +50,14 @@ class PageElems
 		</div>
 		<?php
 	}
-	
+
 	public function getSmallArrow()
 	{
 		?>
 		&nbsp;<img src='includes/img/small_arrow.gif'></img>
 		<?php
 	}
-	
+
 	public function getAsterisk()
 	{
 		?>
@@ -76,12 +76,12 @@ class PageElems
 			echo "Writeable Options ";
 		else
 			echo "Readable Options";
-		
+
 		echo "</div>".$this->getAsterisk()."</td>";
 		$userRWoptions = explode( ',', $user_rwoptions );
 		if($user_level < 16 || $user_level == 17)
 		{
-			
+
 			echo "<td><div id='readWrite_options' name='readWrite_options'>";
 		echo "<table>";
 echo "<tr>";
@@ -100,7 +100,7 @@ else
 echo "N";
 //				echo "checked";
 //			echo ">Patient Registration<br>
-	echo "</td>";				
+	echo "</td>";
 echo '<td id="readwriteOpt3">';
 //					<input type='checkbox' name='readwriteOpt' id='readwriteOpt3' value='3' ";
 					if(in_array("3", $userRWoptions))
@@ -174,7 +174,7 @@ echo "</tr>";
 echo "</table>";
 echo "</div>";
 echo "</td>";
-}		
+}
 //echo "</tr>";
 
 }
@@ -188,7 +188,7 @@ echo "</td>";
 		</small>
 		<?php
 	}
-	
+
 	public function getDatePicker($name_list, $id_list, $value_list, $show_format=true, $lab_config=null)
 	{
 		# Returns a date picker element based on passed parameters
@@ -229,7 +229,7 @@ echo "</td>";
 				$order_list[2] = 2;
 				$date_format_js = "yyyy-mm-dd";
 				$start_date = "1950-01-01";
-				break;			
+				break;
 		}
 		$date_format_js_parts = explode("-", $date_format_js);
 		$picker_id = rand();
@@ -299,9 +299,9 @@ echo "</td>";
 					}
 				);
 		});
-		
+
 		</SCRIPT>
-				
+
 		<style type='text/css'>
 		a.dp-choose-date {
 			float: left;
@@ -326,13 +326,13 @@ echo "</td>";
 			float: right;
 		}
 		</style>
-		
+
 		<input type='text' name='<?php echo $name_list[$order_list[0]]; ?>' id='<?php echo $id_list[$order_list[0]]; ?>' onkeypress="return isNumberKey(event)" value="<?php echo $value_list[$order_list[0]]; ?>" size='2'  maxlength='2' />-
 		<input type='text' name='<?php echo $name_list[$order_list[1]]; ?>' id='<?php echo $id_list[$order_list[1]]; ?>' onkeypress="return isNumberKey(event)" value="<?php echo $value_list[$order_list[1]]; ?>" size='2'  maxlength='2' />-
 		<input type='text' name='<?php echo $name_list[$order_list[2]]; ?>' id='<?php echo $id_list[$order_list[2]]; ?>' onkeypress="return isNumberKey(event)" value="<?php echo $value_list[$order_list[2]]; ?>" size='4'  maxlength='4' />
-		
+
 		<INPUT name="<?php echo $picker_id; ?>" id="<?php echo $picker_id; ?>" class="date-pick dp-applied" style='display:none'/>
-		
+
 		<?php
 		if($show_format == true)
 		{
@@ -347,10 +347,10 @@ echo "</td>";
 		<?php
 		}
 		?>
-		
+
 	<?php
 	}
-	
+
 	public function getDatePickerPlain($name_list, $id_list, $value_list, $show_format=true, $lab_config=null)
 	{
 		# Date field without the Jquery based picker object
@@ -390,7 +390,7 @@ echo "</td>";
 				$order_list[2] = 2;
 				$date_format_js = "yyyy-mm-dd";
 				$start_date = "1950-01-01";
-				break;			
+				break;
 		}
 		$date_format_js_parts = explode("-", $date_format_js);
 		?>
@@ -421,13 +421,13 @@ echo "</td>";
 		<?php
 		}
 	}
-	
+
 	public function getResultFormForTest($test_type)
 	{
 		# Creates HTML form elements for a given test type
 		return true;
 	}
-	
+
 	public function getResultsForm($specimen_id)
 	{
 		# Creates HTML form for all tests pending for a specimen
@@ -474,7 +474,7 @@ echo "</td>";
 		if (is_array($site_records)) {
 		foreach ($site_records as $site){
 			if ($lab_config->name == $site->name)
-			    {   
+			    {
 			        echo "<br/>";
 			         echo "$site->name";
 			          echo "<br/>";
@@ -510,12 +510,11 @@ echo "</td>";
 			echo "<option value='$site->id'>$site->name</option>";
 		}
 	}
-	
+
 	public function getSiteOptions()
 	{
 		# Returns accessible sites for drop down <select> boxes
-		$site_list = get_site_list($_SESSION['user_id']);
-		echo "debug 1 ". $_SESSION['user_id'];
+		$site_list = get_site_list_with_labid($_SESSION['user_id']);
 		foreach($site_list as $key => $value)
 		{
 			echo "<option value='$key'>$value</option>";
@@ -555,7 +554,7 @@ echo "</td>";
 		    if(empty($strings[$site->region]) && $site->region!="")    {
 		        $string[$site->region] = array();
 		    }
-		    
+
 
 
                 if( $site->region!="")    {
@@ -565,14 +564,14 @@ echo "</td>";
                 if( $site->district!="" )    {
                     $string[$site->district][] = $site->id;
                 }
-		        
+
 		    }
 			}
 		}
 
 		$districts = array_values($districts);
 		$regions = array_values($regions);
-       
+
         if (count($districts) != 0){
              echo"<br/>Districts";
         }
@@ -645,13 +644,13 @@ echo "</td>";
 
 	public function getSiteOptionsCheckBoxesCountryDir($checkBoxName)
 	{
-		//$site_list = get_site_list($_SESSION['user_id']); 
+		//$site_list = get_site_list($_SESSION['user_id']);
                 $admin_user_id = $_SESSION['user_id'];
 				#$lab_config_list = get_lab_configs($admin_user_id);
 				$lab_config_list_imported = get_lab_configs_imported();
 				$config_list = $lab_config_list_imported;
 				#$config_list = array_merge($lab_config_list, $lab_config_list_imported);
-                
+
 
 		foreach($config_list as $lab_config) {
 			//$strippedLabName = substr($lab_config->name,0,strpos($lab_config->name,'-')-1);
@@ -667,7 +666,7 @@ echo "</td>";
 			echo "<option value='$key'>$value</option>";
 		}
 	}
-	
+
 	public function getLabUserReadWriteOption($user_level="", $user_rwoptions=""){
 		// if($user_level == 17) {
 		// 	$user_rwoptions= "2,4";
@@ -678,18 +677,18 @@ echo "</td>";
 			echo "Writeable Options ";
 		else
 			echo "Readable Options";
-		
+
 		echo "</div>".$this->getAsterisk()."</td>";
 		$userRWoptions = explode( ',', $user_rwoptions );
 		if($user_level < 16 || $user_level == 17)
 		{
-			
+
 			echo "<td><div id='readWrite_options' name='readWrite_options'>
 		 			<input type='checkbox' name='readwriteOpt' id='readwriteOpt2' value='2' ";
 			if(in_array("2", $userRWoptions))
 				echo "checked";
 			echo ">Patient Registration<br>
-					
+
 					<input type='checkbox' name='readwriteOpt' id='readwriteOpt3' value='3' ";
 					if(in_array("3", $userRWoptions))
 						echo " checked";
@@ -719,10 +718,10 @@ echo "</td>";
 				echo " checked";
 			echo ">Generate Bill - option<br>";
 
-		}		
+		}
 
 	}
-	
+
 	public function getLabUserTypeOptions($selected_value="")
 	{
 		# Returns accessible sites for drop down <select> boxes
@@ -732,9 +731,9 @@ echo "</td>";
 		$saved_db = DbUtil::switchToGlobal();
 		$query = "SELECT * FROM user_type where defaultdisplay = 1";
 		$resultset = query_associative_all($query, $count);
-		
+
 		if( count($resultset) > 0 ) { ?>
-			<?php 
+			<?php
 				foreach($resultset as $record) {
 					echo "<option value='".$record['level']."'";
 					if($selected_value == $record['level'])
@@ -753,13 +752,13 @@ echo "</td>";
 		// $LIS_SUPERADMIN = 4;
 		// $LIS_COUNTRYDIR = 5;
 		// $LIS_CLERK = 6;
-		
+
 		// $LIS_VERIFIER = 15;
 		// $LIS_TECH_SHOWPNAME = 13;
 
-		// $LIS_DOCTOR = 16;		
+		// $LIS_DOCTOR = 16;
 		// $LIS_PHYSICIAN = 17;
-		
+
 		// echo "<option value='$LIS_TECH_RW'";
 		// if($selected_value == $LIS_TECH_RW)
 		// 	echo " selected ";
@@ -774,41 +773,41 @@ echo "</td>";
 		// if($selected_value == $LIS_CLERK)
 		// 	echo " selected ";
 		// echo ">".LangUtil::$generalTerms['LAB_RECEPTIONIST']."</option>";
-		
+
 		// echo "<option value='$LIS_VERIFIER'";
 		// if($selected_value == $LIS_VERIFIER)
 		// 	echo " selected ";
 		// echo ">Verifier</option>";
-		
+
 		// echo "<option value='$LIS_DOCTOR'";
 		// if($selected_value == $LIS_DOCTOR)
 		// 	echo " selected ";
 		// echo ">Requester</option>";
-		
+
 		// echo "<option value='$LIS_READONLY'";
 		// if($selected_value == $LIS_READONLY)
 		// 	echo " selected ";
 		// echo ">Read-Only Mode</option>";
-		
+
 		// echo "<option value='$LIS_PHYSICIAN'";
 		// if($selected_value == $LIS_PHYSICIAN)
 		// 	echo " selected ";
 		// echo ">Doctor</option>";
-		
-	}	
-		
+
+	}
+
 	public function getSpecimenTypesSelect($lab_config_id)
 	{
-		
+
 		# Returns specimen types used at a site for drop down <select> boxes
 		$specimen_type_list = get_specimen_types_by_site($lab_config_id);
-		
+
 		foreach($specimen_type_list as $specimen_type)
 		{
 			echo "<option value='$specimen_type->specimenTypeId'>".$specimen_type->getName()."</option>";
 		}
 	}
-	
+
 	public function getTestTypesSelect($lab_config_id)
 	{
 		# Returns test types used at a site for drop down <select> boxes
@@ -818,20 +817,20 @@ echo "</td>";
 			echo "<option value='$test_type->testTypeId'>".$test_type->getName()."</option>";
 		}
 	}
-	
+
 	public function getTestTypesCountryLevel() {
 		# Returns test types available for aggregation
 		$saved_db = DbUtil::switchToLabConfigRevamp();
 		$user_id = $_SESSION['user_id'];
 		$query = "SELECT * FROM test_mapping where user_id =".$user_id;
 		$resultset = query_associative_all($query, $count);
-		
+
 		if( count($resultset) > 0 ) { ?>
 			<table class='hor-minimalist-b'>
 			<tbody>
 			<th>#</th>
-			<?php 
-				echo "<th>".LangUtil::$generalTerms['NAME']."</th><th></th>"; 
+			<?php
+				echo "<th>".LangUtil::$generalTerms['NAME']."</th><th></th>";
 				foreach($resultset as $record) {
 					$testName = $record['test_name'];
 					echo "<tr><td>".$record['test_id']."</td>";
@@ -848,14 +847,14 @@ echo "</td>";
 		}
 		DbUtil::switchRestore($saved_db);
 	}
-	
+
 	public function getSpecimenTypesCountryLevel() {
 		# Returns specimen types available for aggregation
 		$saved_db = DbUtil::switchToLabConfigRevamp();
 		$user_id = $_SESSION['user_id'];
 		$query = "SELECT * FROM specimen_mapping where user_id =".$user_id;
 		$resultset = query_associative_all($query, $count);
-		
+
 		if( count($resultset) > 0 ) { ?>
 			<table class='hor-minimalist-b'>
 			<tbody>
@@ -873,20 +872,20 @@ echo "</td>";
 		}
 		DbUtil::switchRestore($saved_db);
 	}
-	
+
 	public function getTestCategoryTypesCountryLevel() {
 		# Returns test category types available for aggregation
 		$saved_db = DbUtil::switchToGlobal();
 		$user_id = $_SESSION['user_id'];
 		$query = "SELECT * FROM test_category_mapping where user_id =".$user_id;
 		$resultset = query_associative_all($query, $count);
-		
+
 		if( count($resultset) > 0 ) { ?>
 			<table class='hor-minimalist-b'>
 			<tbody>
 			<th>#</th>
-			<?php 
-				echo "<th>".LangUtil::$generalTerms['NAME']."</th><th></th>"; 
+			<?php
+				echo "<th>".LangUtil::$generalTerms['NAME']."</th><th></th>";
 				foreach($resultset as $record) {
 					echo "<tr><td>".$record['test_category_id']."</td>";
 					echo "<td>".$record['test_category_name']."</td>";
@@ -903,7 +902,7 @@ echo "</td>";
 		}
 		DbUtil::switchRestore($saved_db);
 	}
-	
+
 	public function getTestTypesCountrySelect()
 	{
 		/*
@@ -935,12 +934,12 @@ echo "</td>";
 		foreach($resultset as $record) {
 				//$key = $record['lab_id_test_id'];
                                 $key = $record['test_id'];
-				$value = $record['test_name']; 
+				$value = $record['test_name'];
 				echo "<option value='$key'>$value</option>";
 		}
 		DbUtil::switchRestore($saved_db);
 	}
-	
+
 	public function getTestNamesSelector() {
 		#Return table which includes dropdowns of test types configured in all labs in the country
 		echo "<table>";
@@ -968,16 +967,16 @@ echo "</td>";
 		</td>
 		</tr>
 		<tr>
-		<td></td>		
+		<td></td>
 		<td><input type="button" id="submit" type="submit" onclick="submitTestNames();" value="<?php echo LangUtil::$generalTerms['CMD_SUBMIT']; ?>" size="20" />
 		<?
 	}
-        
+
         public function getTestNamesSelectorForEdit($mapping) {
 		#Return table which includes dropdowns of test types configured in all labs in the country
 		print_r($mapping);
                 ?>
-                  
+
                 <table class='hor-minimalist-a'>
                 <tr>
                 <td><b>Country Test Name:</b></td>
@@ -1005,13 +1004,13 @@ echo "</td>";
 		//echo "<tr><td></td><td></td>";
 		echo "</tr>";
 		 ?>
-		
+
 		<tr>
-		<td></td>		
+		<td></td>
 		<td><input type="button" id="submit" type="submit" onclick="submitTestNames();" value="<?php echo LangUtil::$generalTerms['CMD_UPDATE']; ?>" size="20" />
 		<?
 	}
-	
+
 	public function getSpecimenTypesCountrySelect()
 	{
 		$userId = $_SESSION['user_id'];
@@ -1025,7 +1024,7 @@ echo "</td>";
 		}
 		DbUtil::switchRestore($saved_db);
 	}
-	
+
 	public function getTestCategoryNamesSelector() {
 		#Return table which includes dropdowns of test categories configured in all labs in the country
 		echo "<table>";
@@ -1052,11 +1051,11 @@ echo "</td>";
 		</td>
 		</tr>
 		<tr>
-		<td></td>		
+		<td></td>
 		<td><input type="button" id="submit" type="submit" onclick="submitTestCategoryNames();" value="<?php echo LangUtil::$generalTerms['CMD_SUBMIT']; ?>" size="20" />
 		<?
 	}
-	
+
 	public function getTestCategoryTypesCountrySelect() {
 		$userId = $_SESSION['user_id'];
 		$saved_db = DbUtil::switchToGlobal();
@@ -1069,7 +1068,7 @@ echo "</td>";
 		}
 		DbUtil::switchRestore($saved_db);
 	}
-	
+
 	public function getMeasuresSelector() {
 		#Return table which includes dropdowns of measures configured in all labs in the country
 		echo "<table>";
@@ -1101,13 +1100,13 @@ echo "</td>";
 		</td>
 	<?php
 	}
-	
+
 	public function getMeasuresCountryLevel() {
 		$userId = $_SESSION['user_id'];
 		$saved_db = DbUtil::switchToGlobal();
 		$query = "SELECT * FROM measure_mapping WHERE user_id = $userId";
 		$resultset = query_associative_all($query, $row_count);
-		
+
 		if( count($resultset) > 0 ) { ?>
 			<table class='hor-minimalist-b'>
 			<tbody>
@@ -1129,7 +1128,7 @@ echo "</td>";
 		}
 		DbUtil::switchRestore($saved_db);
 	}
-	
+
         public function getMasterCatalog() {
 		#Return table which includes dropdowns of measures configured in all labs in the country
 		echo "<table class='hor-minimalist-b tablesorter' id='testTypeTable'>";
@@ -1166,7 +1165,7 @@ echo "</td>";
 		//echo "<tr><td></td><td></td></tr>";
 		//echo "<tr>";
 		//echo "<td>Country Specimen Name:</td>"; ?>
-		
+
 	<?php
 	}
 
@@ -1200,7 +1199,7 @@ echo "</td>";
 		</td>
 	<?php
 	}
-	
+
 	public function getDiscreteTestTypesSelect($lab_config_id)
 	{
 		# Returns test types used at a site for drop down <select> boxes
@@ -1217,7 +1216,7 @@ echo "</td>";
 			echo "<option value='$test_type->testTypeId'>".$test_type->getName()."</option>";
 		}
 	}
-		
+
 	public function getTestTypesByCategorySelect($lab_config_id, $cat_code)
 	{
 		# Returns test types used at a site for a particular category (lab section)
@@ -1240,7 +1239,7 @@ echo "</td>";
 			echo "<option value='$test_type->testTypeId'>".$test_type->getName()."</option>";
 		}
 	}
-	
+
 	public function getTestTypeCatalogOptions($elem_name, $elem_id)
 	{
 		# Returns a set of check boxes buttons for all tests available in catalog
@@ -1255,7 +1254,7 @@ echo "</td>";
 			echo "<input type='checkbox' name='".$elem_name."[]' id='$elem_id' value='$key'>$value</input>";
 		}
 	}
-	
+
 	public function getTestCategorySelect($lab_config_id=null)
 	{
 		# Returns a set of drop down options for test categories in catalog
@@ -1268,7 +1267,7 @@ echo "</td>";
 		else
 			return 0;
 	}
-	
+
 	public function getTestCategoryCountrySelect($lab_config_id=null)
 	{
 		#Returns a set of drop down options for test categories in catalog of all labs in a country
@@ -1298,14 +1297,14 @@ echo "<option value='$lc->id'>$lc->name</option>";
 }
 	}
 //AS 09/04/2018 END
-	
+
 	public function getLangSelect()
 	{
 		echo "<option value='default'>Default</option>";
 		echo "<option value='en'>English</option>";
-		echo "<option value='fr'>Francais</option>";		
+		echo "<option value='fr'>Francais</option>";
 	}
-	
+
 	public function getSpecimenTypeCatalogOptions($elem_name, $elem_id)
 	{
 		# Returns a set of check boxes buttons for all tests available in catalog
@@ -1320,7 +1319,7 @@ echo "<option value='$lc->id'>$lc->name</option>";
 			echo "<input type='checkbox' name='".$elem_name."[]' id='$elem_id' value='$key'>$value</input>";
 		}
 	}
-	
+
         public function getTestListToImport($elem_name, $elem_id)
 	{
 		# Returns a set of check boxes buttons for all tests available in catalog
@@ -1335,7 +1334,7 @@ echo "<option value='$lc->id'>$lc->name</option>";
 			echo "<input type='checkbox' name='".$elem_name."[]' id='$elem_id' value='$key'>$value</input>";
 		}
 	}
-	
+
 
 	public function getTestTypeInfo($test_name, $show_db_name=false)
 	{
@@ -1416,7 +1415,7 @@ echo "<option value='$lc->id'>$lc->name</option>";
 					?>
 					</td>
 				</tr>
-		
+
 				<tr valign='top'>
 					<td>Hide Patient Name in Report</td>
 					<td><?php
@@ -1433,7 +1432,7 @@ echo "<option value='$lc->id'>$lc->name</option>";
 					<td>Prevalence Threshold</td>
 					<td><?php echo $test_type->prevalenceThreshold; ?></td>
 				</tr>
-				
+
 				<tr valign='top'>
 					<td>Target TAT</td>
 					<td><?php echo $test_type->targetTat; ?></td>
@@ -1443,13 +1442,13 @@ echo "<option value='$lc->id'>$lc->name</option>";
                                         <td>Cost To Patient</td>
                                         <td><?php print(format_number_to_money(get_latest_cost_of_test_type($test_type->testTypeId))); ?></td>
                                 </tr>
-			
+
 			</tbody>
 		</table>
 		<?php
 
 	}
-	
+
 	public function getTestTypeInfoAggregateDir($testTypeMapping, $show_db_name=false)
 	{
 		# Returns HTML for displaying test type information
@@ -1460,12 +1459,12 @@ echo "<option value='$lc->id'>$lc->name</option>";
 				<tr>
 					<td><?php echo LangUtil::$generalTerms['NAME']; ?></td>
 					<td><?php echo $test_type->name; ?></td>
-				</tr>				
+				</tr>
 			</tbody>
 		</table>
 		<?php
 	}
-        
+
         public function getTestTypeInfoAggregate($testTypeMapping, $show_db_name=false)
 	{
 		# Returns HTML for displaying test type information
@@ -1477,7 +1476,7 @@ echo "<option value='$lc->id'>$lc->name</option>";
 					<td><?php echo LangUtil::$generalTerms['NAME']; ?></td>
 					<td><?php echo $test_type->name; ?></td>
 				</tr>
-				
+
 				<tr>
 					<td><?php echo LangUtil::$generalTerms['LAB_SECTION']; ?></td>
 					<td><?php echo getTestCategoryAggNameById($test_type->testCategoryId); ?></td>
@@ -1492,7 +1491,7 @@ echo "<option value='$lc->id'>$lc->name</option>";
 						foreach($measure_id_list as $measure_id)
 						{
 							$measure = getAggregateMeasureById($measure_id);
-							if($measure==NULL && count($meausre_id_list)==1 ) {	
+							if($measure==NULL && count($meausre_id_list)==1 ) {
 									echo "No Measures Found!";
 									break;
 							}
@@ -1502,12 +1501,12 @@ echo "<option value='$lc->id'>$lc->name</option>";
 					?>
 					</td>
 				</tr>
-			
+
 			</tbody>
 		</table>
 		<?php
 	}
-	
+
 	public function getSpecimenTypeInfo($specimen_name, $show_db_name=false)
 	{
 		# Returns HTML for displaying specimen type information
@@ -1579,18 +1578,18 @@ echo "<option value='$lc->id'>$lc->name</option>";
 		</table>
 		<?php
 	}
-	
+
 	public function getTestTypeTable($lab_config_id)
 	{
 		# Returns HTML table listing all test types in catalog
 		?>
-		
+
 		<script type='text/javascript'>
 			$(document).ready(function(){
 				$('#testTypeTable').tablesorter();
 			});
 		</script>
-		
+
 		<?php
 		$ttype_list = get_test_types_catalog($lab_config_id);
 		if(count($ttype_list) == 0)
@@ -1650,7 +1649,7 @@ echo "<option value='$lc->id'>$lc->name</option>";
 		</table>
 		<?php
 	}
-	
+
 	public function getSpecimenTypeTable($lab_config_id)
 	{
 		# Returns HTML table listing all specimen types in catalog
@@ -1698,7 +1697,7 @@ echo "<option value='$lc->id'>$lc->name</option>";
 		</table>
 		<?php
 	}
-	
+
 	public function getOperatorForm($num_entries)
 	{
 		# Returns HTML form code for adding technicians
@@ -1739,7 +1738,7 @@ echo "<option value='$lc->id'>$lc->name</option>";
 			"<input type='text' name='fullname[]' />&nbsp;&nbsp;&nbsp;";
 		for($count = 1; $count <= $num_entries; $count++)
 		{
-			$radio_row = 	
+			$radio_row =
 				"<input type='radio' name='access_priv_".($count-1)."' id='access_priv_".($count-1)."' value='".$LIS_TECH_RW."' checked /> ".LangUtil::$generalTerms['TECHNICIAN'].
 				"&nbsp;&nbsp;&nbsp;<input type='radio' name='access_priv_".($count-1)."' id='access_priv_".($count-1)."' value='".$LIS_CLERK."' /> ".LangUtil::$generalTerms['LAB_RECEPTIONIST']."<br>";
 			$html_code .= $entry_row.$radio_row;
@@ -1759,12 +1758,12 @@ echo "<option value='$lc->id'>$lc->name</option>";
 			"</script>";
 		echo $html_code;
 	}
-	
+
 	public function getOperatorExistingForm($lab_config_id)
 	{
 		# Returns HTML table listing existing technician account,
 		# with options to change access or delete account
-		
+
 		global $LIS_TECH_RO, $LIS_TECH_RW;
 		?>
 		<table cellspacing='4px'>
@@ -1814,13 +1813,13 @@ echo "<option value='$lc->id'>$lc->name</option>";
 	}
 	public function getTokenLis($count,$id, $name, $json_url, $hint_text, $json_prepopulate="", $class_name="")
 	{
-	
-	
-	
+
+
+
 		# Returns a tokenized list as form input element (using jquery.tokeninput plugin)
 		$test=explode("_",$id);
 		$test_id=$test[1];
-		
+
 		?>
 		<script type="text/javascript">
 		$(document).ready(function() {
@@ -1889,21 +1888,21 @@ echo "<option value='$lc->id'>$lc->name</option>";
 				{
 					echo ", prePopulate: $json_prepopulate";
 				}
-				
+
 				?>
-			});			
-			
+			});
+
 		});
 		</script>
-		
+
 		<input type="text" id="<?php echo $id; ?>" class='uniform_width  <?php
 		if(trim($class_name) != "")
 			echo " ".$class_name." ";
 		?>' name="<?php echo $name; ?>" <?php if($count!=-1){?> onchange="javascript:update_remarks(<?php echo $test_id ; ?>,<?php echo $count; ?>, 1, B)"  <?php }?>/>
 		<?php
-		
+
 	}
-	
+
 	public function getLabConfigTable($lab_config_list)
 	{
 		# Returns HTML table of site/locations
@@ -1962,7 +1961,7 @@ echo "<option value='$lc->id'>$lc->name</option>";
 					</td>
                                         <td>
  						<a href='exportLabConfiguration.php?id=<?php echo $lab_config->id; ?>' title='Click to Export Lab Configuration'><?php echo "Export Lab Configuration"; ?></a>
-                                           
+
                                         </td>
 					<!--<td>
 						<a rel='facebox' href='lab_config_status.php?id=<?php echo $lab_config->id; ?>' title='Click to view pending tests at the lab'><?php echo LangUtil::$generalTerms['LAB_STATUS']; ?></a>
@@ -1992,7 +1991,7 @@ echo "<option value='$lc->id'>$lc->name</option>";
 		</table>
 		<?php
 	}
-	
+
         public function getLabConfigTableImported($lab_config_list)
 	{
 		# Returns HTML table of site/locations
@@ -2023,7 +2022,7 @@ echo "<option value='$lc->id'>$lc->name</option>";
 					</th>
                                         <th>
                                         </th>
-					
+
 				</tr>
 			</thead>
 			<tbody>
@@ -2039,7 +2038,7 @@ echo "<option value='$lc->id'>$lc->name</option>";
 					<!--<td>
 						<a href='lab_config_home.php?id=<?php echo $lab_config->id; ?>' title='Click to Manage Lab Configuration'><?php echo $lab_config->name; ?></a>
 					</td>-->
-                                        
+
 					<td>
 						<?php echo $lab_config->name; ?>
 					</td>
@@ -2055,7 +2054,7 @@ echo "<option value='$lc->id'>$lc->name</option>";
 					<td>
 						<a rel='facebox' href='lab_config_status.php?id=<?php echo $lab_config->id; ?>' title='Click to view pending tests at the lab'><?php echo LangUtil::$generalTerms['LAB_STATUS']; ?></a>
 					</td>
-                                        
+
 					<!--<td>
 						<a href='lab_config_home.php?id=<?php echo $lab_config->id; ?>' title='Click to Manage Lab Configuration'><?php echo LangUtil::$generalTerms['MANAGE']; ?></a>
 					</td>
@@ -2064,8 +2063,8 @@ echo "<option value='$lc->id'>$lc->name</option>";
 					</td>-->
 					<!--
 					<td>
-						<a 
-							href="javascript:delete_lab_config('<?php #echo $lab_config->getSiteName(); ?>', <?php #echo $lab_config->id; ?>);" 
+						<a
+							href="javascript:delete_lab_config('<?php #echo $lab_config->getSiteName(); ?>', <?php #echo $lab_config->id; ?>);"
 							title='Click to Delete Lab Configuration'
 						>
 							Delete
@@ -2081,7 +2080,7 @@ echo "<option value='$lc->id'>$lc->name</option>";
 		</table>
 		<?php
 	}
-        
+
 	public function getLabAdminTable($lab_admin_list)
 	{
 		# Returns HTML table of lab admin accounts
@@ -2181,7 +2180,7 @@ echo "<option value='$lc->id'>$lc->name</option>";
 		</table>
 		<?php
 	}
-	
+
 	public function getLabUsersTable($user_list, $lab_config_id, $to_export=false)
 	{
 		# Returns HTML table of lab users
@@ -2229,9 +2228,9 @@ echo "<option value='$lc->id'>$lc->name</option>";
 							<?php echo $user->username; ?>
 						</td>
 						<td>
-							<?php $l_name = get_level_name($user->level); 
-							if ($l_name == null) 
-								$l_name = get_level_name_db($user->level); 
+							<?php $l_name = get_level_name($user->level);
+							if ($l_name == null)
+								$l_name = get_level_name_db($user->level);
 							echo $l_name;
 							?>
 						</td>
@@ -2312,19 +2311,19 @@ echo "<option value='$lc->id'>$lc->name</option>";
 							<?php echo $user->level; ?>.
 						</td>
 						<td>
-							<?php $val = get_level_name($user->level); 
-								if ($val == null) 
-									echo  $user->name; 
-								else 
-									echo $val; 
+							<?php $val = get_level_name($user->level);
+								if ($val == null)
+									echo  $user->name;
+								else
+									echo $val;
 							?>
 						</td>
 						<td>
-							<?php 
+							<?php
 								if($user->defaultdisplay)
 									echo "Yes";
 								else
-									echo "No"; 
+									echo "No";
 							?>
 						</td>
 						<?php
@@ -2332,7 +2331,7 @@ echo "<option value='$lc->id'>$lc->name</option>";
 						{
 						?>
 						<td>
-							<a href="lab_user_type_edit.php?type=<?php echo $user->level; ?>&backurl=lab_config_home.php?id=<?php echo $lab_config_id; ?>"> 
+							<a href="lab_user_type_edit.php?type=<?php echo $user->level; ?>&backurl=lab_config_home.php?id=<?php echo $lab_config_id; ?>">
 							<!-- <a href="lab_user_edit.php?id=<?php echo "521"; ?>&backurl=lab_config_home.php?id=<?php echo $lab_config_id; ?>"> -->
 							<?php echo LangUtil::$generalTerms['CMD_EDIT']; ?>
 							</a>
@@ -2359,7 +2358,7 @@ echo "<option value='$lc->id'>$lc->name</option>";
 		</table>
 		<?php
 	}
-	
+
 	public function listOwnedLabs($admin_user_id)
 	{
 		# Returns list of lab configurations / sites owned by the admin user
@@ -2379,7 +2378,7 @@ echo "<option value='$lc->id'>$lc->name</option>";
 		}
 		return $retval;
 	}
-	
+
 	public function getLabConfigInfo($lab_config_id)
 	{
 		# Returns HTML displaying lab configuration info
@@ -2457,7 +2456,7 @@ echo "<option value='$lc->id'>$lc->name</option>";
 		</table>
 		<?php
 	}
-	
+
 	public function getReportConfigInfo($report)
 	{
 		# Displays HTML for showing report configuration info
@@ -2525,7 +2524,7 @@ echo "<option value='$lc->id'>$lc->name</option>";
 		</table>
 		<?php
 	}
-	
+
 	public function getLabConfigStatus_backup($lab_config_id)
 	{
 		$lab_config = get_lab_config_by_id($lab_config_id);
@@ -2560,7 +2559,7 @@ echo "<option value='$lc->id'>$lc->name</option>";
 					<td>Pending Specimens -</td>
 					<td><?php echo get_lab_config_num_specimens_pending($lab_config_id); ?></td>
 				</tr>
-				
+
 				<?php
 				$specimen_list = get_specimen_types_by_site($lab_config_id);
 				foreach($specimen_list as $specimen_type)
@@ -2573,12 +2572,12 @@ echo "<option value='$lc->id'>$lc->name</option>";
 					<?php
 				}
 				?>
-				
+
 				<tr>
 					<td>Pending Tests -</td>
 					<td><?php echo get_lab_config_num_tests_pending($lab_config_id); ?></td>
 				</tr>
-				
+
 				<?php
 				$test_list = get_test_types_by_site_map($lab_config_id);
 				foreach($test_list as $test_type_id=>$test_name)
@@ -2595,7 +2594,7 @@ echo "<option value='$lc->id'>$lc->name</option>";
 		</table>
 		<?php
 	}
-	
+
 	public function getLabConfigStatus($lab_config_id)
 	{
 		$lab_config = get_lab_config_by_id($lab_config_id);
@@ -2624,7 +2623,7 @@ echo "<option value='$lc->id'>$lc->name</option>";
 					<td><?php echo LangUtil::$generalTerms['PENDING_RESULTS']; ?></td>
 					<td><?php echo get_lab_config_num_tests_pending($lab_config_id); ?></td>
 				</tr>
-				
+
 				<?php
 				$test_list = get_test_types_by_site_map($lab_config_id);
 				foreach($test_list as $test_type_id=>$test_name)
@@ -2641,7 +2640,7 @@ echo "<option value='$lc->id'>$lc->name</option>";
 		</table>
 		<?php
 	}
-	
+
 	public function getPatientInfo($pid, $width="")
 	{
 		# Returns HTML table displaying patient info
@@ -2715,17 +2714,17 @@ echo "<option value='$lc->id'>$lc->name</option>";
 				# Custom fields here
 				$custom_data_list = get_custom_data_patient($patient->patientId);
 				foreach($custom_data_list as $custom_data)
-				{	
-					
+				{
+
 						$field_name = get_custom_field_name_patient($custom_data->fieldId);
 						if(stripos($field_name,"^^")!= NULL || $field_name!= "" )
-					{	
+					{
 						$field_value = $custom_data->fieldValue;
-					
+
 					?>
 					<tr>
 						<td><u><?php
-						
+
 						echo $field_name; ?></u></td>
 						<td>
 							<?php
@@ -2739,10 +2738,10 @@ echo "<option value='$lc->id'>$lc->name</option>";
 				?>
 			</tbody>
 		</table>
-		
+
 		<?php
 	}
-	
+
 	public function getPatientUpdateForm($pid)
 	{
 		$patient = get_patient_by_id($pid);
@@ -2765,7 +2764,7 @@ echo "<option value='$lc->id'>$lc->name</option>";
 						<input type='text' name='surr_id' id='surr_id' value='<?php if($patient->surrogateId != undefined) { echo $patient->surrogateId; }?>' class='uniform_width'></input>
 					</td>
 				</tr>
-				
+
 				<tr <?php
 				if($lab_config->patientAddl == 0)
 				{
@@ -2925,7 +2924,7 @@ echo "<option value='$lc->id'>$lc->name</option>";
 		</form>
 	<?php
 	}
-	
+
 	public function getSelectSpecimenInfoRow($specimen, $rem_specs, $admin)
 	{
 		# Returns HTML table row containing specimen info
@@ -2933,7 +2932,7 @@ echo "<option value='$lc->id'>$lc->name</option>";
 
 		?>
 		<form name="f1" id="f1">
-		
+
 		<tr valign='top'>
 			<?php
 			if($_SESSION['s_addl'] != 0)
@@ -2975,7 +2974,7 @@ echo "<option value='$lc->id'>$lc->name</option>";
 			<?php
 			$sid=$specimen->specimenId;
 			$pid=$specimen->patientId;
-			
+
 			?>
 			<td><input id="liked" type="checkbox" name="liked" value=<?php echo $specimen->specimenId; ?>> </td>
 		</tr>
@@ -2988,7 +2987,7 @@ echo "<option value='$lc->id'>$lc->name</option>";
 		# Called by getPatientHistory() function
                 $specimenBarcode = specimenBarcodeCheck();
 		?>
-                        
+
 		<tr valign='top'>
 			<?php
 			if($_SESSION['s_addl'] != 0)
@@ -3007,13 +3006,13 @@ echo "<option value='$lc->id'>$lc->name</option>";
 				<?php echo DateLib::mysqlToString($specimen->dateRecvd); ?>
 			</td>
 			<td>
-				<?php 
+				<?php
 				$removed = false;
-				
+
 				//print_r($rem_specs);
 				if($admin == 1)
                                      {
-                                     	
+
                                         if(in_array($specimen->specimenId, $rem_specs))
                                         {
                                             echo "Removed";
@@ -3036,11 +3035,11 @@ echo "<option value='$lc->id'>$lc->name</option>";
 			<?php
 			$sid=$specimen->specimenId;
 			$pid=$specimen->patientId;
-			
+
 			?>
 			<td>
 			<a href="javascript:get_report(<?php echo $pid;?>,<?php echo $sid;?> )">Report</a> </td>
-			<td><!-- <a href="javascript:update_specimen(<?php echo $sid;?>)"> Update</a> &nbsp;/&nbsp; --> 
+			<td><!-- <a href="javascript:update_specimen(<?php echo $sid;?>)"> Update</a> &nbsp;/&nbsp; -->
 			<?php if($removed == false){?>
 			<a href="javascript:delete_specimen(<?php echo $sid;?>)"> Delete</a>
 			<?php } else {
@@ -3048,7 +3047,7 @@ echo "<option value='$lc->id'>$lc->name</option>";
 						?>
 						<a href="javascript:retrieve_deleted(<?php echo $sid;?>,'specimen')"> Retrieve</a>
 					<?php } else {
-			   echo "Request Admin to undo delete"; 
+			   echo "Request Admin to undo delete";
 			   }
 			}?>
 			</td>
@@ -3057,14 +3056,14 @@ echo "<option value='$lc->id'>$lc->name</option>";
                             {
                             ?>
                                 <td><a href="javascript:print_specimen_barcode(<?php echo $pid;?>,<?php echo $sid;?> )">Print Barcode</a> </td>
-                            <? 
+                            <?
                             }
-                                
+
                         ?>
 		</tr>
 		<?php
 	}
-	
+
 	public function getSpecimenExceededInfoRow($specimen, $count)
 	{
 		# Returns HTML table row containing specimen info
@@ -3092,7 +3091,7 @@ echo "<option value='$lc->id'>$lc->name</option>";
 		</tr>
 		<?php
 	}
-	
+
 	public function getPatientHistory($pid)
 	{
 		# Returns HTML table displaying patient test history
@@ -3123,7 +3122,7 @@ echo "<option value='$lc->id'>$lc->name</option>";
 		$(document).ready(function(){
 			$('#test_history_table').tablesorter();
 		});
-		
+
 		function get_report(pid,sid)
 		{
 			var url_string = "report_onetesthistory.php?ppid="+pid+"&spid="+sid;
@@ -3145,15 +3144,15 @@ echo "<option value='$lc->id'>$lc->name</option>";
 						} else {
 							$("#target_div_id_del").html("Specimen cannot be deleted");
 						}
-						
+
 					}
-				}); 
-							
-			}	
+				});
+
+			}
 		}
 
 		function update_specimen(sid){
-			
+
 		}
 
 		function ConfirmDelete()
@@ -3164,7 +3163,7 @@ echo "<option value='$lc->id'>$lc->name</option>";
 		  else
 		    return false;
 		}
-		
+
 		</script>
 		<table class='tablesorter' id='test_history_table'>
 			<thead>
@@ -3189,9 +3188,9 @@ echo "<option value='$lc->id'>$lc->name</option>";
                             {
                             ?>
                                  <th></th>
-                            <? 
+                            <?
                             }
-                                
+
                         ?>
 				</tr>
 			</thead>
@@ -3199,7 +3198,7 @@ echo "<option value='$lc->id'>$lc->name</option>";
 			<?php
 			foreach($specimen_list as $specimen)
 			{
-				
+
                             if($admin == 0)
                             {
                                 if(in_array($specimen->specimenId, $rem_specs))
@@ -3214,7 +3213,7 @@ echo "<option value='$lc->id'>$lc->name</option>";
 		<?php
 		# TODO: Add paging to this table
 	}
-	
+
 	public function getSelectPatientHistory($pid, $labsection)
 	{
 		# Returns HTML table displaying patient test history
@@ -3244,8 +3243,8 @@ echo "<option value='$lc->id'>$lc->name</option>";
 		$(document).ready(function(){
 			$('#test_history_table').tablesorter();
 		});
-		
-		
+
+
 		</script>
 		<table class='tablesorter' id='test_history_table'>
 			<thead>
@@ -3283,15 +3282,15 @@ echo "<option value='$lc->id'>$lc->name</option>";
 		<?php
 		# TODO: Add paging to this table
 	}
-	
-	
+
+
 		public function getPatientSelectReport($patient_id)
 	{
 	?><!--'reports_testhistory.php?location=<?php echo $_SESSION['lab_config_id']; ?>&patient_id=<?php echo $patient_id; ?>'-->
 				<a href='javascript:get_select_tests(<?php echo $patient_id;?>);' title='Click to Generate Test History Report for this Patient'>
 					<?php echo LangUtil::$pageTerms['MSG_PRINTHISTORY']; ?>
 				</a>
-	<?php		
+	<?php
 	}
 
         public function getDeleteOptions($patient_id)
@@ -3300,7 +3299,7 @@ echo "<option value='$lc->id'>$lc->name</option>";
 				<a href='javascript:get_select_tests_del(<?php echo $patient_id;?>);' title='Click here to Delete the selected Tests'>
 					<?php echo "Remove Selected Specimens"; ?>
 				</a>
-	<?php		
+	<?php
 	}
 
         public function getUnDeleteOptions($patient_id)
@@ -3309,9 +3308,9 @@ echo "<option value='$lc->id'>$lc->name</option>";
 				<a href='javascript:get_select_tests_undel(<?php echo $patient_id;?>);' title='Click here to Retrieve deleted Tests'>
 					<?php echo "Retrieve Deleted Specimens"; ?>
 				</a>
-	<?php		
+	<?php
 	}
-	
+
 	public function getPostSpecimenEntryTaskList($patient_id)
 	{
 		?>
@@ -3330,7 +3329,7 @@ echo "<option value='$lc->id'>$lc->name</option>";
 		$patient = get_patient_by_id($patient_id);
 		$patient_num =$patient->getDailyNum();
 		$pieces = explode("-", $patient_num);
-				
+
 		# Lists patient-profile related tasks in a tips box
             $patientBarcodes = patientBarcodeCheck();
 		global $LIS_TECH_RO, $DISABLE_UPDATE_PATIENT_PROFILE;
@@ -3351,7 +3350,7 @@ echo "<option value='$lc->id'>$lc->name</option>";
 					<a href='javascript:toggle_profile_divs();' title='Click to Update Patient Profile'>
 						<?php echo LangUtil::$pageTerms['MSG_UPDATEPROFILE']; ?>
 					</a>
-					
+
 				</p>
 				<?php
 			}
@@ -3369,7 +3368,7 @@ echo "<option value='$lc->id'>$lc->name</option>";
 					<a href='javascript:print_patient_barcode();' title='Click to Print Patient Barcode'>
 						<?php echo "Print Patient Barcode" ?>
 					</a>
-					
+
 				</p>
 				<?php
 			}
@@ -3388,13 +3387,13 @@ echo "<option value='$lc->id'>$lc->name</option>";
 		<?php
 		}
 	}
-	
+
 	public function getSpecimenInfo($sid)
 	{
 		# Returns HTML table displaying specimen info
 		$specimen = get_specimen_by_id($sid);
-		
-		
+
+
 		//print_r($rem_specs);
 		if($specimen == null)
 		{
@@ -3405,7 +3404,7 @@ echo "<option value='$lc->id'>$lc->name</option>";
 			<?php
 			return;
 		}
-		
+
 		$rem_recs = get_removed_specimens($_SESSION['lab_config_id'], "specimen");
 		$rem_specs = array();
 		$rem_remarks = array();
@@ -3414,11 +3413,11 @@ echo "<option value='$lc->id'>$lc->name</option>";
 			$rem_specs[] = $rem_rec['r_id'];
 			$rem_remarks[] = $rem_rec['remarks'];
 		}
-		
-		
-		
+
+
+
 		?>
-		
+
 		<script type="text/javascript">
 		function retrieve_deleted(sid, category){
 			var params = "item_id="+sid+"&ret_cat="+category;
@@ -3432,10 +3431,10 @@ echo "<option value='$lc->id'>$lc->name</option>";
 					} else {
 						$("#target_div_id_del").html("Specimen cannot be Retrieved");
 					}
-					
+
 				}
-			}); 
-			
+			});
+
 		}
 
 		</script>
@@ -3564,7 +3563,7 @@ echo "<option value='$lc->id'>$lc->name</option>";
 				{
 					if(strlen(trim($specimen->referredToName)) > 0){
 					?>
-					
+
 					<tr>
 						<td><u><?php echo LangUtil::$generalTerms['REF_TO']; ?></u></td>
 						<td>
@@ -3580,7 +3579,7 @@ echo "<option value='$lc->id'>$lc->name</option>";
 						?>
 						</td>
 					</tr>
-					<?php } 
+					<?php }
 					if(strlen(trim($specimen->referredFromName)) > 0){
 					?>
 					<tr>
@@ -3611,7 +3610,7 @@ echo "<option value='$lc->id'>$lc->name</option>";
 						echo "Specimen Removed. Contact lab admin";
 					} else if(in_array($specimen->specimenId, $rem_specs) && is_admin(get_user_by_id($_SESSION['user_id']))==1){
 					?> <a href='javascript:retrieve_deleted(<?php echo $specimen->specimenId;?>, "specimen")' title='Click to retrieve deleted Specimen'>Retrieve Specimen</a>
-					<?php 
+					<?php
 					} else {
 					echo $specimen->getStatus();
 					$result1="Completed";
@@ -3620,15 +3619,15 @@ echo "<option value='$lc->id'>$lc->name</option>";
 					<?php if(strcmp($result,$result1)==0 || $_SESSION['user_level'] == 17){ ?> style='display:none;' <?php }?>
 					title='Click to Enter result values for this Specimen'><?php echo LangUtil::$generalTerms['ENTER_RESULTS']; ?></a>
 					<?php }
-					?>					
+					?>
 					</td>
-				</tr>				
+				</tr>
 			</tbody>
 		</table>
 		<?php
 	}
-	
-	
+
+
 	public function getSpecimenTaskList($specimen_id)
 	{
 		# Lists patient-profile related tasks in a tips box
@@ -3655,16 +3654,16 @@ echo "<option value='$lc->id'>$lc->name</option>";
 			<p><a href='reports_specimenlog.php?location=<?php echo $_SESSION['lab_config_id']; ?>&specimen_id=<?php echo $specimen_id; ?>' title='Click to View a Log of Actions Performed on this Specimen' target='_blank'><?php echo LangUtil::$generalTerms['CMD_TRACK']; ?></a></p>
 			<?php
 			if($_SESSION['user_level'] != $LIS_CLERK && $deleted == false)
-			{			
+			{
 				$user = get_user_by_id($_SESSION['user_level']);
 				if
 				( $specimen->statusCodeId == Specimen::$STATUS_TOVERIFY || $specimen->statusCodeId == Specimen::$STATUS_DONE )
 				{
-					
+
 					?>
 					<p><a href='specimen_verify.php?sid=<?php echo $specimen_id; ?>' title='Click to Verify or Update result values for this Specimen'><?php echo LangUtil::$generalTerms['CMD_VERIFY']; ?></a></p>
 					<?php
-					
+
 				}
 				else
 				{
@@ -3678,11 +3677,11 @@ echo "<option value='$lc->id'>$lc->name</option>";
 		</div>
 		<?php
 	}
-	
+
 	public function getSpecimenTestsTable($sid)
 	{
 		# Displays list of all tests registered for a specimen w/ status/results
-		
+
 		$test_list = get_tests_by_specimen_id($sid);
 		if(count($test_list) == 0)
 		{
@@ -3692,7 +3691,7 @@ echo "<option value='$lc->id'>$lc->name</option>";
 			<?php
 			return;
 		}
-		
+
 		?>
 		<script type='text/javascript'>
 		$(document).ready(function(){
@@ -3713,12 +3712,12 @@ echo "<option value='$lc->id'>$lc->name</option>";
 						} else {
 							$("#target_div_id_del").html("Test cannot be deleted");
 						}
-						
+
 					}
-				}); 
+				});
 			}
-		}				
-		
+		}
+
 
 		function ConfirmDelete()
 		{
@@ -3728,7 +3727,7 @@ echo "<option value='$lc->id'>$lc->name</option>";
 		  else
 		    return false;
 		}
-		
+
 		</script>
 		<table class='tablesorter' id='specimen_tests_table'>
 			<thead>
@@ -3739,7 +3738,7 @@ echo "<option value='$lc->id'>$lc->name</option>";
 					<th><?php echo LangUtil::$generalTerms['ENTERED_BY']; ?></th>
 					<th><?php echo LangUtil::$generalTerms['VERIFIED_BY']; ?></th>
 					<th><?php echo LangUtil::$generalTerms['ACTIONS']; ?></th>
-					
+
 				</tr>
 			</thead>
 			<tbody>
@@ -3754,7 +3753,7 @@ echo "<option value='$lc->id'>$lc->name</option>";
 		</table>
 		<?php
 	}
-	
+
 	public function getTestInfoRow($test)
 	{
 		# Returns HTML table row containing specimen info
@@ -3782,35 +3781,35 @@ echo "<option value='$lc->id'>$lc->name</option>";
 				<?php echo $test->getVerifiedBy(); ?>
 			</td>
 			<td>
-			
+
 			<?php
 					if(check_removal_record($_SESSION['lab_config_id'], $test->testId) && is_admin(get_user_by_id($_SESSION['user_id']))!=1){
 						echo "Test removed. Contact Lab admin";
 					} else if(check_removal_record($_SESSION['lab_config_id'], $test->testId) && is_admin(get_user_by_id($_SESSION['user_id']))==1){
 					?> <a href='javascript:retrieve_deleted(<?php echo $test->testId;?>, "test")' title='Click to retrieve deleted Test'>Retrieve Test</a>
-					<?php 
+					<?php
 					} else {
 					?>
 						<a href="javascript:delete_test(<?php echo  $test->testId ;?>)">Delete</a>
 					<?php }
 					?>
-					
-					
-				
+
+
+
 			</td>
 			<?php
 			$specimen_object=Specimen::getById($test->specimenId);
 			$pid=$specimen_object->patientId;
 			$sid=$test->specimenId;
-				
+
 			?>
 			<!--<td><a href="javascript:get_report(<?php echo $pid;?>,<?php echo $sid;?> )">Report</a> </td>-->
-			
+
 		</tr>
 		<?php
 	}
-	
-	
+
+
 	public function getTatStatsTable($lab_config, $date_from, $date_to)
 	{
 		# Returns HTML table showing Turnaround time values
@@ -3905,7 +3904,7 @@ foreach($retval as $value)
 </tbody>
 </table>
 <?php
-}	
+}
 
 public function getInventory($retval) {
 ?>
@@ -3982,10 +3981,10 @@ public function getTestsDoneStatsTable($stat_list)
 			<?php
 		}
 		?>
-		
+
 		<tr>
 			<td><?php
-			echo LangUtil::$pageTerms['TOTAL_TESTS']; 
+			echo LangUtil::$pageTerms['TOTAL_TESTS'];
 			?></td>
 			<td><?php echo $total_tests_done_count; ?></td>
 			<td><?php echo $total_tests_pending_count; ?></td>
@@ -3996,7 +3995,7 @@ public function getTestsDoneStatsTable($stat_list)
 	}
 	public function getDoctorStatsTable($stat_list, $dateFrom = null, $dateTo = null, $location = null)
 	{
-	
+
 		# Returns HTML table showing number of specimens handled
 		# Called from reports_specimencount.php
 		?>
@@ -4028,7 +4027,7 @@ public function getTestsDoneStatsTable($stat_list)
 			$total_patients=$value[0];
 			$total_specimens=$value[1];
 			$total_tests=$value[2];
-			
+
 			///grand totals
 			$grand_total_patients += $total_patients;
 			$grand_total_specimens += $total_specimens;
@@ -4065,14 +4064,14 @@ public function getTestsDoneStatsTable($stat_list)
             <th>Grand Totals</th>
 				<th><?php echo $grand_total_patients; ?></th>
 				<th><?php echo $grand_total_specimens ?></th>
-				<th><?php echo $grand_total_tests; ?></th>				
+				<th><?php echo $grand_total_tests; ?></th>
 				<th></th>
 			</tr>
         </tfoot>
 		</table>
 		<?php
 	}
-	
+
 	public function getSpecimenCountStatsTable($stat_list)
 	{
 		# Returns HTML table showing number of specimens handled
@@ -4108,7 +4107,7 @@ public function getTestsDoneStatsTable($stat_list)
 		</table>
 		<?php
 	}
-	
+
 	public function getInfectionStatsTable($stat_list, $lab_config_id=null)
 	{
 		# Returns HTML table showing infection rate summary
@@ -4196,7 +4195,7 @@ public function getInfectionStatsTableAggregate($stat_list, $date_from, $date_to
 		<?php
 		foreach($stat_list as $key=>$value)
 		{
-			$test_type_name = $key;	
+			$test_type_name = $key;
 			$count_all = $value[0];
 			$count_negative = $value[1];
 			$threshold = $value[2];
@@ -4240,7 +4239,7 @@ public function getInfectionStatsTableAggregate($stat_list, $date_from, $date_to
 		</table>
 		<?php
 	}
-	
+
 	public function getAllSpecimenList()
 	{
 		# Returns HTML listing all specimen types available in catalog
@@ -4269,7 +4268,7 @@ public function getInfectionStatsTableAggregate($stat_list, $date_from, $date_to
 		</table>
 		<?php
 	}
-	
+
 	public function getAllTestList()
 	{
 		# Returns HTML listing all test types available in catalog
@@ -4298,7 +4297,7 @@ public function getInfectionStatsTableAggregate($stat_list, $date_from, $date_to
 		</table>
 		<?php
 	}
-	
+
 	public function getAllMeasureList()
 	{
 		# Returns HTML listing all measures available in catalog
@@ -4327,7 +4326,7 @@ public function getInfectionStatsTableAggregate($stat_list, $date_from, $date_to
 		</table>
 		<?php
 	}
-	
+
 	function getCustomFormField($custom_field, $field_value="")
 	{
 		# Returns HTML form element for this custom field
@@ -4399,7 +4398,7 @@ public function getInfectionStatsTableAggregate($stat_list, $date_from, $date_to
 			echo "<div id='$error_elem_id' class='clean-error uniform_width' style='display:none;'>".LangUtil::$generalTerms['RANGE_OUTOF']."</div>";
 		}
 	}
-	
+
 	function getExistingSpecimenCustomFields($lab_config_id)
 	{
 		$field_list = get_lab_config_specimen_custom_fields($lab_config_id);
@@ -4415,7 +4414,7 @@ public function getInfectionStatsTableAggregate($stat_list, $date_from, $date_to
 				echo ", ";
 		}
 	}
-	
+
 	function getExistingPatientCustomFields($lab_config_id)
 	{
 		$field_list = get_lab_config_patient_custom_fields($lab_config_id);
@@ -4431,7 +4430,7 @@ public function getInfectionStatsTableAggregate($stat_list, $date_from, $date_to
 				echo ", ";
 		}
 	}
-	
+
 	function getExistingLabTitleCustomFields($lab_config_id)
 	{
 		$field_list = get_lab_config_labtitle_custom_fields($lab_config_id);
@@ -4447,7 +4446,7 @@ public function getInfectionStatsTableAggregate($stat_list, $date_from, $date_to
 				echo ", ";
 		}
 	}
-	
+
 	function getStockForm($count)
 	{
 	$name_request="txtRow".$count."1";
@@ -4528,17 +4527,17 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 		Date of Entry
 	</label></td><td>
 	<span id='<?php echo $curr_form_id; ?>_date_l'>
-	
+
 		<?php echo $this->getDatePicker($name_list, $id_list, $value_list); ?>
 		</span>
 	</td></tr>
-			
+
 			</table>
 			</div>
 			<?php
-	
+
 	}
-	
+
 	// field order customizations for specimen
 	function generate_patient_Number($dnum){
 		print "<tr valign='top'";
@@ -4554,13 +4553,13 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 		    echo $dnum;
 		echo "' size='20' class='uniform_width'> </input>	</td></tr>";
 	}
-	
+
 	function generate_specimen_type($stype_id, $testbox_id){
 		echo "<tr valign='top'><td><label for='stype'>".LangUtil::$generalTerms['SPECIMEN_TYPE'];
 		$this->getAsterisk();
 		echo "</label></td><td></td><td>";
-		
-		
+
+
 		echo "<select name='stype'
 						id='".$stype_id."'
 						onchange=\"javascript:get_testbox('".$testbox_id."', '".$stype_id."');\"
@@ -4570,40 +4569,40 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 						";
 		echo $this->getSpecimenTypesSelect($_SESSION['lab_config_id']);
 		echo "</select>";
-		
+
 		echo "</td></tr>";
-		
-		
-		
+
+
+
 	}
-	
+
 	function generate_test($testbox_id){
 		echo "<tr valign='top'><td><label for='tests'>".
 		      LangUtil::$generalTerms['TESTS'];
-			 $this->getAsterisk(); 
+			 $this->getAsterisk();
 		echo "</label></td><td></td><td><span id='".$testbox_id."' class='uniform_width'>-".
 		      LangUtil::$pageTerms['MSG_SELECT_STYPE'].
 		      "-</span></td></tr>";
 	}
-	
+
 	function generate_specimen_addId($lab_config){
 		echo "<tr valign='top' ";
 		if($lab_config->specimenAddl == 0)
 			echo " style='display:none;' ";
 		echo ">	<td> <label for='addlid'>".LangUtil::$generalTerms['SPECIMEN_ID'];
-		if($_SESSION['s_addl'] == 2) 
-		 $this->getAsterisk(); 
+		if($_SESSION['s_addl'] == 2)
+		 $this->getAsterisk();
 		echo " </label>	</td> <td>   </td>	<td><input type=\"text\" name=\"addl_id\" id=\"addl_id\" value=\"\" size=\"20\" class='uniform_width'> </input>
 				</td>
 			</tr>";
 	}
-	
+
 	function generate_reciept_date($lab_config, $form_id){
 		echo "<tr valign='top' ";
 		if($_SESSION['rdate'] == 0)
 				echo " style='display:none;' ";
 		echo ">	<td><label>".LangUtil::$generalTerms['R_DATE'];
-		if($_SESSION['rdate'] == 2) 
+		if($_SESSION['rdate'] == 2)
 			$this->getAsterisk();
 		echo "</label>	</td>	<td>  </td>	<td>";
 			$today = date("Y-m-d");
@@ -4616,15 +4615,15 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 				</td>
 			</tr>";
 	}
-	
-	
+
+
 	function generate_comments(){
 		echo "<tr valign='top'";
 		if($_SESSION['comm'] == 0)
 				echo " style='display:none;' ";
 		echo ">	<td> <label for='comments' valign='top'>".LangUtil::$generalTerms['COMMENTS'];
-		if($_SESSION['comm'] == 2) 
-		    $this->getAsterisk(); 
+		if($_SESSION['comm'] == 2)
+		    $this->getAsterisk();
 		echo "</label>	</td><td>   </td>		<td>
 					<textarea name=\"comments\" id=\"comments\" class='uniform_width'></textarea>
 				</td>
@@ -4649,15 +4648,15 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 		</tr>
 		<?php
 	}
-	
+
 	function generate_doctors($doc_row_id, $doc=""){
 		/* $doc_array= getDoctorList();
 		$php_array= addslashes(implode("%", $doc_array));
 		echo '<script type="text/javascript">$(document).ready(function(){';
-			
+
 		echo 'var data_string="'.$php_array;
 		echo 'var data=data_string.split("%");
-					
+
 			$("#doc_row_1_input").autocomplete(data);
 		}</script>';
  */
@@ -4672,15 +4671,15 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 				echo " style='display:none;' ";
 		echo ">
 				<td><label for='doctor' valign='top'>".LangUtil::$generalTerms['DOCTOR'];
-			if($_SESSION['doctor'] == 2) 
-				$this->getAsterisk(); 
+			if($_SESSION['doctor'] == 2)
+				$this->getAsterisk();
 		echo "</label></label>
 				</td>
 				<td>";
 		$labtitlefieldoptions = get_custom_fields_labtitle(1);
 		$lab_titles = explode("/",$labtitlefieldoptions);
 		echo "<SELECT name='title' id='".$doc_row_id."_title'>";
-		
+
 		foreach($lab_titles as $option)
 			{
 				if(trim($option) == "")
@@ -4701,7 +4700,7 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 		{
 			echo "<option value='" .$option. "'>";
 		}
-		
+
 		echo "</datalist></td>";
 			/*
 		echo "	</SELECT>
@@ -4713,7 +4712,7 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 			</tr>";
 			*/
 	}
-	
+
 	function generate_refOut($ref_out_check_id, $ref_out_row_id, $refTo_row_id, $ref_from_row_id, $refTo=""){
 // refTo_row_
 		echo "<tr valign='top'";
@@ -4722,7 +4721,7 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 		echo ">
 				<td>
 					<label for='ref_out' valign='top'>".LangUtil::$generalTerms['REF_OUT']."?";
-			if($_SESSION['refout'] == 2) $this->getAsterisk(); 
+			if($_SESSION['refout'] == 2) $this->getAsterisk();
 		echo "</label>
 				</td>
 				<td>   </td>
@@ -4736,17 +4735,17 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 				<td>
 					<input type='text' name='ref_out_name' id='".$refTo_row_id."_input"."' value='".$refTo."'></input></td>
 					<td>&nbsp;&nbsp; OR </td>
-				
+
 			</tr>
 			<tr valign='top' id='".$ref_from_row_id."' style='display:none'>
 				<td>Referred From</td>
 				<td>
 					<input type='text' name='ref_from_name' id='".$ref_from_row_id."_input"."'></input>
-					
+
 				</td>
 			</tr>";
 	}
-	
+
 	function generate_customFields($custom_field){
 		echo "<tr valign='top'>
 					<td>".$custom_field->fieldName."</td>
@@ -4755,8 +4754,8 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 		$this->getCustomFormField($custom_field);
 		echo "</td>	</tr>";
 	}
-	
-		
+
+
 	function getNewSpecimenForm($form_num, $pid, $dnum, $session_num, $doc="" ,$title ="Dr.", $refTo="")
 	{
 		# Returns HTML for new specimen form
@@ -4776,10 +4775,10 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 		$refTo_row_id = 'refTo_row_'.$form_num;
 		$ref_out_row_id = 'ref_out_row_'.$form_num;
 		$ref_out_check_id = 'ref_out_'.$form_num;
-		
+
 		$ref_from_row_id = 'ref_from_row_'.$form_num;
 		$ref_from_check_id = 'ref_out_'.$form_num;
-		
+
 		$lab_config = LabConfig::getById($_SESSION['lab_config_id']);
 		?>
 		<div id='<?php echo $div_id; ?>'>
@@ -4789,17 +4788,17 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 			<?php /*<input type='hidden' name='session_num' value='<?php echo get_session_number(); ?>' class='uniform_width'></input> */ ?>
 			<table class='regn_form_table'>
 			<tbody>
-			
+
 			<?php $this->generate_patient_Number($dnum);?>
 			<?php $this->generate_specimen_type($stype_id, $testbox_id);?>
 			<?php $this->generate_test($testbox_id);?>
-			
-			<?php 
+
+			<?php
 					$specimenFieldOrder = $_SESSION['specimenFieldOrder'];
 					$custom_field_list = get_custom_fields_specimen();
 					$custFieldArray = array();
 					foreach($custom_field_list as $custom_field)
-					{	
+					{
 						if(($custom_field->flag)==NULL)
 						{
 							array_push($custFieldArray, $custom_field->fieldName);
@@ -4807,7 +4806,7 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 					}
 					if(sizeOf($specimenFieldOrder) > 0){
 						foreach($specimenFieldOrder as $field){
-							
+
 							if(in_array($field, $custFieldArray)){
 								// custom field generation
 								$custom_field = null;
@@ -4816,18 +4815,18 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 										$custom_field = $custField;
 									}
 								}
-								$this->generate_customFields($custom_field); 
+								$this->generate_customFields($custom_field);
 							}
 							else if($field == "Specimen ID"){
 								 $this->generate_specimen_addId($lab_config);
 							} /*else if($field == "Specimen Additional ID"){
 								<?php $this->generate_specimen_addId($lab_config);?>
 							}*/ else if($field == "Comments"){
-								$this->generate_comments(); 
+								$this->generate_comments();
 							} else if($field == "Lab Reciept Date"){
 								 $this->generate_reciept_date($lab_config, $form_id);
 							} else if($field == "Referred Out"){
-								$this->generate_refOut($ref_out_check_id, $ref_out_row_id, $refTo_row_id, $ref_from_row_id, $refTo); 
+								$this->generate_refOut($ref_out_check_id, $ref_out_row_id, $refTo_row_id, $ref_from_row_id, $refTo);
 							} else if($field == "Physician"){
 								$this->generate_doctors($doc_row_id, $doc);
 							}
@@ -4835,12 +4834,12 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 					}
 			$this->generate_sites($lab_config, $lab_config->site_choice_enabled);
 				?>
-				
-				
-			
-			
-			
-			
+
+
+
+
+
+
 			<tr valign='top'<?php
 			//if($_SESSION['sid'] == 0)
 			if(true)
@@ -4861,11 +4860,11 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 					<br><span id='<?php echo $specimen_err_div_id; ?>'></span>
 				</td>
 			</tr>
-			
-			
-			
-			
-			
+
+
+
+
+
 			<tr valign='top' style='display:none;'>
 				<td>
 					<label><?php echo LangUtil::$generalTerms['C_DATE']; ?></label>
@@ -4902,8 +4901,8 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 						//if($option == 9)
 							echo "selected ";
 						echo ">$option</option>";
-						
-						
+
+
 					}
 					?>
 					</select>
@@ -4927,8 +4926,8 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 					&nbsp;&nbsp;hrs
 				</td>
 			</tr>
-			
-			
+
+
 			<tr valign='top' style='display:none' <?php ## Disabled for now ?>>
 				<td>
 					<label for='report_to' valign='top'>Report To</label>
@@ -4945,10 +4944,10 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 					</select>
 				</td>
 			</tr>
-			
-			
-			
-			
+
+
+
+
 			<?php
 			/*$custom_field_list = get_custom_fields_specimen();
 			foreach($custom_field_list as $custom_field)
@@ -4964,9 +4963,9 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 				}
 			}*/
 			?>
-			
-			
-			
+
+
+
 			<?php
 			if($form_num != 1)
 			{
@@ -5000,7 +4999,7 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 		</div>
 		<?php
 	}
-	
+
 	public function getReportResultsForm($form_name, $form_id)
 	{
 		$specimen_list = Specimen::getUnreported();
@@ -5097,8 +5096,8 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 		</table>
 		<?php
 	}
-	
-	
+
+
 	public function getGoalTatForm($lab_config_id)
 	{
 		# Returns HTML form for setting/modifying goal TAT values
@@ -5184,7 +5183,7 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 		</table>
 		<?php
 	}
-	
+
 	public function getGetGoalTatTable($lab_config_id)
 	{
 		# Returns HTML table showing existing goal TAT values
@@ -5213,7 +5212,7 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 				}
 			  	// days exists^M
 			 	if($value >= 24) {
-			  		$days = round($value/24); 
+			  		$days = round($value/24);
 			  		$hours = $value - $days*24;
 			  	}
 
@@ -5255,7 +5254,7 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 		</table>
 		<?php
 	}
-	
+
 	public function getCustomFieldTable($lab_config_id, $custom_field_list, $type)
 	{
 		# Returns a list of existing custom fields in a lab configuration
@@ -5313,7 +5312,7 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 							Edit
 							</a>
 						</td>
-						
+
 					</tr>
 				<?php
 				$count++;
@@ -5323,7 +5322,7 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 		</table>
 		<?php
 	}
-	
+
 	public function getCustomFieldTypeOptions($edit=0, $type='')
 	{
 		# Returns <select> options for custom field type
@@ -5360,7 +5359,7 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 
 	<?php
 	}
-		
+
 	public function getCustomFieldNewForm($lab_config_id)
 	{
 		# Returns HTML form field for adding a new custom field
@@ -5464,7 +5463,7 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 		</table>
 		<?php
 	}
-	
+
 	public function getCustomFieldEditForm($field_id, $lab_config_id, $type)
 	{
 		# Returns HTML form fields for editing a custom field
@@ -5481,7 +5480,7 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 			<?php
 			return;
 		}
-		
+
 		?>
 		<input type='hidden' name='id' value='<?php echo $custom_field->id; ?>'></input>
 		<input type='hidden' name='lid' value='<?php echo $lab_config_id; ?>'></input>
@@ -5618,7 +5617,7 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 					Enable:
 					</td>
 					<td>
-					
+
 					<input type="checkbox" name="Enable" value="enable" <?php if(($custom_field->flag)==0) { ?> checked <?php }?> >
 					</td>
 				</tr>
@@ -5661,7 +5660,7 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 		</table>
 		<?php
 	}
-	
+
 	public function getSpecimenTypeCheckboxes($lab_config_id=null, $allCompatibleCheckingOn=true)
 	{
 		# Returns a set of checkboxes with existing specimen types checked if allCompatibleCheckingOn is set to true,
@@ -5712,7 +5711,7 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 					echo ">$specimen_name";
 				?>
 				</input></td>
-				
+
 				<?php
 				if($count % 3 == 0)
 					echo "</tr><tr>";
@@ -5722,7 +5721,7 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 		</table>
 		<?php
 	}
-	
+
 	public function getTestTypeCheckboxes($lab_config_id=null, $allCompatibleCheckingOn=true)
 	{
 		# Returns a set of checkboxes with existing test types checked, if allCompatibleCheckingOn is set to true,
@@ -5782,7 +5781,7 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 					echo ">$test_name";
 				?>
 				</input></td>
-				
+
 				<?php
 				if($count % 3 == 0)
 					echo "</tr><tr>";
@@ -5792,7 +5791,7 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 		</table>
 		<?php
 	}
-	
+
         //NC3065
         public function getTestTypeCheckboxes_dir($lab_config_id=null, $allCompatibleCheckingOn=true)
 	{
@@ -5853,7 +5852,7 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 					echo ">$test_name";
 				?>
 				</input></td>
-				
+
 				<?php
 				if($count % 3 == 0)
 					echo "</tr><tr>";
@@ -5868,7 +5867,7 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
         public function getSearchFieldsCheckboxes($lab_config_id=null)
 	{
 		# Returns a set of checkboxes with existing fields types checked.
-		
+
 		$lab_config = get_lab_config_by_id($lab_config_id);
 		if($lab_config == null && $lab_config_id != "")
 		{
@@ -5885,7 +5884,7 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 		//else
 			//$specimen_list = get_search_fields($lab_config_id);
                         $sfields = get_search_fields($lab_config_id);
-                        $ssfields = get_lab_config_settings_search();
+                        $ssfields = get_lab_config_settings_search($lab_config_id);
                        //"SELECT pid, p_addl, daily_num, pname, age, sex, dob FROM lab_config WHERE lab_config_id=$lab_config_id";
 
 		//$current_specimen_list = array();
@@ -5895,7 +5894,7 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 		?>
 		<table class='hor-minimalist-b' style='width:700px;'>
 			<tbody>
-			
+
                         <tr>
 				<td><input type='checkbox' class='sfields_entry' name='sfields_daily_num' id='sfields_daily_num' value='1'
 				<?php
@@ -5922,7 +5921,7 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
                                         }
 				?>
 				</input></td>
-				
+
 			</tr>
 
 
@@ -5949,7 +5948,7 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
         public function getBarcodeFields($lab_config_id=null)
 	{
 		# Returns a set of checkboxes with existing fields types checked.
-		
+
 		$lab_config = get_lab_config_by_id($lab_config_id);
 		if($lab_config == null && $lab_config_id != "")
 		{
@@ -6096,7 +6095,7 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 				echo $measure_name;
 				?>
 				</input></td>
-				
+
 				<?php
 				if($count % 2 == 0)
 					echo "</tr><tr>";
@@ -6106,7 +6105,7 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 		</table>
 		<?php
 	}
-	
+
 	public function getConfirmDialog($div_id, $message, $ok_function_call, $cancel_function_call, $width=300)
 	{
 		?>
@@ -6119,7 +6118,7 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 		</div>
 		<?php
 	}
-	
+
 	public function getAlertDialog($div_id, $message, $width=300)
 	{
 		?>
@@ -6130,7 +6129,7 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 		</div>
 		<?php
 	}
-	
+
 	public function getCompatibilityJsArray($array_name, $lab_config_id=null)
 	{
 		# Returns a JavaScript array storing compatible test types for each specimen type
@@ -6143,7 +6142,7 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 			echo $array_name."[".$key."]='$test_csv'; ";
 		}
 	}
-	
+
         public function getGroupedCountReportConfigureForm($lab_config)
         {
             $configArray = getTestCountGroupedConfig($lab_config->id);
@@ -6219,7 +6218,7 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 						<div id='t_agegrouplist'>
 							<span id='t_agegrouplist_inner'>
 							<?php
-							
+
 								# Group by age enabled. Shoe prefilled form fields.
                                                             $age_parts = explode(",", $ageGroups);
 								foreach($age_parts as $age_part)
@@ -6231,7 +6230,7 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 									<input type='text' name='age_l[]' class='range_field' value='<?php echo $age_bounds[0]; ?>'></input>-<input type='text' name='age_u[]' class='range_field' value='<?php echo $age_bounds[1]; ?>'></input>&nbsp;&nbsp;&nbsp;
 									<?php
 								}
-							
+
 							?>
 							</span>
 							<br>
@@ -6299,7 +6298,7 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 						<div id='s_agegrouplist'>
 							<span id='s_agegrouplist_inner'>
 							<?php
-							
+
 								# Group by age enabled. Shoe prefilled form fields.
                                                             $sp_age_parts = explode(",", $sp_ageGroups);
 								foreach($sp_age_parts as $age_part)
@@ -6311,7 +6310,7 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 									<input type='text' name='sp_age_l[]' class='range_field' value='<?php echo $age_bounds[0]; ?>'></input>-<input type='text' name='sp_age_u[]' class='range_field' value='<?php echo $age_bounds[1]; ?>'></input>&nbsp;&nbsp;&nbsp;
 									<?php
 								}
-							
+
 							?>
 							</span>
 							<br>
@@ -6392,7 +6391,7 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 						?>><?php echo LangUtil::$generalTerms['NO']; ?></input>
 					</td>
 				</tr>
-				
+
 				<tr valign='top'>
 					<td><?php echo LangUtil::$pageTerms['AGE_UNIT']; ?></td>
 					<td>
@@ -6427,7 +6426,7 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 						<div id='agegrouplist'>
 							<span id='agegrouplist_inner'>
 							<?php
-							
+
 								# Group by age enabled. Shoe prefilled form fields.
                                                             $age_parts = explode(",", $ageGroups);
 								foreach($age_parts as $age_part)
@@ -6439,7 +6438,7 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 									<input type='text' name='age_l[]' class='range_field' value='<?php echo $age_bounds[0]; ?>'></input>-<input type='text' name='age_u[]' class='range_field' value='<?php echo $age_bounds[1]; ?>'></input>&nbsp;&nbsp;&nbsp;
 									<?php
 								}
-							
+
 							?>
 							</span>
 							<br>
@@ -6462,7 +6461,7 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 					</td>
 				</tr>
 
-				
+
                                 <tr valign='top'>
 					<td><?php echo "Counts to Display"; ?></td>
 					<td>
@@ -6548,7 +6547,7 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 						<div id='s_agegrouplist'>
 							<span id='s_agegrouplist_inner'>
 							<?php
-							
+
 								# Group by age enabled. Shoe prefilled form fields.
                                                             $sp_age_parts = explode(",", $sp_ageGroups);
 								foreach($sp_age_parts as $age_part)
@@ -6560,7 +6559,7 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 									<input type='text' name='sp_age_l[]' class='range_field' value='<?php echo $age_bounds[0]; ?>'></input>-<input type='text' name='sp_age_u[]' class='range_field' value='<?php echo $age_bounds[1]; ?>'></input>&nbsp;&nbsp;&nbsp;
 									<?php
 								}
-							
+
 							?>
 							</span>
 							<br>
@@ -7238,7 +7237,7 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 							echo $age_bounds[0]."-".$age_bounds[1];
 							echo "&nbsp;&nbsp;&nbsp;";
 						}
-					
+
 					?>
 					</td>
 				</tr>
@@ -7299,7 +7298,7 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 							echo $age_bounds[0]."-".$age_bounds[1];
 							echo "&nbsp;&nbsp;&nbsp;";
 						}
-					
+
 					?>
 					</td>
 				</tr>
@@ -7402,7 +7401,7 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 							echo $age_bounds[0]."-".$age_bounds[1];
 							echo "&nbsp;&nbsp;&nbsp;";
 						}
-					
+
 					?>
 					</td>
 				</tr>
@@ -7481,7 +7480,7 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 							echo $age_bounds[0]."-".$age_bounds[1];
 							echo "&nbsp;&nbsp;&nbsp;";
 						}
-					
+
 					?>
 					</td>
 				</tr>
@@ -7496,7 +7495,7 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 	{
 		# Returns HTML form elements for configuring aggregate reports
 		# Called from lab_config_home.php
-		
+
 		# Fetch site-wide settings for all tests from dummy record
 		$site_settings = DiseaseReport::getByKeys($lab_config->id, 0, 0);
 		if($site_settings == null)
@@ -7607,7 +7606,7 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 									# Numeric ranges
 									# Show fields to select range slots
 									$measure_to_set = true;
-									
+
 									if(count($measure_list) != 1)
 									{
 										# Show measure names if more than one.
@@ -7665,7 +7664,7 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 							}
 							?>
 						</td>
-					</tr>				
+					</tr>
 					<?php
 				}
 				?>
@@ -7691,12 +7690,12 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 	}
 
 
-	
+
 	public function getInfectionReportConfigureForm()
 	{
 		# Returns HTML form elements for configuring infection reports
 		# Called from lab_config_home.php
-		
+
 		# Fetch site-wide settings for all tests from dummy record
 		$site_settings = GlobalInfectionReport::getByKeys($_SESSION['user_id'], 0, 0);
 		?>
@@ -7801,7 +7800,7 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 									# Numeric ranges
 									# Show fields to select range slots
 									$measure_to_set = true;
-									
+
 									if(count($measure_list) != 1)
 									{
 										# Show measure names if more than one.
@@ -7849,7 +7848,7 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 							}
 							?>
 						</td>
-					</tr>				
+					</tr>
 					<?php
 				}
 				?>
@@ -7873,12 +7872,12 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 		</div>
 		<?php
 	}
-	
+
 	public function getAggregateReportSummary($lab_config)
 	{
 		# Returns HTML form elements for configuring infection report
 		# Called from lab_config_home.php
-		
+
 		# Fetch site-wide settings for all tests from dummy record
 		$site_settings = DiseaseReport::getByKeys($lab_config->id, 0, 0);
 		if($site_settings == null)
@@ -7929,7 +7928,7 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 							echo $age_bounds[0]."-".$age_bounds[1];
 							echo "&nbsp;&nbsp;&nbsp;";
 						}
-					
+
 					?>
 					</td>
 				</tr>
@@ -7965,7 +7964,7 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 									# Numeric ranges
 									# Show fields to select range slots
 									$measure_to_set = true;
-									
+
 									if(count($measure_list) != 1)
 									{
 										# Show measure names if more than one.
@@ -7983,7 +7982,7 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 									if($disease_report == null)
 									{
 										# No entry exists. Show default values.
-										echo $range_bounds[0]."-".$range_bounds[1];											
+										echo $range_bounds[0]."-".$range_bounds[1];
 									}
 									else
 									{
@@ -8009,7 +8008,7 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 							}
 							?>
 						</td>
-					</tr>				
+					</tr>
 					<?php
 				}
 				?>
@@ -8018,12 +8017,12 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 		</div>
 		<?php
 	}
-	
+
 	public function getInfectonReportSummary()
 	{
 		# Returns HTML form elements for configuring infection report for country administrators
 		# Called from reports.php
-		
+
 		# Fetch settings for all tests from dummy record
 		$site_settings = GlobalInfectionReport::getByKeys($_SESSION['user_id'], 0, 0);
 		?>
@@ -8069,7 +8068,7 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 							echo $age_bounds[0]."-".$age_bounds[1];
 							echo "&nbsp;&nbsp;&nbsp;";
 						}
-					
+
 					?>
 					</td>
 				</tr>
@@ -8105,7 +8104,7 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 									# Numeric ranges
 									# Show fields to select range slots
 									$measure_to_set = true;
-									
+
 									if(count($measure_list) != 1)
 									{
 										# Show measure names if more than one.
@@ -8115,7 +8114,7 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 									if($disease_report == null)
 									{
 										# No entry exists. Show default values.
-										echo $range_bounds[0]."-".$range_bounds[1];											
+										echo $range_bounds[0]."-".$range_bounds[1];
 									}
 									else
 									{
@@ -8139,7 +8138,7 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 							}
 							?>
 						</td>
-					</tr>				
+					</tr>
 					<?php
 				}
 				?>
@@ -8148,7 +8147,7 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 		</div>
 		<?php
 	}
-	
+
 	public function getReportConfigForm($report_config, $worksheet_config=false, $test_type_id = 0)
 	{
 		# Creates html fields for report configuration form
@@ -8191,7 +8190,7 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 					<input type='radio' name='align' value='right' <?php
 					if($report_config->alignment_header == 'right') echo " checked "; ?>>Right</input>
 				</td>
-			
+
 			<tr valign='top'>
 				<td>Header</td>
 				<td>
@@ -8259,7 +8258,7 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 					<input type='radio' name='do_landscape' value='N' <?php
 					if($report_config->landscape == false) echo " checked "; ?>><?php echo LangUtil::$generalTerms['NO']; ?></input>
 				</td>
-				
+
 			</tr>
 			<tr valign='top'>
 				<td>Clinical Data</td>
@@ -8291,7 +8290,7 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 					if($report_config->showResultBorder == 0) echo " checked "; ?> onclick="javascript:$('#R_Border').hide();"><?php echo LangUtil::$generalTerms['NO']; ?></input>
                     &nbsp;&nbsp;&nbsp;&nbsp;<span id="R_Border">
                    <input type="checkbox" name="result_box_hori" value="Y" <?php if($report_config->resultborderHorizontal == 1) echo " checked "; ?> ><?php echo  LangUtil::$pageTerms['RPT_R_BORDER_HOR'];?>&nbsp;
-                    <input type="checkbox" name="result_box_vert"  value="Y"  <?php if($report_config->resultborderVertical == 1) echo " checked "; ?>  ><?php echo LangUtil::$pageTerms['RPT_R_BORDER_VERT'];?>                  
+                    <input type="checkbox" name="result_box_vert"  value="Y"  <?php if($report_config->resultborderVertical == 1) echo " checked "; ?>  ><?php echo LangUtil::$pageTerms['RPT_R_BORDER_VERT'];?>
                     </span>
                     </td>
             </tr>
@@ -8300,7 +8299,7 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 			 if (file_exists("../logos/logo_".$report_config->labConfigId.".jpg")==true)
 			echo "LOGO being Used "; ?></h4></td></tr>
 	  		<tr><td><h3>File Upload:</h3></td><td><?php
-			
+
 	 if (file_exists("../logos/logo_".$report_config->labConfigId.".jpg")==false)
 	{echo "( Add a Logo)"; }else echo "(Change Logo)"; ?>
 	Choose a .jpg logo File to upload:
@@ -8309,8 +8308,8 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 	<br />
 	</td></tr> <?php }?>
 	<br/>
-	
-	
+
+
 		</table>
 		<table cellspacing='5px' class='smaller_font'>
 			<tr valign='top'>
@@ -8471,14 +8470,14 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 				}
 			}
 			?>
-			
+
 			<tr valign='top'<?php
 			if($report_config->reportId != 6)
 				echo " style='display:none;' ";
 			?>>
 				<td><b>Patient Daily Report - Other Fields</b></td>
 			</tr>
-			
+
 			<tr valign='top'>
 				<td>
 				<?php if($report_config->reportId == 6){?>
@@ -8492,7 +8491,7 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 				<td></td>
 			<!--<?php echo $report_config->reportId. " | Requester ".$report_config->useRequesterName." | ReferredTo ".$report_config->useReferredTo ?>-->
 			</tr>
-			
+
 			<tr valign='top'<?php
 			if($report_config->reportId != 4)
 				echo " style='display:none;' ";
@@ -8512,7 +8511,7 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 				<td></td>
 			<!--<?php echo $report_config->reportId. " | Requester ".$report_config->useRequesterName." | ReferredTo ".$report_config->useReferredTo ?>-->
 			</tr>
-				
+
 			<tr valign='top'<?php
 			if($report_config->reportId == 6)
 				echo " style='display:none;' ";
@@ -8565,7 +8564,7 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 					</input>
 					<?php echo LangUtil::$generalTerms['SPECIMEN_TYPE']; ?>
 				</td>
-				
+
 			</tr>
 			<tr valign='top'<?php
 			if($report_config->reportId == 6)
@@ -8579,7 +8578,7 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 					</input>
 					<?php echo LangUtil::$generalTerms['R_DATE']; ?>
 				</td>
-				
+
 			</tr>
 			<tr valign='top'<?php
 			if($report_config->reportId == 6)
@@ -8593,7 +8592,7 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 					</input>
 					<?php echo LangUtil::$generalTerms['COMMENTS']; ?>
 				</td>
-				
+
 			</tr>
 			<tr valign='top'<?php
 			if($report_config->reportId == 6)
@@ -8607,7 +8606,7 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 					</input>
 					<?php echo "Referred To";//LangUtil::$generalTerms['REF_OUT']; ?>
 				</td>
-				
+
 			</tr>
 			<tr valign='top'<?php
 			if($report_config->reportId == 6)
@@ -8621,8 +8620,8 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 					</input>
 					<?php echo LangUtil::$generalTerms['DOCTOR']; ?>
 				</td>
-				
-			</tr>			
+
+			</tr>
 			<?php
 			# Specimen custom fields
 			$lab_config = LabConfig::getById($report_config->labConfigId);
@@ -8632,7 +8631,7 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 				{
 					?>
 					<tr valign='top'<?php
-					
+
 				if($report_config->reportId == 6)
 					echo " style='display:none;' ";
 				?>>
@@ -8644,21 +8643,21 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 							</input>
 							<?php echo $custom_field->fieldName; ?>
 						</td>
-						
+
 					</tr>
 				<?php
 				}
 			}
 			?>
-			
+
 			<tr valign='top'<?php
 			if($report_config->reportId == 6 || $report_config->reportId == 2)
 				echo " style='display:none;' ";
 			?>>
 				<td><b><?php echo LangUtil::$generalTerms['TESTS']?></b></td>
-				
+
 			</tr>
-			
+
 
 			<?php # Test main fields ?>
 			<tr valign='top'<?php
@@ -8712,7 +8711,7 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 						?>>
 					</input>
 					<?php echo LangUtil::$generalTerms['RANGE']; ?></td>
-				
+
 			</tr>
 			<tr valign='top'<?php
 			if($report_config->reportId == 6 || $report_config->reportId == 2)
@@ -8726,7 +8725,7 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 					</input>
 					<?php echo LangUtil::$generalTerms['RESULT_COMMENTS']; ?>
 				</td>
-				
+
 			</tr>
 			<tr valign='top'<?php
 			if($report_config->reportId == 6 || $report_config->reportId == 2)
@@ -8740,7 +8739,7 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 					</input>
 					<?php echo LangUtil::$generalTerms['E_DATE']; ?>
 				</td>
-				
+
 			</tr>
 			<tr valign='top'<?php
 			if($report_config->reportId == 6 || $report_config->reportId == 2)
@@ -8754,7 +8753,7 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 					</input>
 					<?php echo LangUtil::$generalTerms['ENTERED_BY']; ?>
 				</td>
-				
+
 			</tr>
 			<tr valign='top'<?php
 			if($report_config->reportId == 6 || $report_config->reportId == 2)
@@ -8768,12 +8767,12 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 					</input>
 					<?php echo LangUtil::$generalTerms['VERIFIED_BY']; ?>
 				</td>
-				
+
 			</tr>
 			<tr valign='top'<?php
 			if($report_config->reportId == 6 || $report_config->reportId == 2)
 				echo " style='display:none;' ";
-			
+
 			?>>
 				<td>
 					<input type='checkbox' name='t_field_6' <?php
@@ -8783,7 +8782,7 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 					</input>
 					<?php echo LangUtil::$generalTerms['SP_STATUS']; ?>
 				</td>
-				
+
 			</tr>
 			<tr valign='top'<?php
 			if($report_config->reportId == 6 || $report_config->reportId == 2)
@@ -8797,7 +8796,7 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 					</input>
 					<?php echo "Confirm before print" ?>
 				</td>
-				
+
 			</tr>
 			<tr valign='top'<?php
 			if($report_config->reportId == 6 || $report_config->reportId == 2)
@@ -8811,12 +8810,12 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 					</input>
 					<?php echo "Confirm before updating results" ?>
 				</td>
-				
+
 			</tr>
 		</table>
 		<table>
 			<tr valign='top'>
-				
+
 				<td>
 					<input type='button' value='<?php echo LangUtil::$generalTerms['CMD_SUBMIT']; ?>' onclick="<?php
 					if($worksheet_config === false)
@@ -8847,15 +8846,15 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 			<tr valign='top'>
 				<td></td>
 				<td>
-					
+
 				</td>
 			</tr>
-			
+
 		</table>
 		</form>
-		<?php		
+		<?php
 	}
-	
+
 	public function getReportConfigSummary($report_config, $worksheet_config=false)
 	{
 		if($report_config == null)
@@ -8936,7 +8935,7 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 				<td><?php  echo LangUtil::$pageTerms['RPT_ITEMS_ON_ROW'];?></td>
 				<td>
 					<?php
-					echo $report_config->rowItems;					
+					echo $report_config->rowItems;
 					?>
 				</td>
 			</tr>
@@ -8965,7 +8964,7 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 						if( $report_config->resultborderVertical == 1)
 							echo ": ".LangUtil::$generalTerms['YES'];
 						else
-							echo ": ".LangUtil::$generalTerms['NO'];						 
+							echo ": ".LangUtil::$generalTerms['NO'];
 					?>
                     &nbsp;&nbsp;
                      <?php
@@ -8973,7 +8972,7 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 						if( $report_config->resultborderHorizontal == 1)
 							echo ": ".LangUtil::$generalTerms['YES'];
 						else
-							echo ": ".LangUtil::$generalTerms['NO'];						 
+							echo ": ".LangUtil::$generalTerms['NO'];
 					?>
 				</td>
 			</tr>
@@ -9040,7 +9039,7 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 					if($report_config->useGender == 1)
 						echo LangUtil::$generalTerms['GENDER'];
 					?>
-				</td>			
+				</td>
 			</tr>
 			<tr valign='top'>
 				<td>
@@ -9100,8 +9099,8 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 			<?php
 			}
 			?> <br/>
-			
-			
+
+
 			<?php
 			if($report_config->reportId == 4 || $report_config->reportId == 6){
 			 if($report_config->useRequesterName == 1 || $report_config->useReferredToHospital == 1) {
@@ -9111,8 +9110,8 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 				<td></td>
 			</tr>
 			<?php }?>
-			
-			
+
+
 			<tr valign='top'>
 				<td>
 					<?php
@@ -9130,9 +9129,9 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 				</td>
 			</tr>
 			<?php }?>
-				
+
 				<br/>
-				
+
 			<tr valign='top'<?php
 			if($report_config->reportId == 6)
 				echo " style='display:none;' ";
@@ -9173,7 +9172,7 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 						echo LangUtil::$generalTerms['R_DATE'];
 					?>
 				</td>
-				
+
 			</tr>
 			<tr valign='top'<?php
 			if($report_config->reportId == 6)
@@ -9196,8 +9195,8 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 						echo LangUtil::$generalTerms['REF_OUT'];
 					?>
 				</td>
-				
-			</tr>	
+
+			</tr>
 			<tr valign='top'<?php
 			if($report_config->reportId == 7)
 				echo " style='display:none;' ";
@@ -9208,8 +9207,8 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 						echo LangUtil::$generalTerms['DOCTOR'];
 					?>
 				</td>
-				
-			</tr>				
+
+			</tr>
 			<?php
 			# Specimen custom fields
 			$lab_config = LabConfig::getById($report_config->labConfigId);
@@ -9231,13 +9230,13 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 			<?php
 			}
 			?>
-			
+
 			<tr valign='top'<?php
 			if($report_config->reportId == 6 || $report_config->reportId == 2)
 				echo " style='display:none;' ";
 			?>>
 				<td><b><?php echo LangUtil::$generalTerms['TESTS']?></b></td>
-				
+
 			</tr>
 			<?php # Test main fields ?>
 			<tr valign='top'<?php
@@ -9306,7 +9305,7 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 						echo LangUtil::$generalTerms['E_DATE'];
 					?>
 				</td>
-				
+
 			</tr>
 			<tr valign='top'<?php
 			if($report_config->reportId == 6 || $report_config->reportId == 2)
@@ -9329,12 +9328,12 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 						echo LangUtil::$generalTerms['VERIFIED_BY'];
 					?>
 				</td>
-				
+
 			</tr>
 			<tr valign='top'<?php
 			if($report_config->reportId == 6 || $report_config->reportId == 2)
 				echo " style='display:none;' ";
-			
+
 			?>>
 				<td>
 					<?php
@@ -9342,7 +9341,7 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 						echo LangUtil::$generalTerms['SP_STATUS'];
 					?>
 				</td>
-				
+
 			</tr>
 			<tr valign='top'<?php
 			if($report_config->reportId == 6 || $report_config->reportId == 2)
@@ -9354,7 +9353,7 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 						echo 'Confirm before print';
 					?>
 				</td>
-				
+
 			</tr>
 			<tr valign='top'<?php
 			if($report_config->reportId == 6 || $report_config->reportId == 2)
@@ -9366,13 +9365,13 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 						echo 'Confirm before updating results';
 					?>
 				</td>
-				
-			</tr>			
+
+			</tr>
 			</tbody>
 		</table>
 		<?php
 	}
-	
+
 	public function getReportConfigCss($margin_list, $left_margin_line=true)
 	{
 		?>
@@ -9387,11 +9386,11 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 			{
 				echo "border-left: 1px solid black;";
 			}
-			?>			
+			?>
 		}
 	<?php
 	}
-	
+
 	public function getTableSortTip()
 	{
 		$tips_string = LangUtil::$pageTerms['TIPS_TABLESORT'];
@@ -9401,7 +9400,7 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 		</small>
 		<?php
 	}
-	
+
 	public function getDateFormatSelect($lab_config)
 	{
 		global $DATE_FORMAT_LIST, $DATE_FORMAT_PRETTY_LIST;
@@ -9417,7 +9416,7 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 			$count++;
 		}
 	}
-	
+
 	public function getExportTxtScript()
 	{
 		?>
@@ -9434,7 +9433,7 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 		</form>
 		<?php
 	}
-	
+
 	public function getRegistrationFieldsSummary($lab_config)
 	{
 		?>
@@ -9449,7 +9448,7 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 									else
 										echo "Not in use";
 									if($lab_config->pid == 1 )
-										echo "(allows duplicates)";										
+										echo "(allows duplicates)";
 									if($lab_config->pid == 2 )
 										echo " (Mandatory field) (allows duplicates)";
 									if($lab_config->pid == 4)
@@ -9660,16 +9659,16 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 							</tr>
 						</tbody>
 					</table>
-					
+
 		<?php
 	}
-	
+
 	public function getDoctorRegistrationFieldsSummary($lab_config)
 	{
 		?>
 			<table class='hor-minimalist-b' style='width:auto;'>
 							<tbody>
-								
+
 								<tr>
 									<td><?php echo LangUtil::$generalTerms['PATIENTS']; ?> - <?php echo LangUtil::$generalTerms['PATIENT_DAILYNUM']; ?></td>
 									<td>
@@ -9858,10 +9857,10 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 								</tr>
 							</tbody>
 						</table>
-						
+
 			<?php
 		}
-		
+
 	public function getPatientSearchAttribSelect($hide_patient_name=false)
 	{
             $userrr = get_user_by_id($_SESSION['user_id']);
@@ -9877,7 +9876,7 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 			$_SESSION['user_level'] == 17
 		)
 		{
-			$lab_config = LabConfig::getById($_SESSION['lab_config_id']); 
+			$lab_config = LabConfig::getById($_SESSION['lab_config_id']);
                         $patientBarcodeSearch = patientSearchBarcodeCheck();
                         echo $hide_patient_name;
                         echo $lab_config->pname ;
@@ -9960,25 +9959,25 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 			<option value='3'><?php echo LangUtil::$generalTerms['PATIENT_DAILYNUM']; ?></option>
 			<option value='0'><?php echo LangUtil::$generalTerms['PATIENT_ID']; ?></option>
 			<option value='2'><?php echo LangUtil::$generalTerms['ADDL_ID']; ?></option>
-			
-			
-			<?php 
+
+
+			<?php
                if($patientBarcodeSearch != 0 && is_country_dir($userrr) != 1 && is_super_admin($userrr) != 1 ){ ?>
                         				<option value='10'><?php echo 'Patient Barcode'; ?></option>
                                                         <?php } ?>
-                                                        
-                                                        
-            <?php 
+
+
+            <?php
                 if($specimenBarcodeSearch != 0 && is_country_dir($userrr) != 1 && is_super_admin($userrr) != 1 ){ ?>
                         				<option value='9'><?php echo 'Specimen Barcode'; ?></option>
                                                         <?php } ?>
-                                                        
-                        
+
+
 
 			<?php
 		}
 	}
-	
+
 	public function getNewCustomWorksheetForm($lab_config)
 	{
 		if($lab_config == null)
@@ -10064,7 +10063,7 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 					<small><a href='javascript:add_another_uf();'><?php echo LangUtil::$generalTerms['ADDANOTHER']; ?>&raquo;</a></small>
 				</td>
 			</tr>
-			
+
 			<tr valign='top'>
 				<td><?php echo LangUtil::$generalTerms['LAB_SECTION']; ?></td>
 				<td>
@@ -10159,7 +10158,7 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 			<?php
 			}
 			?>
-				
+
 			<tr valign='top'>
 				<td><b><?php echo LangUtil::$generalTerms['SPECIMENS']?></b></td>
 			</tr>
@@ -10180,7 +10179,7 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 					</input>
 					<?php echo LangUtil::$generalTerms['SPECIMEN_TYPE']; ?>
 				</td>
-				
+
 			</tr>
 			<tr valign='top'>
 				<td>
@@ -10188,7 +10187,7 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 					</input>
 					<?php echo LangUtil::$generalTerms['R_DATE']; ?>
 				</td>
-				
+
 			</tr>
 			<tr valign='top'>
 				<td>
@@ -10196,7 +10195,7 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 					</input>
 					<?php echo LangUtil::$generalTerms['COMMENTS']; ?>
 				</td>
-				
+
 			</tr>
 			<tr valign='top'>
 				<td>
@@ -10204,7 +10203,7 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 					</input>
 					<?php echo LangUtil::$generalTerms['REF_OUT']; ?>
 				</td>
-				
+
 			</tr>
 			<tr valign='top'>
 				<td>
@@ -10212,8 +10211,8 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 					</input>
 					<?php echo LangUtil::$generalTerms['DOCTOR']; ?>
 				</td>
-				
-			</tr>			
+
+			</tr>
 			<?php
 			# Specimen custom fields
 			$custom_field_list = $lab_config->getSpecimenCustomFields();
@@ -10226,7 +10225,7 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 						</input>
 						<?php echo $custom_field->fieldName; ?>
 					</td>
-					
+
 				</tr>
 			<?php
 			}
@@ -10243,7 +10242,7 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 		?>
 		<br>
 		<div id='test_boxes' class='smaller_font' style='width:auto;'>
-		
+
 		</div>
 		<input type='button' value='<?php echo LangUtil::$generalTerms['CMD_SUBMIT']; ?>' id='worksheet_submit_button' onclick='javascript:submit_worksheet_form();'>
 		</input>
@@ -10257,9 +10256,9 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 		<span id='worksheet_submit_progress' style='display:none;'>
 			<?php $this->getProgressSpinner(LangUtil::$generalTerms['CMD_SUBMITTING']); ?>
 		</span>
-		<?php		
+		<?php
 	}
-	
+
 	public function getCustomWorksheetSummary($worksheet)
 	{
 		?>
@@ -10361,7 +10360,7 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 						echo LangUtil::$pageTerms['COLUMN_WIDTH'].": ";
 						echo $field_width;
 						echo ")";
-						echo "<br>";						
+						echo "<br>";
 					}
 					?>
 					</span>
@@ -10417,7 +10416,7 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 	</div>
 	<?php
 	}
-	
+
 	public function getCustomWorksheetSelect($lab_config)
 	{
 		if($lab_config == null)
@@ -10431,7 +10430,7 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 			echo "<option value='$worksheet->id'>$worksheet->name</option>";
 		}
 	}
-	
+
 	public function getCustomWorksheetTable($lab_config)
 	{
 		echo "Custom Worksheets";
@@ -10488,7 +10487,7 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 		</table>
 		<?php
 	}
-	
+
 	public function getEditCustomWorksheetForm($worksheet_id, $lab_config)
 	{
 		if($lab_config == null)
@@ -10631,7 +10630,7 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 					$record = query_associative_one($query_string);
 					$cat_code = $record['test_category_id'];
 					$cat_name = get_test_category_name_by_id($cat_code);
-					DbUtil::switchRestore($saved_db);				
+					DbUtil::switchRestore($saved_db);
 					echo $cat_name;
 					?>
 				</td>
@@ -10711,7 +10710,7 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 				toggle_mlist(this);
 			});
 		});
-		
+
 		function toggle_mlist(elem)
 		{
 			var target_div = elem.name+"_mlist";
@@ -10727,14 +10726,14 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 		</script>
 		<?php
 	}
-	
+
 	public function getBackupRevertRadio($field_name, $lab_config_id)
 	{
 		# Returns radio options for selecting one among existing backup directories
 		$folder_list = get_backup_folders($lab_config_id);
 		if($folder_list === null || count($folder_list) == 0)
 		{
-			echo LangUtil::$generalTerms['MSG_NOTFOUND'];			
+			echo LangUtil::$generalTerms['MSG_NOTFOUND'];
 			return;
 		}
 		$count = 0;
@@ -10752,14 +10751,14 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 			$count++;
 		}
 	}
-	
+
 	public function getPatientSearchCondition()
 	{
 		?>
         	<option value='%[pq]%'><?php echo LangUtil::getSearchCondition('SEARCH_CONTAINS'); ?></option>
-			<option value='[pq]%'><?php echo LangUtil::getSearchCondition('SEARCH_BEGIN_WITH'); ?></option>           
+			<option value='[pq]%'><?php echo LangUtil::getSearchCondition('SEARCH_BEGIN_WITH'); ?></option>
 		<?php
-		
+
 	}
 
 	public function getToggleTestReportsForm()
@@ -10850,11 +10849,11 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 	    foreach ($tests as $test)
 				echo "<option id='$test->testTypeId' value='$test->testTypeId'>".$test->name."</option>";
 	}
-	
+
 	//starting point of changes
-	public function getBatchResultsFieldsForm()
+	public function getBatchResultsFieldsForm($lab_config_id)
 	{
-		$lab_config = LabConfig::getById($_SESSION['lab_config_id']);	
+		$lab_config = LabConfig::getById($lab_config_id);
 		$report_config = $lab_config->getAnyWorksheetConfig();
 		// echo $report_config->usePatientId, "hello";
 		// echo "<br>";
@@ -10982,7 +10981,7 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 
 		</table>
 
-	<?php	
+	<?php
 	}
 	// ending point of changes
 
@@ -10993,7 +10992,7 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 		<table cellspacing='5px' class='smaller_font'>
 			<tr valign='top'>
 				<td><b><?php echo LangUtil::$generalTerms['PATIENT_FIELDS']?></b></td>
-                <td></td>               
+                <td></td>
 				<td><b><?php echo LangUtil::$generalTerms['PATIENT_ORDERED_FIELDS']?></b></td>
                 <td></td>
 			</tr>
@@ -11001,21 +11000,21 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 			<tr valign='top'>
             <td>
             <input type="hidden" id="p_fields_left" name="p_fields_left" />
-            <input type="hidden" id="o_fields_left" name="o_fields_left" />                         
+            <input type="hidden" id="o_fields_left" name="o_fields_left" />
             <select id="p_fields" name="p_fields"  size="15" onchange="javascript:setSel(this);">
-            <?php 
+            <?php
 			 $combined_fields =$SYSTEM_PATIENT_FIELDS;
-				$lab_config = LabConfig::getById($_SESSION['lab_config_id']);				
+				$lab_config = LabConfig::getById($_SESSION['lab_config_id']);
 				if( $lab_config ) {
 					$custom_field_list = $lab_config->getPatientCustomFields();
 					foreach($custom_field_list as $custom_field)
 					{
 						 $custom_array = array ("p_custom_$custom_field->id" => $custom_field->fieldName);
 						 $combined_fields = array_merge($combined_fields,$custom_array);
-					
+
 					}
 				}
-			
+
 			$record=Patient::getReportfieldsOrder();
 			if((!is_array($record)) or (is_array($record) and (strlen(trim($record["o_fields"])) ==0)))
 			{
@@ -11023,26 +11022,26 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 				{?>
 					<option value="<?php echo $field ?>">
 						<?php
-						if(!stristr($field,"custom")) 
-							echo LangUtil::$generalTerms[$text]; 
-							
+						if(!stristr($field,"custom"))
+							echo LangUtil::$generalTerms[$text];
+
 						else
 							echo $text;
 						?></option>
-                
+
 				<?php
-				}		
-				
+				}
+
 			}
 			else
 			{
-				$unordered=explode(",",$record['p_fields']);				
+				$unordered=explode(",",$record['p_fields']);
 				foreach( $unordered as $field)
 				{
 				?>
-				<option value="<?php echo $field ?>"><?php 
-				if(!stristr($field,"custom")) 
-					echo LangUtil::$generalTerms[$combined_fields[$field]]; 
+				<option value="<?php echo $field ?>"><?php
+				if(!stristr($field,"custom"))
+					echo LangUtil::$generalTerms[$combined_fields[$field]];
 				else
 					echo $combined_fields[$field];
 					?></option>
@@ -11050,60 +11049,60 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 				}
             }
 			?>
-            
+
             </select>
             </td>
-            <td valign="middle"> 
-            <input type="button" name="AddOrder" id="AddOrder" value=">" disabled="disabled"  onclick="javascript:setOrder();"/> 
+            <td valign="middle">
+            <input type="button" name="AddOrder" id="AddOrder" value=">" disabled="disabled"  onclick="javascript:setOrder();"/>
             <input type="button" name="RemOrder" id="RemOrder" value="<" disabled="disabled"  onclick="javascript:remOrder();" />
             </td>
             <td><select id="o_fields" name="o_fields" size="15" onchange="javascript:setSel(this);">
             <?php
 			if(is_array($record) and (strlen(trim($record["o_fields"]))>0))
 			{
-				$ordered=explode(",",$record['o_fields']);				
+				$ordered=explode(",",$record['o_fields']);
 				foreach( $ordered as $field)
 				{
 				?>
-				<option value="<?php echo $field ?>"><?php 
-				if(!stristr($field,"custom")) 
-					echo LangUtil::$generalTerms[$combined_fields[$field]]; 
+				<option value="<?php echo $field ?>"><?php
+				if(!stristr($field,"custom"))
+					echo LangUtil::$generalTerms[$combined_fields[$field]];
 				else
 					echo $combined_fields[$field];?></option>
 			<?php
 				}
             }
-			?>			
-            </select>          
+			?>
+            </select>
             </td>
             <td valign="middle">
-            <input type="button" id="o_up" name="o_up" value="Move Up"  onclick="javascript:reorder('up');"/><br /> 
-             <input type="button" id="o_down" name="o_down" value="Move Down" onclick="javascript:reorder('down');" />  
+            <input type="button" id="o_up" name="o_up" value="Move Up"  onclick="javascript:reorder('up');"/><br />
+             <input type="button" id="o_down" name="o_down" value="Move Down" onclick="javascript:reorder('down');" />
             </td>
             </tr>
             <tr>
-            
+
             <td> <br />   <input type='button' value='<?php echo LangUtil::$generalTerms['CMD_SUBMIT']; ?>' id='ordered_fields_submit' onclick='javascript:submit_ordered_fields_form();'>
 		</input><small>
 		<a href='lab_config_home.php?id=<?php echo $lab_config->id; ?>'>
 			<?php echo LangUtil::$generalTerms['CMD_CANCEL']; ?>
 		</a>
 		</small>
-		</td>           
+		</td>
             <td>&nbsp;&nbsp;&nbsp;
 		<span id='ordered_fields_submit_progress' style='display:none;'>
 			<?php $this->getProgressSpinner(LangUtil::$generalTerms['CMD_SUBMITTING']); ?>
 		</span></td> <td></td>
             </tr>
             </table>
-                 
+
        <script type='text/javascript'>
 		var selvalue;
 		var seltext;
-		var selIndex;		
+		var selIndex;
 		function setSel(sel)
 		{
-			
+
 			selvalue=sel.options[sel.selectedIndex].value;
 			seltext=sel.options[sel.selectedIndex].text;
 			selIndex=sel.selectedIndex;
@@ -11118,41 +11117,41 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 				document.getElementById("AddOrder").disabled=true;
 			}
 		}
-		
+
 		function setOrder()
 		{
 			var opt = document.createElement("option");
-			document.getElementById("o_fields").options.add(opt);       
+			document.getElementById("o_fields").options.add(opt);
 			opt.text = seltext;
-			opt.value = selvalue;		
+			opt.value = selvalue;
 			document.getElementById("p_fields").options.remove(selIndex);
 			document.getElementById("AddOrder").disabled=true;
 		}
-		
+
 		function remOrder()
 		{
 			var opt = document.createElement("option");
-			document.getElementById("p_fields").options.add(opt);       
+			document.getElementById("p_fields").options.add(opt);
 			opt.text = seltext;
-			opt.value = selvalue;		
+			opt.value = selvalue;
 			document.getElementById("o_fields").options.remove(selIndex);
 			document.getElementById("RemOrder").disabled=true;
 		}
-		
+
 		function reorder(direction)
 		{
-					
-			var o_fields=document.getElementById("o_fields");			
-			var newIndex=0;			
-			
+
+			var o_fields=document.getElementById("o_fields");
+			var newIndex=0;
+
 			if(direction=="up")
 				newIndex=selIndex-1;
 			else
-				newIndex=selIndex+1;						
-			
+				newIndex=selIndex+1;
+
 			if(newIndex >=o_fields.options.length || newIndex < 0)
 				return;
-			
+
 			var keys = new Array();
 			var texts = new Array();
 			var tempkey="";
@@ -11160,40 +11159,40 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 				for(var i=0;i<o_fields.options.length;i++)
 				{
 					keys[i] = o_fields.options[i].value;
-					texts[i] = o_fields.options[i].text;					
-				}	
-				
+					texts[i] = o_fields.options[i].text;
+				}
+
 				while(o_fields.options.length>0)
 				{
 					o_fields.options.remove(0);
 				}
-				
+
 				tempkey=keys[newIndex];
 				temptext=texts[newIndex];
-				
+
 				keys[newIndex]=keys[selIndex];
 				texts[newIndex]=texts[selIndex];
-				
+
 				keys[selIndex]=tempkey;
 				texts[selIndex]=temptext;
-				
+
 				for(var i=0;i<keys.length;i++)
-				{			
+				{
 					var opt = document.createElement("option");
-					o_fields.options.add(opt);       
+					o_fields.options.add(opt);
 					opt.text = texts[i];
-					opt.value = keys[i];							
-				}	
-				
+					opt.value = keys[i];
+				}
+
 			o_fields.selectedIndex=newIndex;
 			selIndex=newIndex;
-			
+
 		}
-		</script>			
+		</script>
   <?php
 	}
 	public function DHIMS2ConfigsForm($lab_config_id)
-	{ ?>    
+	{ ?>
    	<div class='pretty_box' style='width:800px;'>
    	  <table class='hor-minimalist-b'>
             <tr>
@@ -11203,49 +11202,49 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
     	<tbody>
         <tr>
         <td>Username:</td>
-        <td><input type="text"  name="dhims2username"  id="dhims2username"/></td>  
-        </tr>      
+        <td><input type="text"  name="dhims2username"  id="dhims2username"/></td>
+        </tr>
         <tr>
          <td>Password:</td>
-        <td><input type="password"  name="dhims2password"  id="dhims2password"/></td>       
-       
+        <td><input type="password"  name="dhims2password"  id="dhims2password"/></td>
+
         </tr>
         <tr>
          <td></td>
         <td><input type="button" id="dhims2Authenticate" name="dhims2Authenticate" value="Authenticate" onclick="javascript:authenticateDHIMS2();" />
         	<span id='DHIMS2AuthenticateProgress' style='display:none'>
             <br />
-											<?php $this->getProgressSpinner("Connecting to DHIMS2, Please wait..."); 
+											<?php $this->getProgressSpinner("Connecting to DHIMS2, Please wait...");
 											?>
-                                            
-		  </span>  
-        </td>       
-       
+
+		  </span>
+        </td>
+
         </tr>
          <tr>
          <td>Organisation Unit:</td>
-        <td><select id="dhims2orgunit" name="dhims2orgunit" onchange="javascript:getDHIMS2DataSet(this.value);">        
+        <td><select id="dhims2orgunit" name="dhims2orgunit" onchange="javascript:getDHIMS2DataSet(this.value);">
         </select><span id='DHIMS2orgunitProgress' style='display:none'>
             <br />
-											<?php $this->getProgressSpinner("Connecting to DHIMS2, Please wait..."); 
+											<?php $this->getProgressSpinner("Connecting to DHIMS2, Please wait...");
 											?>
-                                            
-										</span>  </td>       
-       
+
+										</span>  </td>
+
         </tr>
         <th></th>
           <th><b>Dataset Mapping:</b></th>
           </tr>
          <tr>
          <td>Dataset:</td>
-        <td><select id="dhims2dataset" name="dhims2dataset" onchange="javascript:getDHIMS2DataElements(this.value);">       
+        <td><select id="dhims2dataset" name="dhims2dataset" onchange="javascript:getDHIMS2DataElements(this.value);">
         </select><a style="display:none" id="DHIMS2datasetProgressRetry" href="javascript:getDHIMS2DataElements(null);">Retry</a><span id='DHIMS2datasetProgress' style='display:none'>
             <br />
-											<?php $this->getProgressSpinner("Connecting to DHIMS2, Please wait..."); 
+											<?php $this->getProgressSpinner("Connecting to DHIMS2, Please wait...");
 											?>
-                                            
-										</span> </td>       
-       
+
+										</span> </td>
+
         </tr>
         <tr>
         <td>Entry Period:</td>
@@ -11253,7 +11252,7 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
         </tr>
        <tr><th></th>
           <th><b>DataElements Mapping:</b></th>
-        </tr>     
+        </tr>
         </tbody>
         </table>
         <table class='hor-minimalist-b'>
@@ -11264,22 +11263,22 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
           </tr>
            <tr valign="middle">
          <td>DataElement:<select id="dhims2dataelement" name="dhims2dataelement" onchange="javascript:getDHIMS2CatComboOptions(this.value);">
-        
+
         </select><a style="display:none" id="DHIMS2ElementProgressRetry" href="javascript:getDHIMS2CatComboOptions(null);">Retry</a><span id='DHIMS2ElementProgress' style='display:none'>
             <br />
-											<?php $this->getProgressSpinner("Connecting to DHIMS2, Please wait..."); 
+											<?php $this->getProgressSpinner("Connecting to DHIMS2, Please wait...");
 											?>
-                                            
+
 										</span> </td>
-        <td valign="middle">   
+        <td valign="middle">
         <select id="blis2dataelement" name="blis2dataelement" class='uniform_width' onchange="javascript:setSelB(this);">
         <option value="">-</option>
         <?php
 			$this->getTestTypesSelect($lab_config_id->id);
 		?>
         </select><input type="button" id="addBlisTest" value=">" onclick="javascript:addtoBlisList();" /><input type="button" id="removeBlisTest"  onclick="javascript: remBOrder();" value="<" /></td><td>Selected:<select id="blistestSelected" name="blistestSelected" size="5" onchange="javascript: setSelB(this);">
-        </select></td> 
-           </tr>      
+        </select></td>
+           </tr>
           <tr>
          <td>Date Range:<select id="dhims2catCombo" name="dhims2catCombo">
          </select></td>
@@ -11300,10 +11299,10 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 		}
 		?>
         </select>
-        
+
         Sex:<input type="text" id="blisgender" name="blisgender" size="1" value="B" /><input type="button" id="addtolist" name="addtolist" value="Apply"  onclick="javascript:AddnewDHIMS2Config();" disabled="disabled"/><span id='DHIMS2ApplyProgress' style='display:none'>
-											<?php $this->getProgressSpinner(LangUtil::$generalTerms['CMD_SUBMITTING']); 
-											?>                                            
+											<?php $this->getProgressSpinner(LangUtil::$generalTerms['CMD_SUBMITTING']);
+											?>
 										</span>
          <input type="hidden" name="dhims2orgunit_text"  id="dhims2orgunit_text" />
          <input type="hidden" name="dhims2dataset_text" id="dhims2dataset_text" />
@@ -11311,71 +11310,71 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
          <input type="hidden" name="blis2dataelement_text" id="blis2dataelement_text" />
          <input type="hidden" name="dhims2catCombo_text" id="dhims2catCombo_text" />
          <input type="hidden" name="lid" id="lid" value="<?php echo $lab_config_id->id?>" />
-        </td>       
-       
+        </td>
+
         </tr>
         <tr>
         <td colspan="3"><?php $this->getDHIMSConfigs($lab_config_id->id);?></td>
         </tr>
           <tr>
          <td colspan="3" align="center"><a href="javascript:toggle_DHIMS2();"><?php echo LangUtil::$generalTerms['CMD_CANCEL']; ?></a></td>
-           
+
         </tr>
          </tbody>
-        </table>         
+        </table>
     </div>
-	<?php	
+	<?php
 	}
-	
-	
+
+
 	public function getDHIMSConfigs($lab_config_id)
 	{
 		?>
         <script type='text/javascript'>
 		var selvalue;
 		var seltext;
-		var selIndex;		
+		var selIndex;
 		function setSelB(sel)
-		{			
+		{
 			selvalue=sel.options[sel.selectedIndex].value;
 			seltext=sel.options[sel.selectedIndex].text;
-			selIndex=sel.selectedIndex;			
+			selIndex=sel.selectedIndex;
 		}
 		function addtoBlisList()
-		{			
+		{
 			 if (isNaN(parseInt(selvalue)))
 				return;
-			
+
 			var opt = document.createElement("option");
-			document.getElementById("blistestSelected").options.add(opt);       
+			document.getElementById("blistestSelected").options.add(opt);
 			opt.text = seltext;
-			opt.value = selvalue;		
+			opt.value = selvalue;
 			//document.getElementById("p_fields").options.remove(selIndex);
 			//document.getElementById("AddOrder").disabled=true;
 		}
-		
+
 		function remBOrder()
 		{
 			if (isNaN(parseInt(selvalue)))
 				return;
 			//var opt = document.createElement("option");
-			//document.getElementById("p_fields").options.add(opt);       
+			//document.getElementById("p_fields").options.add(opt);
 			//opt.text = seltext;
-			//opt.value = selvalue;		
+			//opt.value = selvalue;
 			document.getElementById("blistestSelected").options.remove(selIndex);
 			//document.getElementById("remBOrder").disabled=true;
 		}
 		var zTree, rMenu;
 		$(document).ready(function(){
-			showTree();			
+			showTree();
 			zTree = $.fn.zTree.getZTreeObj("treeDemo");
 			rMenu = $("#rMenu");
 
 		});
-		
+
 		function showTree()
 		{
-			//alert("here");			
+			//alert("here");
 			var setting = {
 				check: {
 					enable: true
@@ -11384,7 +11383,7 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 					enable: true,
 					url:"ajax/getDHIMS2Config.php",
 					autoParam:["id", "name=n", "level=lv"],
-					otherParam:{"l":"<?php echo $lab_config_id ?>"}				
+					otherParam:{"l":"<?php echo $lab_config_id ?>"}
 				},
 				callback: {
 					onRightClick: OnRightClick
@@ -11394,14 +11393,14 @@ $name_list = array("yyyy_to".$count, "mm_to".$count, "dd_to".$count);
 						enable: true
 					}
 				}
-			};	
-		
-			try{	
+			};
+
+			try{
 				$.fn.zTree.init($("#treeDemo"), setting);
 				$.fn.zTree.init($("#treeDemo2"), setting);
 			}catch(err){ alert(err.message);}
 		}
-			
+
 function OnRightClick(event, treeId, treeNode) {
 			if (!treeNode && event.target.tagName.toLowerCase() != "button" && $(event.target).parents("a").length == 0) {
 				zTree.cancelSelectedNode();
@@ -11468,11 +11467,11 @@ function OnRightClick(event, treeId, treeNode) {
 				}
 			}
 		}
-		
+
 		var listtodelete="";
-		
+
 		function prepareDeleteList(node)
-		{			
+		{
 			if (node.children && node.children.length > 0)
 			{
 				for(var i=0; i<node.children.length;i++)
@@ -11488,7 +11487,7 @@ function OnRightClick(event, treeId, treeNode) {
 					listtodelete = node.ename;
 			}
 		}
-		
+
 		function deleteItems()
 		{
 			//alert(listtodelete);
@@ -11498,29 +11497,29 @@ function OnRightClick(event, treeId, treeNode) {
 				resetTree();
 			}});
 		}
-		
+
 		function resetTree() {
 			hideRMenu();
 			showTree();
 		}
-		
+
 		function hideNodes()
 		{
 			var zTree = $.fn.zTree.getZTreeObj("treeDemo");
 			var nodes = zTree.getNodes();
 			for(var i=0;i<nodes.length;i++)
-			{	
-				zTree.hideNodes(nodes[i].children);	
-				zTree.hideNode(nodes[i]);		
+			{
+				zTree.hideNodes(nodes[i].children);
+				zTree.hideNode(nodes[i]);
 			}
 		}
-		
+
 		function showNodes()
 		{
 			var zTree = $.fn.zTree.getZTreeObj("treeDemo");
 			var nodes = zTree.getNodes();
 			for(var i=0;i<nodes.length;i++)
-			{	
+			{
 				zTree.showNodes(nodes[i].children);
 			}
 		}
@@ -11529,7 +11528,7 @@ function OnRightClick(event, treeId, treeNode) {
 			//var value = $('#listSearch').attr('value');
 			$('#listSearch').attr('value','');
 		}
-		
+
 		function searchList(value)
 		{
 			hideNodes();
@@ -11538,31 +11537,31 @@ function OnRightClick(event, treeId, treeNode) {
 			var node;
 			var value = value;
 			var keyType = "name";
-			nodeList = zTree.getNodesByParamFuzzy(keyType, value);	
+			nodeList = zTree.getNodesByParamFuzzy(keyType, value);
 			for(var i=0;i<nodeList.length;i++)
 			{
-				showNode(nodeList[i]);		
-			}				
-				
+				showNode(nodeList[i]);
+			}
+
 		}
-		
+
 		function showNode(node)
 		{
 			var flag = false;
-			try{			
+			try{
 				var nodeParent = node.getParentNode();
 				flag = true;
-			}catch(err){ nodeParent = "";}			
+			}catch(err){ nodeParent = "";}
 			var zTree = $.fn.zTree.getZTreeObj("treeDemo");
-			zTree.showNode(node);	
+			zTree.showNode(node);
 			if(flag)
 			{
-				//alert("hasParent");				
-				showNode(nodeParent);				
+				//alert("hasParent");
+				showNode(nodeParent);
 			}
 		}
-		
-				
+
+
 		function resetsearch()
 		{
 			var value = $('#listSearch').attr('value');
@@ -11571,21 +11570,21 @@ function OnRightClick(event, treeId, treeNode) {
 				$('#listSearch').attr('value','Search here');
 				showNodes();
 			}
-			
+
 		}
 		</script>
-        
+
         <table class='tablesorter' id='dhims_config_list'  style='width:750px'>
 	<thead>
     <tr align='left'>
     <th colspan="4"><b>Saved Interface mappings</b>&nbsp;&nbsp;(Right click on item to delete or show details)&nbsp;&nbsp;
-    <input type="text" id="listSearch" name="listSearch" value="Search here" onclick="javascript:clearsearch();" onkeyup="javascript:searchList(this.value);" onblur="javascript:resetsearch();" /> </th>  
-   
+    <input type="text" id="listSearch" name="listSearch" value="Search here" onclick="javascript:clearsearch();" onkeyup="javascript:searchList(this.value);" onblur="javascript:resetsearch();" /> </th>
+
     </tr>
     </thead>
     <tbody>
     <tr align='left'>
-    <td colspan="4"><ul id="treeDemo" class="ztree"></ul></td>    
+    <td colspan="4"><ul id="treeDemo" class="ztree"></ul></td>
     </tr>
     </tbody>
     </table>
@@ -11593,49 +11592,49 @@ function OnRightClick(event, treeId, treeNode) {
     <style type="text/css">._css3m{display:none}</style>
     <style type="text/css">
 div#rMenu {position:absolute; visibility:visible; top:0;}
-div#rMenu ul li{	
+div#rMenu ul li{
 	cursor: pointer;
-	list-style: none outside none;	
+	list-style: none outside none;
 }
 
 	</style>
 
     <div id="rMenu">
-	<ul id="css3menu1">	
-	<ul>		
+	<ul id="css3menu1">
+	<ul>
 		<li><a href="javascript:removeTreeNode();">Delete Node</a></li>
 		<li class="sublast"><a href="javascript:resetTree();">Refresh Tree</a></li>
-        
-	</ul>	
+
+	</ul>
 </ul>
 </div>
 
-        <?php		
+        <?php
 	}
 	public function DHIMS2ConfigsSummary($lab_config_id)
-	{ ?>   
+	{ ?>
     	<div class='pretty_box' style='width:750px;'>
 		  <table class='tablesorter' id='dhims_config_list'  style='width:750px'>
 			<thead>
     			<tr align='left'>
-    			<th colspan="4"><b>Saved Interface mappings</b></th>  	   
+    			<th colspan="4"><b>Saved Interface mappings</b></th>
     			</tr>
     		</thead>
     		<tbody>
     			<tr align='left'>
-    			<td colspan="4"><ul id="treeDemo2" class="ztree"></ul></td>    
+    			<td colspan="4"><ul id="treeDemo2" class="ztree"></ul></td>
     			</tr>
     		</tbody>
     	  </table>
    		</div>
-	<?php	
+	<?php
 	}
 
-	
+
 	public function getEquipmentList()
 	{
 		# Returns a set of drop down options for equipment List
-		$list = getEquipmentList();		
+		$list = getEquipmentList();
 		if(is_array($list) && count($list) > 0)
 		{
 			foreach($list as $Equipment)
@@ -11643,7 +11642,7 @@ div#rMenu ul li{
 				echo "<option value='".$Equipment['id']."'>".$Equipment['equipment_name']."</option>";
 			}
 		}
-		
+
 	}
 }
 

--- a/htdocs/includes/stats_lib.php
+++ b/htdocs/includes/stats_lib.php
@@ -26,7 +26,7 @@ function get_tests_done_count($lab_config, $test_type_id, $date_from, $date_to)
 {
 	$query_string = "";
 	if($date_from == "" || $date_to == "") {
-		$query_string = 
+		$query_string =
 			"SELECT COUNT(*) as count_val FROM test ".
 			"WHERE result <> '' ".
 			"AND test_type_id=$test_type_id";
@@ -56,10 +56,10 @@ function get_test_count_grouped($test_type_id, $date_from, $date_to, $gender, $a
 
     $l_age_s = "-".$age_to." ".$age_unit;
     $l_age_t = strtotime($l_age_s);
-    
+
     $u_age_s = "-".$age_from." ".$age_unit;
     $u_age_t = strtotime($u_age_s);
-    
+
     $l_age_d = date('Y-m-d', $l_age_t);
     $u_age_d = date('Y-m-d', $u_age_t);
     $query_filter_dob = "dob >= '$l_age_d' AND dob < '$u_age_d'";
@@ -74,7 +74,7 @@ function get_test_count_grouped($test_type_id, $date_from, $date_to, $gender, $a
     $l_age = (date("md", date("U", $u_age_t)) > date("md")
     ? ((date("Y") - $u_age_temp[0]) - 1)
     : (date("Y") - $u_age_temp[0]));
-    
+
     $l_age_m = date('Y-m', $l_age_t);
     $u_age_m = date('Y-m', $u_age_t);
     $query_filter_partial_dob_yyyy_mm = "partial_dob >= '$l_age_m' AND partial_dob < '$u_age_m'";
@@ -83,7 +83,7 @@ function get_test_count_grouped($test_type_id, $date_from, $date_to, $gender, $a
     $u_age_y = date('Y', $u_age_t);
     $query_filter_partial_dob_yyyy = "partial_dob >= '$l_age_y' AND partial_dob < '$u_age_y'";
 
-   
+
     //$query_string = "SELECT count(*) as count_val FROM test WHERE test_type_id = $test_type_id";
     if($completed == 0)
     {
@@ -283,10 +283,10 @@ function get_test_count_grouped_country_dir($test_type_id, $date_from, $date_to,
 
     $l_age_s = "-".$age_to." ".$age_unit;
     $l_age_t = strtotime($l_age_s);
-    
+
     $u_age_s = "-".$age_from." ".$age_unit;
     $u_age_t = strtotime($u_age_s);
-    
+
     $l_age_d = date('Y-m-d', $l_age_t);
     $u_age_d = date('Y-m-d', $u_age_t);
     $query_filter_dob = "dob >= '$l_age_d' AND dob < '$u_age_d'";
@@ -301,7 +301,7 @@ function get_test_count_grouped_country_dir($test_type_id, $date_from, $date_to,
     $l_age = (date("md", date("U", $u_age_t)) > date("md")
     ? ((date("Y") - $u_age_temp[0]) - 1)
     : (date("Y") - $u_age_temp[0]));
-    
+
     $l_age_m = date('Y-m', $l_age_t);
     $u_age_m = date('Y-m', $u_age_t);
     $query_filter_partial_dob_yyyy_mm = "partial_dob >= '$l_age_m' AND partial_dob < '$u_age_m'";
@@ -309,7 +309,7 @@ function get_test_count_grouped_country_dir($test_type_id, $date_from, $date_to,
     $l_age_y = date('Y', $l_age_t);
     $u_age_y = date('Y', $u_age_t);
     $query_filter_partial_dob_yyyy = "partial_dob >= '$l_age_y' AND partial_dob < '$u_age_y'";
-   
+
     //$query_string = "SELECT count(*) as count_val FROM test WHERE test_type_id = $test_type_id";
     if($completed == 0)
     {
@@ -363,7 +363,7 @@ function get_test_count_grouped_country_dir($test_type_id, $date_from, $date_to,
 function get_test_count_grouped2($test_type_id, $date_from, $date_to, $gender, $completed = 0, $section = 0)
 {
     $query_string = "";
-    
+
     //$query_string = "SELECT count(*) as count_val FROM test WHERE test_type_id = $test_type_id";
     if($completed == 0)
     {
@@ -413,10 +413,10 @@ function get_specimen_count_grouped_country_dir($specimen_type_id, $date_from, $
 
     $l_age_s = "-".$age_to." ".$age_unit;
     $l_age_t = strtotime($l_age_s);
-    
+
     $u_age_s = "-".$age_from." ".$age_unit;
     $u_age_t = strtotime($u_age_s);
-    
+
     $l_age_d = date('Y-m-d', $l_age_t);
     $u_age_d = date('Y-m-d', $u_age_t);
     $query_filter_dob = "dob >= '$l_age_d' AND dob < '$u_age_d'";
@@ -431,7 +431,7 @@ function get_specimen_count_grouped_country_dir($specimen_type_id, $date_from, $
     $l_age = (date("md", date("U", $u_age_t)) > date("md")
     ? ((date("Y") - $u_age_temp[0]) - 1)
     : (date("Y") - $u_age_temp[0]));
-    
+
     $l_age_m = date('Y-m', $l_age_t);
     $u_age_m = date('Y-m', $u_age_t);
     $query_filter_partial_dob_yyyy_mm = "partial_dob >= '$l_age_m' AND partial_dob < '$u_age_m'";
@@ -485,17 +485,17 @@ function get_specimen_count_grouped_country_dir($specimen_type_id, $date_from, $
 #nc40
 function get_specimen_count_grouped($specimen_type_id, $date_from, $date_to, $gender, $age_from, $age_to, $completed = 0, $section = 0)
 {
-    
+
     $age_unit = "years";
 
     $query_string = "";
 
     $l_age_s = "-".$age_to." ".$age_unit;
     $l_age_t = strtotime($l_age_s);
-    
+
     $u_age_s = "-".$age_from." ".$age_unit;
     $u_age_t = strtotime($u_age_s);
-    
+
     $l_age_d = date('Y-m-d', $l_age_t);
     $u_age_d = date('Y-m-d', $u_age_t);
     $query_filter_dob = "dob >= '$l_age_d' AND dob < '$u_age_d'";
@@ -510,7 +510,7 @@ function get_specimen_count_grouped($specimen_type_id, $date_from, $date_to, $ge
     $l_age = (date("md", date("U", $u_age_t)) > date("md")
     ? ((date("Y") - $u_age_temp[0]) - 1)
     : (date("Y") - $u_age_temp[0]));
-    
+
     $l_age_m = date('Y-m', $l_age_t);
     $u_age_m = date('Y-m', $u_age_t);
     $query_filter_partial_dob_yyyy_mm = "partial_dob >= '$l_age_m' AND partial_dob < '$u_age_m'";
@@ -564,7 +564,7 @@ function get_specimen_count_grouped($specimen_type_id, $date_from, $date_to, $ge
 function get_specimen_count_grouped2($specimen_type_id, $date_from, $date_to, $gender, $completed = 0, $section = 0)
 {
     $query_string = "";
-    
+
     //$query_string = "SELECT count(*) as count_val FROM test WHERE test_type_id = $test_type_id";
     if($completed == 0)
     {
@@ -601,7 +601,7 @@ function get_test_count($lab_config, $test_type_id, $date_from, $date_to)
 $query_string = "";
 	if($date_from == "" || $date_to == "")
 	{
-		$query_string = 
+		$query_string =
 			"SELECT COUNT(*) as count_val FROM test ".
 			"WHERE test_type_id=$test_type_id";
 	}
@@ -625,7 +625,7 @@ function get_specimen_count($lab_config, $specimen_type_id, $date_from, $date_to
 	$query_string = "";
 	if($date_from == "" || $date_to == "")
 	{
-		$query_string = 
+		$query_string =
 			"SELECT COUNT(*) as count_val FROM specimen ".
 			"WHERE specimen_type_id=$specimen_type_id";
 	}
@@ -646,7 +646,7 @@ function get_discrete_value_test_types($lab_config)
 	# Returns test type IDs for tests that have explicit P/N results
 	$saved_db = DbUtil::switchToLabConfigRevamp($lab_config->id);
 	$retval = array();
-	$query_string = 
+	$query_string =
 		"SELECT DISTINCT test_type_id FROM test_type ".
 		"WHERE test_type_id IN ( ".
 			"SELECT test_type_id FROM lab_config_test_type ".
@@ -656,7 +656,7 @@ function get_discrete_value_test_types($lab_config)
 	foreach($resultset as $record)
 	{
 		$test_type_id = $record['test_type_id'];
-		$query_string2 = 
+		$query_string2 =
 			"SELECT DISTINCT ttm.test_type_id FROM test_type_measure ttm ".
 			"WHERE ttm.measure_id IN ( ".
 				"SELECT measure_id FROM measure ".
@@ -696,7 +696,7 @@ class MeasureMeta
 	public $rangeParts;
 	public $countParts;
 	public $countTotal;
-	
+
 	public static $DISCRETE = 1;
 	public static $CONTINUOUS = 2;
 }
@@ -708,7 +708,7 @@ class DiseaseSet
 	public $patientAge;
 	public $patientGender;
 	public $resultValues;
-}	
+}
 
 
 class DiseaseSetFilter
@@ -720,7 +720,7 @@ class DiseaseSetFilter
 	public $measureId;
 	public $rangeType;
 	public $rangeValues;
-	
+
 	public static $DISCRETE = 1;
 	public static $CONTINUOUS = 2;
 }
@@ -729,13 +729,13 @@ class DiseaseSetFilter
 class StatsLib
 {
 	public static $diseaseSetList = array(); # Used while aggregating Disease Report stats
-		
+
 	public static function  get_ip()
 {
-	$ip_address=$_SERVER['HTTP_X_FORWARDED_FOR']; 
-	
+	$ip_address=$_SERVER['HTTP_X_FORWARDED_FOR'];
+
 	if ($ip_address==NULL){
-	$ip_address=$_SERVER[REMOTE_ADDR]; }
+	$ip_address=$_SERVER['REMOTE_ADDR']; }
 	$ip_address="http://".$ip_address.":4001/login.php";
 	return($ip_address);
 }
@@ -747,7 +747,7 @@ class StatsLib
 		$mark = ceil(round($ile_value/100, 2) * $num_values);
 		return $list[$mark-1];
 	}
-	
+
 	public static function getTatStats($lab_config, $date_from, $date_to)
 	{
 		# Returns a list of {test_type, Turnaround Time (tat), total specimens} for a given time period
@@ -768,21 +768,21 @@ class StatsLib
 				$curr_entry = array();
 				$curr_entry[] = 0;
 				$curr_entry[] = 0;
-				
+
 				# Append to result
 				$retval[$test_type_id] = $curr_entry;
 				continue;
 			}
-			
+
 			# Calculate TAT value
 			$cumulative_diff = 0;
-	
+
 			foreach($resultset as $record)
 			{
 				$date_collected = $record['date_collected'];
 				$date_ts = $record['ts'];
 				$date_diff = $date_ts - $date_collected;
-				
+
 				$cumulative_diff += $date_diff;
 			}
 			$avg_tat = round(($cumulative_diff/(60*60*24))/count($resultset), 2);
@@ -796,7 +796,7 @@ class StatsLib
 		DbUtil::switchRestore($saved_db);
 		return $retval;
 	}
-	
+
 	public static function getTatMonthlyProgressionStats($lab_config, $test_type_id, $date_from, $date_to, $include_pending=false)
 	{
 		# Calculates monthly progression of TAT values for a given test type and time period
@@ -838,7 +838,7 @@ class StatsLib
 				$progression_count[$month_ts] += 1;
 			}
 			if($date_diff/(60*60*24) > $goal_tat[$month_ts])
-			{	
+			{
 				# Add to list of TAT exceeded specimens
 				$progression_val[$month_ts][3][] = $record['specimen_id'];
 			}
@@ -890,11 +890,11 @@ class StatsLib
 			# Convert from sec timestamp to days
 			$progression_val[$key][1] = $progression_val[$key][1]/(60*60*24);
 			$progression_val[$key][2] = $goal_tat[$key];
-		}		
+		}
 		DbUtil::switchRestore($saved_db);
 		return $progression_val;
 	}
-	
+
 	public static function getTatWeeklyProgressionStats($lab_config, $test_type_id, $date_from, $date_to, $include_pending=false)
 	{
 		# Calculates weekly progression of TAT values for a given test type and time period
@@ -931,7 +931,7 @@ class StatsLib
 				$percentile_count[$week_ts][] = $date_diff;
 				$progression_count[$week_ts] += 1;
 			}
-			if($date_diff/(60*60*24) > $goal_tat[$week_ts]) {	
+			if($date_diff/(60*60*24) > $goal_tat[$week_ts]) {
 				$progression_val[$week_ts][3][] = $record['specimen_id'];
 			}
 		}
@@ -942,7 +942,7 @@ class StatsLib
 			$resultset_pending = get_pendingtat_tests_by_type($test_type_id, $date_from, $date_to);
 			$num_pending = count($resultset_pending);
 			foreach($resultset_pending as $record) {
-			
+
 				$date_collected = $record['date_collected'];
 				$week_collected = date("W", $date_collected);
 				$year_collected = date("Y", $date_collected);
@@ -986,7 +986,7 @@ class StatsLib
 		# Return {week=>[avg tat, percentile tat, goal tat, [overdue specimen_ids], [pending specimen_ids]]}
 		return $progression_val;
 	}
-	
+
 	public static function getTatDailyProgressionStats($lab_config, $test_type_id, $date_from, $date_to, $include_pending=false)
 	{
 		# Calculates weekly progression of TAT values for a given test type and time period
@@ -1005,7 +1005,7 @@ class StatsLib
 			$date_collected = $record['date_collected'];
 			$date_ts = $record['ts'];
 			$date_diff = ($date_ts - $date_collected);
-			$day_ts = $date_collected; 
+			$day_ts = $date_collected;
 			$day_ts_datetime = date("Y-m-d H:i:s", $day_ts);
 			if(!isset($progression_val[$day_ts]))
 			{
@@ -1025,7 +1025,7 @@ class StatsLib
 				$progression_count[$day_ts] += 1;
 			}
 			if($date_diff/(60*60*24) > $goal_tat[$day_ts])
-			{	
+			{
 				# Add to list of TAT exceeded specimens
 				$progression_val[$day_ts][3][] = $record['specimen_id'];
 			}
@@ -1042,7 +1042,7 @@ class StatsLib
 				$date_collected = $record['date_collected'];
 				$date_ts = $record['ts'];
 				$date_diff = $pending_tat_value*60*60;;
-				$day_ts = $date_collected; 
+				$day_ts = $date_collected;
 				$day_ts_datetime = date("Y-m-d H:i:s", $day_ts);
 				if(!isset($progression_val[$day_ts]))
 				{
@@ -1081,7 +1081,7 @@ class StatsLib
 		# Return {week=>[avg tat, percentile tat, goal tat, [overdue specimen_ids], [pending specimen_ids]]}
 		return $progression_val;
 	}
-	
+
 	public static function getTestsDoneStats($lab_config, $date_from, $date_to)
 	{
 		# Returns a list of {test_type, number of tests performed} for the given time period
@@ -1092,7 +1092,7 @@ class StatsLib
 		$saved_db = DbUtil::switchToLabConfig($lab_config->id);
 		$tests_done_list = array();
 		$tests_list=array();
-		
+
 		foreach($test_type_list as $test_type_id)
 		{
 			$count_value = get_tests_done_count($lab_config, $test_type_id, $date_from, $date_to);
@@ -1100,9 +1100,9 @@ class StatsLib
 			$tests_done_count_list[] = $count_value;
 			$tests_pending_list[]=$test_count-$count_value;
 
-			
+
 		}
-		
+
 		for($i = 0; $i < count($test_type_list); $i++)
 		{
 			# Add to return value if test count not zero
@@ -1115,7 +1115,7 @@ class StatsLib
 	public static function getTestsDoneStatsAggregate($date_from, $date_to)
 	{
 		$site_list = get_site_list($_SESSION['user_id']);
-			
+
 		$userId = $_SESSION['user_id'];
 		$saved_db = DbUtil::switchToGlobal();
 		$query = "SELECT * FROM test_mapping WHERE user_id = $userId";
@@ -1132,7 +1132,7 @@ class StatsLib
 		}
 		DbUtil::switchRestore($saved_db);
 		$retval = array();
-		
+
 		$test_done_count = 0;
 		$test_pending_count = 0;
 		foreach( $site_list as $key => $value) {
@@ -1146,14 +1146,14 @@ class StatsLib
 			$saved_db = DbUtil::switchToLabConfig($lab_config->id);
 			$tests_done_list = array();
 			$tests_list=array();
-			
+
 			foreach($test_type_list as $test_type_id) {
 				$count_value = get_tests_done_count($lab_config, $test_type_id, $date_from, $date_to);
 				$test_count=get_test_count($lab_config, $test_type_id, $date_from, $date_to);
 				$tests_done_count_list[] = $count_value;
 				$tests_pending_list[]=$test_count-$count_value;
 			}
-					
+
 			for($i = 0; $i < count($test_type_list); $i++) {
 				# Add to return value if test count not zero
 				$testName = $testNames[$i];
@@ -1162,13 +1162,13 @@ class StatsLib
 					$test_pending_count += intval($tests_pending_list[$i]);
 					$retval[$testName] = array($test_done_count,$test_pending_count);
 				}
-				
+
 			}
 			DbUtil::switchRestore($saved_db);
 		}
 		return $retval;
 	}
-	
+
 	public static function getDoctorStats($lab_config,$date_from,$date_to) {
 	$retval=array();
 	$saved_db = DbUtil::switchToLabConfig($lab_config->id);
@@ -1177,10 +1177,10 @@ class StatsLib
 					"GROUP BY doctor";
 				//echo($query_string);
 	$resultset = query_associative_all($query_string);
-	
+
 			if(count($resultset) == 0 || $resultset == null)
 		{
-			
+
 			DbUtil::switchRestore($saved_db);
 			return;
 		}
@@ -1193,7 +1193,7 @@ class StatsLib
 			"AND doctor='$doctor_name'".
 			"AND ( s.date_collected BETWEEN '$date_from' AND '$date_to' ) ".
 			"GROUP BY DOCTOR";
-	
+
 		$record1 = query_associative_one($query_string1);
 	if($doctor_name=="")
 	$doctor_name="Not Known";
@@ -1202,11 +1202,11 @@ class StatsLib
 	$test_count=$record1['test'];
 	$retval[$doctor_name] = array($patient_count,$specimen_count,$test_count);
 	}
-	
+
 	DbUtil::switchRestore($saved_db);
 	return($retval);
-	
-	
+
+
 	}
 	public static function getSpecimenCountStats($lab_config, $date_from, $date_to)
 	{
@@ -1230,7 +1230,7 @@ class StatsLib
 		DbUtil::switchRestore($saved_db);
 		return $retval;
 	}
-	
+
 	public static function getDiscreteInfectionStats($lab_config, $date_from, $date_to, $test_type_id_passed = null)
 	{
 		# Fetch all test types with one measure having discrete P/N range
@@ -1243,7 +1243,7 @@ class StatsLib
 		# For each test type, fetch negative records
 		foreach($test_type_list as $test_type_id)
 		{
-			$query_string = 
+			$query_string =
 				"SELECT COUNT(*) AS count_val FROM test t, specimen s ".
 				"WHERE t.test_type_id=$test_type_id ".
 				"AND t.specimen_id=s.specimen_id ".
@@ -1251,7 +1251,7 @@ class StatsLib
 				"AND (result LIKE 'N,%' OR result LIKE 'n�gatif,%' OR result LIKE 'negatif,%' OR result LIKE 'n,%' OR result LIKE 'negative,%')";
 			$record = query_associative_one($query_string);
 			$count_negative = $record['count_val'];
-			$query_string = 
+			$query_string =
 				"SELECT COUNT(*) AS count_val FROM test t, specimen s ".
 				"WHERE t.test_type_id=$test_type_id ".
 				"AND t.specimen_id=s.specimen_id ".
@@ -1262,25 +1262,25 @@ class StatsLib
 			# If total tests is 0, ignore
 			if($count_all == 0)
 				continue;
-				
-			$query_string = 
+
+			$query_string =
 					"SELECT prevalence_threshold FROM test_type ".
 					"WHERE test_type_id=$test_type_id ";
 			$record = query_associative_one($query_string);
 			$threshold = $record['prevalence_threshold'];
 			$retval[$test_type_id] = array($count_all, $count_negative, $threshold);
 		}
-		DbUtil::switchRestore($saved_db); 
+		DbUtil::switchRestore($saved_db);
 		return $retval;
 	}
-	
+
 	public static function getDiscreteInfectionStatsAggregate($lab_config_id, $date_from, $date_to, $test_type_id) {
 		$retval = array();
-		
+
 		#All Tests & All Labs
 		if( $test_type_id == 0 && $lab_config_id == 0 ) {
 			$site_list = get_site_list($_SESSION['user_id']);
-			
+
 			$userId = $_SESSION['user_id'];
 			$saved_db = DbUtil::switchToGlobal();
 			$query = "SELECT * FROM test_mapping WHERE user_id = $userId";
@@ -1297,18 +1297,18 @@ class StatsLib
 			}
 			DbUtil::switchRestore($saved_db);
 			foreach( $site_list as $key => $value) {
-				
+
 				$lab_config = LabConfig::getById($key);
 				$test_type_list = array();
 				$test_type_list = $test_type_list_all[$key];
 				$testNames = $test_type_names[$key];
 				$saved_db = DbUtil::switchToLabConfig($lab_config->id);
 				$testCount = -1;
-				
+
 				# For each test type, fetch negative records
 				foreach($test_type_list as $test_type_id)
 				{
-					$query_string = 
+					$query_string =
 						"SELECT COUNT(*) AS count_val FROM test t, specimen s ".
 						"WHERE t.test_type_id=$test_type_id ".
 						"AND t.specimen_id=s.specimen_id ".
@@ -1316,7 +1316,7 @@ class StatsLib
 						"AND (result LIKE 'N,%' OR result LIKE 'n�gatif,%' OR result LIKE 'negatif,%' OR result LIKE 'n,%' OR result LIKE 'negative,%')";
 					$record = query_associative_one($query_string);
 					$count_negative = intval($record['count_val']);
-					$query_string = 
+					$query_string =
 						"SELECT COUNT(*) AS count_val FROM test t, specimen s ".
 						"WHERE t.test_type_id=$test_type_id ".
 						"AND t.specimen_id=s.specimen_id ".
@@ -1329,7 +1329,7 @@ class StatsLib
 					if( $count_all == 0 )
 						continue;
 					$testName = $testNames[$testCount];
-					
+
 					if( !array_key_exists($testName, $retval) ) {
 						$retval[$testName] = array($count_all, $count_negative);
 					}
@@ -1340,7 +1340,7 @@ class StatsLib
 					}
 				}
 			}
-			DbUtil::switchRestore($saved_db);		
+			DbUtil::switchRestore($saved_db);
 			return $retval;
 		}
 		# All Tests for a Single Lab
@@ -1352,7 +1352,7 @@ class StatsLib
 				$testName = get_test_name_by_id($key);
 				$retval[$testName] = $value;
 			}
-			DbUtil::switchRestore($saved_db);	
+			DbUtil::switchRestore($saved_db);
 			return $retval;
 		}
 		# All Tests for more than one lab
@@ -1372,7 +1372,7 @@ class StatsLib
 					}
 			}
 			DbUtil::switchRestore($saved_db);
-			
+
 			foreach( $lab_config_id as $key) {
 				$lab_config = LabConfig::getById($key);
 				$test_type_list = array();
@@ -1380,11 +1380,11 @@ class StatsLib
 				$testNames = $test_type_names[$key];
 				$saved_db = DbUtil::switchToLabConfig($lab_config->id);
 				$testCount = -1;
-				
+
 				# For each test type, fetch negative records
 				foreach($test_type_list as $test_type_id)
 				{
-					$query_string = 
+					$query_string =
 						"SELECT COUNT(*) AS count_val FROM test t, specimen s ".
 						"WHERE t.test_type_id=$test_type_id ".
 						"AND t.specimen_id=s.specimen_id ".
@@ -1392,7 +1392,7 @@ class StatsLib
 						"AND (result LIKE 'N,%' OR result LIKE 'n�gatif,%' OR result LIKE 'negatif,%' OR result LIKE 'n,%' OR result LIKE 'negative,%')";
 					$record = query_associative_one($query_string);
 					$count_negative = intval($record['count_val']);
-					$query_string = 
+					$query_string =
 						"SELECT COUNT(*) AS count_val FROM test t, specimen s ".
 						"WHERE t.test_type_id=$test_type_id ".
 						"AND t.specimen_id=s.specimen_id ".
@@ -1406,7 +1406,7 @@ class StatsLib
 					if($count_all == 0)
 						continue;
 					$testName = $testNames[$testCount];
-					
+
 					if( !array_key_exists($testName, $retval) ) {
 						$retval[$testName] = array($count_all, $count_negative);
 					}
@@ -1417,10 +1417,10 @@ class StatsLib
 					}
 				}
 			}
-			DbUtil::switchRestore($saved_db);		
+			DbUtil::switchRestore($saved_db);
 			return $retval;
 		}
-		else {		
+		else {
 			/* Build Array Map with Lab Id as Key and Test Id as corresponding Value */
 			$labIdTestIds = explode(";",$test_type_id);
 			$testIds = array();
@@ -1430,7 +1430,7 @@ class StatsLib
 					$testId = $labIdTestIdsSeparated[1];
 					$testIds[$labId] = $testId;
 			}
-			
+
 			# Particular Test & All Labs
 			if ( $test_type_id != 0 && $lab_config_id == 0 ) {
 				$site_list = get_site_list($_SESSION['user_id']);
@@ -1439,10 +1439,10 @@ class StatsLib
 					$lab_config = LabConfig::getById($key);
 					$saved_db = DbUtil::switchToLabConfig($lab_config->id);
 					$test_type_id = $testIds[$lab_config->id];
-					
+
 					# For particular test type, fetch negative records
-			
-						$query_string = 
+
+						$query_string =
 							"SELECT COUNT(*) AS count_val FROM test t, specimen s ".
 							"WHERE t.test_type_id=$test_type_id ".
 							"AND t.specimen_id=s.specimen_id ".
@@ -1450,7 +1450,7 @@ class StatsLib
 							"AND (result LIKE 'N,%' OR result LIKE 'n�gatif,%' OR result LIKE 'negatif,%' OR result LIKE 'n,%' OR result LIKE 'negative,%')";
 						$record = query_associative_one($query_string);
 						$count_negative = intval($record['count_val']);
-						$query_string = 
+						$query_string =
 							"SELECT COUNT(*) AS count_val FROM test t, specimen s ".
 							"WHERE t.test_type_id=$test_type_id ".
 							"AND t.specimen_id=s.specimen_id ".
@@ -1462,16 +1462,16 @@ class StatsLib
 						if($count_all == 0)
 							continue;
 						$testName = get_test_name_by_id($test_type_id);
-												
+
 						$labName = $lab_config->name;
-						$retval[$labName] = array( $count_all, $count_negative);			
+						$retval[$labName] = array( $count_all, $count_negative);
 				}
-				DbUtil::switchRestore($saved_db);		
+				DbUtil::switchRestore($saved_db);
 				return $retval;
 			}
 			# Particular Test for Single Lab
 			else if ( $test_type_id != 0 && count($lab_config_id) == 1 ) {
-			
+
 				$lab_config = LabConfig::getById($lab_config_id[0]);
 				$test_type_id = $testIds[$lab_config->id];
 				$retvalues = StatsLib::getDiscreteInfectionStats($lab_config, $date_from, $date_to, $test_type_id);
@@ -1480,19 +1480,19 @@ class StatsLib
 					$testName = get_test_name_by_id($key);
 					$retval[$testName] = $value;
 				}
-				DbUtil::switchRestore($saved_db);	
+				DbUtil::switchRestore($saved_db);
 				return $retval;
 			}
-			# Particular Test & Multiple Labs	
+			# Particular Test & Multiple Labs
 			else if ( $lab_config_id != 0 && $test_type_id != 0 ) {
 				foreach( $lab_config_id as $key) {
 					$lab_config = LabConfig::getById($key);
 					$test_type_id = $testIds[$lab_config->id];
-					$saved_db = DbUtil::switchToLabConfig($lab_config->id);	
-					
+					$saved_db = DbUtil::switchToLabConfig($lab_config->id);
+
 					# For particular test type, fetch negative records
-			
-						$query_string = 
+
+						$query_string =
 							"SELECT COUNT(*) AS count_val FROM test t, specimen s ".
 							"WHERE t.test_type_id=$test_type_id ".
 							"AND t.specimen_id=s.specimen_id ".
@@ -1500,7 +1500,7 @@ class StatsLib
 							"AND (result LIKE 'N,%' OR result LIKE 'n�gatif,%' OR result LIKE 'negatif,%' OR result LIKE 'n,%' OR result LIKE 'negative,%')";
 						$record = query_associative_one($query_string);
 						$count_negative = intval($record['count_val']);
-						$query_string = 
+						$query_string =
 							"SELECT COUNT(*) AS count_val FROM test t, specimen s ".
 							"WHERE t.test_type_id=$test_type_id ".
 							"AND t.specimen_id=s.specimen_id ".
@@ -1514,38 +1514,38 @@ class StatsLib
 							continue;
 						$testName = get_test_name_by_id($test_type_id);
 						$labName = $lab_config->name;
-						$query_string = 
+						$query_string =
 							"SELECT prevalence_threshold FROM test_type ".
 							"WHERE test_type_id=$test_type_id ";
 						$record = query_associative_one($query_string);
 						$threshold = intval($record['prevalence_threshold']);
-						
-						$retval[$labName] = array( $count_all, $count_negative, $threshold );				
+
+						$retval[$labName] = array( $count_all, $count_negative, $threshold );
 				}
-				DbUtil::switchRestore($saved_db);		
+				DbUtil::switchRestore($saved_db);
 				return $retval;
 			}
 		}
 	}
-	
+
 	public static function getDiscreteInfectionStatsWeekly($lab_config,$test_type_id, $date_from, $date_to, $gender=null)
 	{
-		$i=7;		
+		$i=7;
 		# Fetch all test types with one measure having discrete P/N range
 		$retval = array();
 		$saved_db = DbUtil::switchToLabConfig($lab_config->id);
-		$date_from_parts = explode("-", $date_from);		
+		$date_from_parts = explode("-", $date_from);
 		$date_to_parts = explode("-", $date_to);
 		$date_ts = mktime(0, 0, 0, $date_from_parts[1], $date_from_parts[2], $date_from_parts[0]);
 		$date_to_ts=mktime(0, 0, 0, $date_to_parts[1], $date_to_parts[2], $date_to_parts[0]);
-		
-		while($date_ts<=$date_to_ts) {     
+
+		while($date_ts<=$date_to_ts) {
 			$second_day_ts= mktime(0, 0, 0, $date_from_parts[1],$date_from_parts[2]+$i,$date_from_parts[0]);
 			$date_fromp=date("Y-m-d", $date_ts);
 			$date_top=date("Y-m-d", $second_day_ts);
-		
-			if($gender=='M'||$gender=='F') { 
-				$query_string = 
+
+			if($gender=='M'||$gender=='F') {
+				$query_string =
 						"SELECT COUNT(*) AS count_val  FROM test t, patient p, specimen s ".
 						"WHERE t.test_type_id=$test_type_id ".
 						"AND p.patient_id=s.patient_id ".
@@ -1555,7 +1555,7 @@ class StatsLib
 						"AND  (t.result LIKE 'N,%' OR t.result LIKE 'n�gatif,%' OR t.result LIKE 'negatif,%' OR t.result LIKE 'n,%' OR t.result LIKE 'negative,%')";
 			}
 			else {
-				$query_string = 
+				$query_string =
 				"SELECT COUNT(*) AS count_val  FROM test t, specimen s ".
 				"WHERE t.test_type_id=$test_type_id ".
 				"AND t.specimen_id=s.specimen_id ".
@@ -1565,8 +1565,8 @@ class StatsLib
 				}
 			$record = query_associative_one($query_string);
 			$count_negative = $record['count_val'];
-			
-			$query_string = 
+
+			$query_string =
 				"SELECT COUNT(*) AS count_val  FROM test t, specimen s ".
 				"WHERE t.test_type_id=$test_type_id ".
 				"AND t.specimen_id=s.specimen_id ".
@@ -1576,24 +1576,24 @@ class StatsLib
 			$count_all = $record['count_val'];
 			/*if($count_all != 0)*/
 				$retval[$date_ts] = array($count_all, $count_negative);
-			
+
 		$date_ts = $second_day_ts;
 		$i=$i+7;
-			
-					
+
+
 
 	}
 		DbUtil::switchRestore($saved_db);
-		
+
 		return $retval;
 	}
 public static function getDiscreteInfectionStatsG($lab_config,$test_type_id, $date_from,$date_to,$type) {
-			
+
 		$retval = array();
 		$saved_db = DbUtil::switchToLabConfig($lab_config->id);
 		if($type=='w') {
 
-				$query_string =   
+				$query_string =
 				"SELECT year(s.date_collected), s.date_collected  AS week ,COUNT(*) AS count_val  FROM test t,specimen s ".
 				"WHERE t.test_type_id=$test_type_id ".
 				"AND t.specimen_id=s.specimen_id ".
@@ -1601,18 +1601,18 @@ public static function getDiscreteInfectionStatsG($lab_config,$test_type_id, $da
 				"AND (s.date_collected BETWEEN '$date_from' AND '$date_to') ".
 				 "GROUP BY year(s.date_collected), week(s.date_collected)";
 			$resultset = query_associative_all($query_string);
-			$query_string1=   
+			$query_string1=
 				"SELECT year(s.date_collected), s.date_collected AS week ,COUNT(*) AS count_val  FROM test t,specimen s ".
 				"WHERE t.test_type_id=$test_type_id ".
 				"AND t.specimen_id=s.specimen_id ".
 				"AND (t.result LIKE 'N,%' OR t.result LIKE 'n�gatif,%' OR t.result LIKE 'negatif,%' OR t.result LIKE 'n,%' OR t.result LIKE 'negative,%')".
 				"AND (s.date_collected BETWEEN '$date_from' AND '$date_to') ".
 				 "GROUP BY year(s.date_collected), week(s.date_collected)";
-			
+
 				$resultset1= query_associative_all($query_string1);
 				}
 		else if($type=='d') {
-			$query_string =   
+			$query_string =
 				"SELECT s.date_collected  AS week ,COUNT(*) AS count_val  FROM test t,specimen s ".
 				"WHERE t.test_type_id=$test_type_id ".
 				"AND t.specimen_id=s.specimen_id ".
@@ -1620,18 +1620,18 @@ public static function getDiscreteInfectionStatsG($lab_config,$test_type_id, $da
 				"AND (s.date_collected BETWEEN '$date_from' AND '$date_to') ".
 				 "GROUP BY s.date_collected";
 			$resultset = query_associative_all($query_string);
-			$query_string1=   
+			$query_string1=
 				"SELECT s.date_collected AS week ,COUNT(*) AS count_val  FROM test t,specimen s ".
 				"WHERE t.test_type_id=$test_type_id ".
 				"AND t.specimen_id=s.specimen_id ".
 				"AND (t.result LIKE 'N,%' OR t.result LIKE 'n�gatif,%' OR t.result LIKE 'negatif,%' OR t.result LIKE 'n,%' OR t.result LIKE 'negative,%')".
 				"AND (s.date_collected BETWEEN '$date_from' AND '$date_to') ".
 				 "GROUP BY s.date_collected";
-			
+
 			$resultset1= query_associative_all($query_string1);
 		}
 		else {
-			$query_string =   
+			$query_string =
 				"SELECT year(s.date_collected), s.date_collected  AS week ,COUNT(*) AS count_val  FROM test t,specimen s ".
 				"WHERE t.test_type_id=$test_type_id ".
 				"AND t.specimen_id=s.specimen_id ".
@@ -1639,18 +1639,18 @@ public static function getDiscreteInfectionStatsG($lab_config,$test_type_id, $da
 				"AND (s.date_collected BETWEEN '$date_from' AND '$date_to') ".
 				 "GROUP BY year(s.date_collected), month(s.date_collected)";
 			$resultset = query_associative_all($query_string);
-			$query_string1=   
+			$query_string1=
 				"SELECT year(s.date_collected), s.date_collected AS week ,COUNT(*) AS count_val  FROM test t,specimen s ".
 				"WHERE t.test_type_id=$test_type_id ".
 				"AND t.specimen_id=s.specimen_id ".
 				"AND (t.result LIKE 'N,%' OR t.result LIKE 'n�gatif,%' OR t.result LIKE 'negatif,%' OR t.result LIKE 'n,%' OR t.result LIKE 'negative,%')".
 				"AND (s.date_collected BETWEEN '$date_from' AND '$date_to') ".
 				 "GROUP BY year(s.date_collected),month(s.date_collected)";
-			
+
 				$resultset1= query_associative_all($query_string1);
-				
+
 				}
-	
+
 $record_total= array();
 $record_neg=array();
 		foreach($resultset1 as $record) {
@@ -1672,27 +1672,27 @@ $record_neg=array();
 				$count_negative=0;
 			else
 				$count_negative=$record_neg[$key];
-				
+
 			$count_all=$value;
-			$date_from_parts = explode("-", $key);	
+			$date_from_parts = explode("-", $key);
 			$date_ts= mktime(0, 0, 0, $date_from_parts[1]+$i,$date_from_parts[2],$date_from_parts[0]);
 			$retval[$counter] = array($count_all, $count_negative, $date_ts);
 			$counter++;
 		}
 
 		DbUtil::switchRestore($saved_db);
-		
+
 		return $retval;
 }
 public static function getDiscreteInfectionStatsGenderM($lab_config,$test_type_id, $date_from,$date_to,$type)
-{		
+{
 
 $gender='M';
 $retval = array();
 		$saved_db = DbUtil::switchToLabConfig($lab_config->id);
 				if($type=='w')
 				{
-				$query_string =   
+				$query_string =
 				"SELECT year(s.date_collected), s.date_collected  AS week ,COUNT(*) AS count_val  FROM test t, patient p,specimen s ".
 				"WHERE t.test_type_id=$test_type_id ".
 				"AND t.specimen_id=s.specimen_id ".
@@ -1702,7 +1702,7 @@ $retval = array();
 				"AND (s.date_collected BETWEEN '$date_from' AND '$date_to') ".
 				 "GROUP BY year(s.date_collected), week(s.date_collected)";
 			$resultset = query_associative_all($query_string);
-			$query_string1=   
+			$query_string1=
 				"SELECT year(s.date_collected), s.date_collected AS week ,COUNT(*) AS count_val  FROM test t, patient p,specimen s ".
 				"WHERE t.test_type_id=$test_type_id ".
 				"AND p.patient_id=s.patient_id ".
@@ -1711,12 +1711,12 @@ $retval = array();
 				"AND (t.result LIKE 'N,%' OR t.result LIKE 'n�gatif,%' OR t.result LIKE 'negatif,%' OR t.result LIKE 'n,%' OR t.result LIKE 'negative,%')".
 				"AND (s.date_collected BETWEEN '$date_from' AND '$date_to') ".
 				 "GROUP BY year(s.date_collected), week(s.date_collected)";
-			
+
 				$resultset1= query_associative_all($query_string1);
 				}
 				else if($type=='d')
 				{
-				$query_string =   
+				$query_string =
 				"SELECT s.date_collected  AS week ,COUNT(*) AS count_val  FROM test t, patient p,specimen s ".
 				"WHERE t.test_type_id=$test_type_id ".
 				"AND t.specimen_id=s.specimen_id ".
@@ -1726,7 +1726,7 @@ $retval = array();
 				"AND (s.date_collected BETWEEN '$date_from' AND '$date_to') ".
 				 "GROUP BY s.date_collected";
 			$resultset = query_associative_all($query_string);
-			$query_string1=   
+			$query_string1=
 				"SELECT s.date_collected AS week ,COUNT(*) AS count_val  FROM test t, patient p,specimen s ".
 				"WHERE t.test_type_id=$test_type_id ".
 				"AND t.specimen_id=s.specimen_id ".
@@ -1735,12 +1735,12 @@ $retval = array();
 				"AND (t.result LIKE 'N,%' OR t.result LIKE 'n�gatif,%' OR t.result LIKE 'negatif,%' OR t.result LIKE 'n,%' OR t.result LIKE 'negative,%')".
 				"AND (s.date_collected BETWEEN '$date_from' AND '$date_to') ".
 				 "GROUP BY s.date_collected";
-			
+
 				$resultset1= query_associative_all($query_string1);
 				}
 				else
 				{
-				$query_string =   
+				$query_string =
 				"SELECT year(s.date_collected), s.date_collected  AS week ,COUNT(*) AS count_val  FROM test t, patient p,specimen s ".
 				"WHERE t.test_type_id=$test_type_id ".
 				"AND t.specimen_id=s.specimen_id ".
@@ -1750,7 +1750,7 @@ $retval = array();
 				"AND (s.date_collected BETWEEN '$date_from' AND '$date_to') ".
 				 "GROUP BY year(s.date_collected), month(s.date_collected)";
 			$resultset = query_associative_all($query_string);
-			$query_string1=   
+			$query_string1=
 				"SELECT year(s.date_collected), s.date_collected AS week ,COUNT(*) AS count_val  FROM test t, patient p,specimen s ".
 				"WHERE t.test_type_id=$test_type_id ".
 				"AND t.specimen_id=s.specimen_id ".
@@ -1759,11 +1759,11 @@ $retval = array();
 				"AND (t.result LIKE 'N,%' OR t.result LIKE 'n�gatif,%' OR t.result LIKE 'negatif,%' OR t.result LIKE 'n,%' OR t.result LIKE 'negative,%')".
 				"AND (s.date_collected BETWEEN '$date_from' AND '$date_to') ".
 				 "GROUP BY year(s.date_collected),month(s.date_collected)";
-			
+
 				$resultset1= query_associative_all($query_string1);
-				
+
 				}
-	
+
 $record_total= array();
 $record_neg=array();
 foreach($resultset1 as $record)
@@ -1790,7 +1790,7 @@ $count_negative=0;
 else
 $count_negative=$record_neg[$key];
 $count_all=$value;
-$date_from_parts = explode("-", $key);	
+$date_from_parts = explode("-", $key);
 $date_ts= mktime(0, 0, 0, $date_from_parts[1]+$i,$date_from_parts[2],$date_from_parts[0]);
 $retval[$counter] = array($count_all, $count_negative, $date_ts);
 $counter++;
@@ -1798,25 +1798,25 @@ $counter++;
 	/*	$i=1;
 		if($type=='w')
 			$i=7;
-		
+
 		# Fetch all test types with one measure having discrete P/N range
 		$retval = array();
 		$saved_db = DbUtil::switchToLabConfig($lab_config->id);
-		$date_from_parts = explode("-", $date_from);		
+		$date_from_parts = explode("-", $date_from);
 		$date_to_parts = explode("-", $date_to);
 		$date_ts = mktime(0, 0, 0, $date_from_parts[1], $date_from_parts[2], $date_from_parts[0]);
 		$date_to_ts=mktime(0, 0, 0, $date_to_parts[1], $date_to_parts[2], $date_to_parts[0]);
-		
+
 		while($date_ts<$date_to_ts)
-	{     
+	{
 		if($type=='m')
 		$end_date_ts= mktime(0, 0, 0, $date_from_parts[1]+$i,0,$date_from_parts[0]);
 		else
 		$end_date_ts= mktime(0, 0, 0, $date_from_parts[1],$date_from_parts[2]+$i,$date_from_parts[0]);
 		$date_fromp=date("Y-m-d", $date_ts);
 		$date_top=date("Y-m-d", $end_date_ts);
-	
-$query_string = 
+
+$query_string =
 				"SELECT COUNT(*) AS count_val  FROM test t, patient p, specimen s ".
 				"WHERE t.test_type_id=$test_type_id ".
 				"AND p.patient_id=s.patient_id ".
@@ -1824,12 +1824,12 @@ $query_string =
 				"AND t.specimen_id=s.specimen_id ".
 				"AND (s.date_collected BETWEEN '$date_fromp' AND '$date_top') ".
 				"AND  (t.result LIKE 'N,%' OR t.result LIKE 'n�gatif,%' OR t.result LIKE 'negatif,%' OR t.result LIKE 'n,%' OR t.result LIKE 'negative,%')";
-				
-				
+
+
 			$record = query_associative_one($query_string);
 			$count_negative = $record['count_val'];
-		
-			$query_string = 
+
+			$query_string =
 				"SELECT COUNT(*) AS count_val  FROM test t,specimen s ".
 				"WHERE t.test_type_id=$test_type_id ".
 				"AND p.sex= '$gender' ".
@@ -1846,12 +1846,12 @@ $query_string =
 				$i=$i+7;
 			else
 				$i++;
-			
-					
+
+
 
 	}*/
 		DbUtil::switchRestore($saved_db);
-		
+
 		return $retval;
 
 }
@@ -1861,26 +1861,26 @@ $query_string =
 		/*$i=1;
 		if($type=='w')
 			$i=7;
-		
+
 		# Fetch all test types with one measure having discrete P/N range
-		
+
 		$retval = array();
 		$saved_db = DbUtil::switchToLabConfig($lab_config->id);
-		$date_from_parts = explode("-", $date_from);		
+		$date_from_parts = explode("-", $date_from);
 		$date_to_parts = explode("-", $date_to);
 		$date_ts = mktime(0, 0, 0, $date_from_parts[1], $date_from_parts[2], $date_from_parts[0]);
 		$date_to_ts=mktime(0, 0, 0, $date_to_parts[1], $date_to_parts[2], $date_to_parts[0]);
-		
+
 		while($date_ts<$date_to_ts)
-	{     
+	{
 		if($type=='m')
 		$end_date_ts= mktime(0, 0, 0, $date_from_parts[1]+$i,0,$date_from_parts[0]);
 		else
 		$end_date_ts= mktime(0, 0, 0, $date_from_parts[1],$date_from_parts[2]+$i,$date_from_parts[0]);
 		$date_fromp=date("Y-m-d", $date_ts);
 		$date_top=date("Y-m-d", $end_date_ts);
-	
-$query_string = 
+
+$query_string =
 				"SELECT COUNT(*) AS count_val  FROM test t, patient p, specimen s ".
 				"WHERE t.test_type_id=$test_type_id ".
 				"AND p.patient_id=s.patient_id ".
@@ -1888,11 +1888,11 @@ $query_string =
 				"AND t.specimen_id=s.specimen_id ".
 				"AND (s.date_collected BETWEEN '$date_fromp' AND '$date_top') ".
 				"AND  (t.result LIKE 'N,%' OR t.result LIKE 'n�gatif,%' OR t.result LIKE 'negatif,%' OR t.result LIKE 'n,%' OR t.result LIKE 'negative,%')";
-				
+
 					$record = query_associative_one($query_string);
 			$count_negative = $record['count_val'];
-			
-			$query_string = 
+
+			$query_string =
 				"SELECT COUNT(*) AS count_val  FROM test t,patient p, specimen s ".
 				"WHERE t.test_type_id=$test_type_id ".
 				"AND p.sex = '$gender' ".
@@ -1905,21 +1905,21 @@ $query_string =
 			$count_all = $record['count_val'];
 						if($count_all != 0)
 				$retval[$date_ts] = array($count_all, $count_negative);
-			
+
 		$date_ts = $end_date_ts;
 		if($type=='w')
 		$i=$i+7;
 		else
 		$i++;
-			
-					
+
+
 
 	}*/
 	$retval = array();
 		$saved_db = DbUtil::switchToLabConfig($lab_config->id);
 				if($type=='w')
 				{
-				$query_string =   
+				$query_string =
 				"SELECT year(s.date_collected), s.date_collected  AS week ,COUNT(*) AS count_val  FROM test t, patient p,specimen s ".
 				"WHERE t.test_type_id=$test_type_id ".
 				"AND t.specimen_id=s.specimen_id ".
@@ -1929,7 +1929,7 @@ $query_string =
 				"AND (s.date_collected BETWEEN '$date_from' AND '$date_to') ".
 				 "GROUP BY year(s.date_collected), week(s.date_collected)";
 			$resultset = query_associative_all($query_string);
-			$query_string1=   
+			$query_string1=
 				"SELECT year(s.date_collected), s.date_collected AS week ,COUNT(*) AS count_val  FROM test t, patient p,specimen s ".
 				"WHERE t.test_type_id=$test_type_id ".
 				"AND p.patient_id=s.patient_id ".
@@ -1938,12 +1938,12 @@ $query_string =
 				"AND (t.result LIKE 'N,%' OR t.result LIKE 'n�gatif,%' OR t.result LIKE 'negatif,%' OR t.result LIKE 'n,%' OR t.result LIKE 'negative,%')".
 				"AND (s.date_collected BETWEEN '$date_from' AND '$date_to') ".
 				 "GROUP BY year(s.date_collected), week(s.date_collected)";
-			
+
 				$resultset1= query_associative_all($query_string1);
 				}
 				else if($type=='d')
 				{
-				$query_string =   
+				$query_string =
 				"SELECT s.date_collected  AS week ,COUNT(*) AS count_val  FROM test t, patient p,specimen s ".
 				"WHERE t.test_type_id=$test_type_id ".
 				"AND t.specimen_id=s.specimen_id ".
@@ -1953,7 +1953,7 @@ $query_string =
 				"AND (s.date_collected BETWEEN '$date_from' AND '$date_to') ".
 				 "GROUP BY s.date_collected";
 			$resultset = query_associative_all($query_string);
-			$query_string1=   
+			$query_string1=
 				"SELECT s.date_collected AS week ,COUNT(*) AS count_val  FROM test t, patient p,specimen s ".
 				"WHERE t.test_type_id=$test_type_id ".
 				"AND t.specimen_id=s.specimen_id ".
@@ -1962,12 +1962,12 @@ $query_string =
 				"AND (t.result LIKE 'N,%' OR t.result LIKE 'n�gatif,%' OR t.result LIKE 'negatif,%' OR t.result LIKE 'n,%' OR t.result LIKE 'negative,%')".
 				"AND (s.date_collected BETWEEN '$date_from' AND '$date_to') ".
 				 "GROUP BY s.date_collected";
-			
+
 				$resultset1= query_associative_all($query_string1);
 				}
 				else
 				{
-				$query_string =   
+				$query_string =
 				"SELECT year(s.date_collected), s.date_collected  AS week ,COUNT(*) AS count_val  FROM test t, patient p,specimen s ".
 				"WHERE t.test_type_id=$test_type_id ".
 				"AND t.specimen_id=s.specimen_id ".
@@ -1977,7 +1977,7 @@ $query_string =
 				"AND (s.date_collected BETWEEN '$date_from' AND '$date_to') ".
 				 "GROUP BY year(s.date_collected), month(s.date_collected)";
 			$resultset = query_associative_all($query_string);
-			$query_string1=   
+			$query_string1=
 				"SELECT year(s.date_collected), s.date_collected AS week ,COUNT(*) AS count_val  FROM test t, patient p,specimen s ".
 				"WHERE t.test_type_id=$test_type_id ".
 				"AND t.specimen_id=s.specimen_id ".
@@ -1986,11 +1986,11 @@ $query_string =
 				"AND (t.result LIKE 'N,%' OR t.result LIKE 'n�gatif,%' OR t.result LIKE 'negatif,%' OR t.result LIKE 'n,%' OR t.result LIKE 'negative,%')".
 				"AND (s.date_collected BETWEEN '$date_from' AND '$date_to') ".
 				 "GROUP BY year(s.date_collected),month(s.date_collected)";
-			
+
 				$resultset1= query_associative_all($query_string1);
-				
+
 				}
-	
+
 $record_total= array();
 $record_neg=array();
 foreach($resultset1 as $record)
@@ -2017,37 +2017,37 @@ $count_negative=0;
 else
 $count_negative=$record_neg[$key];
 $count_all=$value;
-$date_from_parts = explode("-", $key);	
+$date_from_parts = explode("-", $key);
 $date_ts= mktime(0, 0, 0, $date_from_parts[1]+$i,$date_from_parts[2],$date_from_parts[0]);
 $retval[$counter] = array($count_all, $count_negative, $date_ts);
 $counter++;
 }
 		DbUtil::switchRestore($saved_db);
-		
+
 		return $retval;
 
 
-	
+
 	}
 	public static function getDiscreteInfectionStatsDaily($lab_config,$test_type_id, $date_from, $date_to, $gender=null)
 	{
-			$i=1;		
+			$i=1;
 		# Fetch all test types with one measure having discrete P/N range
 		$retval = array();
 		$saved_db = DbUtil::switchToLabConfig($lab_config->id);
-		$date_from_parts = explode("-", $date_from);		
+		$date_from_parts = explode("-", $date_from);
 		$date_to_parts = explode("-", $date_to);
 		$date_ts = mktime(0, 0, 0, $date_from_parts[1], $date_from_parts[2], $date_from_parts[0]);
 		$date_to_ts=mktime(0, 0, 0, $date_to_parts[1], $date_to_parts[2], $date_to_parts[0]);
-		
+
 		while($date_ts<$date_to_ts)
-	{     
+	{
 		$second_day_ts= mktime(0, 0, 0, $date_from_parts[1],$date_from_parts[2]+$i,$date_from_parts[0]);
 		$date_fromp=date("Y-m-d", $date_ts);
 		$date_top=date("Y-m-d", $second_day_ts);
 	if($gender=='M'||$gender=='F')
-	{ 
-$query_string = 
+	{
+$query_string =
 				"SELECT COUNT(*) AS count_val  FROM test t, patient p, specimen s ".
 				"WHERE t.test_type_id=$test_type_id ".
 				"AND p.patient_id=s.patient_id ".
@@ -2055,12 +2055,12 @@ $query_string =
 				"AND t.specimen_id=s.specimen_id ".
 				"AND (s.date_collected BETWEEN '$date_fromp' AND '$date_top') ".
 				"AND  (t.result LIKE 'N,%' OR t.result LIKE 'n�gatif,%' OR t.result LIKE 'negatif,%' OR t.result LIKE 'n,%' OR t.result LIKE 'negative,%')";
-				
+
 				}
 				else
 {
-	
-$query_string = 
+
+$query_string =
 				"SELECT COUNT(*) AS count_val  FROM test t, specimen s ".
 				"WHERE t.test_type_id=$test_type_id ".
 				"AND t.specimen_id=s.specimen_id ".
@@ -2071,8 +2071,8 @@ $query_string =
 
 	$record = query_associative_one($query_string);
 			$count_negative = $record['count_val'];
-			
-			$query_string = 
+
+			$query_string =
 				"SELECT COUNT(*) AS count_val  FROM test t, specimen s ".
 				"WHERE t.test_type_id=$test_type_id ".
 				"AND t.specimen_id=s.specimen_id ".
@@ -2082,33 +2082,33 @@ $query_string =
 			$count_all = $record['count_val'];
 						if($count_all != 0)
 				$retval[$date_ts] = array($count_all, $count_negative);
-			
+
 		$date_ts = $second_day_ts;
 		$i++;
-			
-					
+
+
 
 	}
 		DbUtil::switchRestore($saved_db);
-		
+
 		return $retval;
 	}
-	
-	
-	
+
+
+
 		public static function getDiscreteInfectionStatsMonthly($lab_config,$test_type_id, $date_from, $date_to, $gender=null)
 	{
 		$i=1;
-		
-				
+
+
 		# Fetch all test types with one measure having discrete P/N range
 		$retval = array();
-		
+
 		$saved_db = DbUtil::switchToLabConfig($lab_config->id);
-		
-		
+
+
 		$date_from_parts = explode("-", $date_from);
-		
+
 		$date_to_parts = explode("-", $date_to);
 
 		$month_ts = mktime(0, 0, 0, $date_from_parts[1], 0, $date_from_parts[0]);
@@ -2116,14 +2116,14 @@ $query_string =
 		# For the test type, fetch negative records
 
 		while($month_ts<$date_to_ts)
-	{     
+	{
 	$end_of_month_ts= mktime(0, 0, 0, $date_from_parts[1]+$i,0,$date_from_parts[0]);
 	$date_fromp=date("Y-m-d", $month_ts);
 	$date_top=date("Y-m-d", $end_of_month_ts);
-	
+
 				if($gender=='M'||$gender=='F')
-	{ 
-$query_string = 
+	{
+$query_string =
 				"SELECT COUNT(*) AS count_val  FROM test t, patient p, specimen s ".
 				"WHERE t.test_type_id=$test_type_id ".
 				"AND p.patient_id=s.patient_id ".
@@ -2131,12 +2131,12 @@ $query_string =
 				"AND t.specimen_id=s.specimen_id ".
 				"AND (s.date_collected BETWEEN '$date_fromp' AND '$date_top') ".
 				"AND  (t.result LIKE 'N,%' OR t.result LIKE 'n�gatif,%' OR t.result LIKE 'negatif,%' OR t.result LIKE 'n,%' OR t.result LIKE 'negative,%')";
-				
+
 				}
 				else
 			{
-	
-$query_string = 
+
+$query_string =
 				"SELECT COUNT(*) AS count_val  FROM test t, specimen s ".
 				"WHERE t.test_type_id=$test_type_id ".
 				"AND t.specimen_id=s.specimen_id ".
@@ -2146,8 +2146,8 @@ $query_string =
 				}
 			$record = query_associative_one($query_string);
 			$count_negative = $record['count_val'];
-			
-			$query_string = 
+
+			$query_string =
 				"SELECT COUNT(*) AS count_val  FROM test t, specimen s ".
 				"WHERE t.test_type_id=$test_type_id ".
 				"AND t.specimen_id=s.specimen_id ".
@@ -2158,18 +2158,18 @@ $query_string =
 				# If total tests is 0, ignore
 			if($count_all != 0)
 		$retval[$month_ts] = array($count_all, $count_negative);
-		 
-		
+
+
 		$month_ts = $end_of_month_ts;
 		$i++;
-					
-					
+
+
 
 	}
 		DbUtil::switchRestore($saved_db);
 		return $retval;
 	}
-	
+
 	public static function getRangeInfectionStats($lab_config, $date_from, $date_to)
 	{
 		$test_type_list = get_range_value_test_types($lab_config);
@@ -2187,7 +2187,7 @@ $query_string =
 				$measure_meta->name = $measure->getName();
 				$measure_meta->countParts = array();
 				$range = $measure->range;
-				
+
 				if(strpos($range, ":") === false)
 				{
 					# Discrete value range
@@ -2204,9 +2204,9 @@ $query_string =
 				}
 				$measure_meta_list[] = $measure_meta;
 			}
-			
+
 			# Calculate stats
-			$query_string = 
+			$query_string =
 				"SELECT COUNT(*) AS count_val FROM test t, specimen s ".
 				"WHERE t.test_type_id=$test_type_id ".
 				"AND t.specimen_id=s.specimen_id ".
@@ -2215,7 +2215,7 @@ $query_string =
 			$record = query_associative_one($query_string);
 			$count_all = $record['count_val'];
 			# Fetch result values
-			$query_string = 
+			$query_string =
 				"SELECT t.result FROM test t, specimen s ".
 				"WHERE t.test_type_id=$test_type_id ".
 				"AND t.specimen_id=s.specimen_id ".
@@ -2240,15 +2240,15 @@ $query_string =
 						break;
 					}
 				}
-			}	
+			}
 		}
 	}
-	
+
 	#
 	# Disease Report related functions
 	# Called from report_disease.php
 	#
-	
+
 	public static function getDiseaseTotal($lab_config, $test_type, $date_from, $date_to)
 	{
 		# Returns the total number of tests performed during the given date range
@@ -2263,10 +2263,10 @@ $query_string =
 		DbUtil::switchRestore($saved_db);
 		return $resultset[0]['val'];
 	}
-	
+
 	public static function setDiseaseSetList($lab_config, $test_type, $date_from, $date_to, $multipleCount = 0,$site_list,$add_site_condition)
 	{
-		# Initializes diseaseSetList for capturing params	
+		# Initializes diseaseSetList for capturing params
 		if($multipleCount == 0)
 			StatsLib::$diseaseSetList = array();
 		$query_string =
@@ -2312,7 +2312,7 @@ $query_string=$query_string." and sp.site_id in (".$site_list.")";
 		}
 		DbUtil::switchRestore($saved_db);
 	}
-	
+
 	public static function setDiseaseSetListAggregate($lab_config_ids, $test_type, $date_from, $date_to)
 	{
 		$testIds = array();
@@ -2325,7 +2325,7 @@ $query_string=$query_string." and sp.site_id in (".$site_list.")";
 		}
 		$labCount = 0;
 		/* All Tests for All Labs */
-		if ( count($lab_config_ids) == 1 && $lab_config_ids == 0 ) { 
+		if ( count($lab_config_ids) == 1 && $lab_config_ids == 0 ) {
 			$site_list = get_site_list($_SESSION['user_id']);
 
 			foreach( $site_list as $key => $value) {
@@ -2365,9 +2365,9 @@ $query_string=$query_string." and sp.site_id in (".$site_list.")";
 				$labCount++;
 				DbUtil::switchRestore($saved_db);
 			}
-		}	
+		}
 	}
-	
+
 	public static function getDiseaseFilterCountAggregate($disease_filter, $globalTestType, $currentMeasurecount, $lab_config_ids) {
 		# Returns total number of records matching filter criteria
 		$retval = 0;
@@ -2379,7 +2379,7 @@ $query_string=$query_string." and sp.site_id in (".$site_list.")";
 				$testId = $labIdTestIdsSeparated[1];
 				$testIds[$labId] = $testId;
 		}
-		if ( count($lab_config_ids) == 1 && $lab_config_ids == 0 ) { 
+		if ( count($lab_config_ids) == 1 && $lab_config_ids == 0 ) {
 			$site_list = get_site_list($_SESSION['user_id']);
 			foreach( $site_list as $key => $value) {
 				$currentMeasureCount = 0;
@@ -2415,7 +2415,7 @@ $query_string=$query_string." and sp.site_id in (".$site_list.")";
 		}
 		return $retval;
 	}
-	
+
 	public static function getDiseaseFilterCount($disease_filter)
 	{
 		# Returns total number of records matching filter criteria
@@ -2435,7 +2435,7 @@ $query_string=$query_string." and sp.site_id in (".$site_list.")";
 				)
 				||
 				(
-					($disease_set->patientAge >= $disease_filter->patientAgeRange[0]) && 
+					($disease_set->patientAge >= $disease_filter->patientAgeRange[0]) &&
 					($disease_set->patientAge < $disease_filter->patientAgeRange[1])
 				)
 			)

--- a/htdocs/regn/doctor_add_patient.php
+++ b/htdocs/regn/doctor_add_patient.php
@@ -26,7 +26,7 @@ $lab_config = get_lab_config_by_id($_SESSION['lab_config_id']);
 $session_num = get_session_number();
 $uiinfo = "qr=".$_REQUEST['n'];
 putUILog('new_patient', $uiinfo, basename($_SERVER['REQUEST_URI'], ".php"), 'X', 'X', 'X');
-$field_odering = field_order_update::install_first_order($lab_config, 1);
+$field_odering = field_order_update::install_first_order($lab_config, 1, $_SESSION['lab_config_id']);
 ?>
 <script type='text/javascript'>
 $(document).ready(function(){

--- a/htdocs/regn/new_patient.php
+++ b/htdocs/regn/new_patient.php
@@ -26,7 +26,7 @@ $lab_config = get_lab_config_by_id($_SESSION['lab_config_id']);
 $session_num = get_session_number();
 $uiinfo = "qr=".$_REQUEST['n'];
 putUILog('new_patient', $uiinfo, basename($_SERVER['REQUEST_URI'], ".php"), 'X', 'X', 'X');
-$field_odering = field_order_update::install_first_order($lab_config, 1);
+$field_odering = field_order_update::install_first_order($lab_config, 1, $_SESSION['lab_config_id']);
 ?>
 <script type='text/javascript'>
 $(document).ready(function(){

--- a/htdocs/regn/new_specimen.php
+++ b/htdocs/regn/new_specimen.php
@@ -420,7 +420,7 @@ if($patient == null)
 	if (! isset($_SESSION['specimenFieldOrder']))
 	{
 		$lab_config = get_lab_config_by_id($_SESSION['lab_config_id']);
-		$specimenFieldOrderingObj = field_order_update::install_first_order($lab_config, 2);
+		$specimenFieldOrderingObj = field_order_update::install_first_order($lab_config, 2, $_SESSION['lab_config_id']);
 		$specimenOrder = $specimenFieldOrderingObj->form_field_inOrder;
 		$_SESSION['specimenFieldOrder'] = explode( ',', $specimenOrder );
 	}


### PR DESCRIPTION
The PR represents some of my bug fixes and refactors around backing up and importing data.

The first was https://github.com/c4g-spr22-blis/BLIS/pull/12.

This PR introduces some significant refactors to `lab_config_home.php` and `db_lib.php`, which will introduce merge conflicts with @ritajett and @kvsakano's changes, so I am holding off on merging!

That said, these are fairly straight-forward changes. Make sure to look at the diff with "Hide whitespace" enabled. Primarily I modified some functions to pass around the `$lab_config_id` rather than infer it from the session, because it is not always in the session.